### PR TITLE
my interpretation of a policy-document defining a state

### DIFF
--- a/myAppState.config.yml
+++ b/myAppState.config.yml
@@ -66,20 +66,21 @@ DesiredState: # This is the unique desired state we want to converge to (in this
       data_resolver_type:
         name: Microsoft.PowerShell.SecretManagement\Get-Secret
         version: "[10.0.25227-*)"
-      resource_parameters:
+      data_resolver_parameters:
         vault: AzureKeyVault
         name: psgallerykey
 
     - id: AskForGitUserName
       data_resolver_type:
         name: Microsoft.DSC.Configuration\GetUserInput.exe # not necessarily an exe, but refer to the configuration utility capability to request user input
-      resource_parameters:
+      data_resolver_parameters:
         prompt: Please provide the username to use in git
         type: string
     
     - id: AskUserWhetherToInstallAzModule
       data_resolver_type:
         name: Microsoft.DSC.Configuration\GetUserInput.exe
+      data_resolver_parameters:
         prompt: do you want to ensure the PS Module PowerShell get is Present or Absent? 
         type: string
         ValidateSet: [present,absent]
@@ -87,7 +88,8 @@ DesiredState: # This is the unique desired state we want to converge to (in this
     - id: PS7InstalledPath
       data_resolver_type:
         name: cmd
-        parameters: /C Where.exe pwsh
+      data_resolver_parameters:
+        cmd_parameters: /C Where.exe pwsh
 
 
   ResourceGraph: # this is the Directed Acyclic Graph of the resources drawing the path of states (nodes) or changes (edges) a system need to go through to converge towards the desired state


### PR DESCRIPTION
Example of what a configuration doc may look like authored by end user or through a tool (compilation) to be used by an utility.
I don't like to call the utility "orchestrator" because you can orchestrate at many levels (i.e. orchestrating the change from a desired state to another desired state).

I refer to the **Utility** for a simple tool  that tries to apply a resource at a time, or agent (sometimes interchangeably) although an agent would have some more _cleverness_ to refresh the desired state policy document, and how/when to converge to the desired state.

This approach (in contrast with the other proposal), tries to minimise the features/complexity needed **when converging** to the DesiredState, and push them back to a higher level (called `AgentContext` here).

We're enabling Parameters to be defined in the configuration and re-used as needed.

We uniquely identify each resource instances with an instance ID that has to be unique.
We're using this string to identify the resource to use (namespace\resource), but if we want it to be free text, each resource instance will have to refer to detailed resource defintion (as listed in dependencies).
