### PR TITLE
refactor config code to be a helper

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -93,11 +93,13 @@ if ($Test) {
             Pop-Location
         }
     }
-}
 
-if ($failed) {
-    Write-Host -ForegroundColor Red "Test failed"
-    exit 1
+    if ($failed) {
+        Write-Host -ForegroundColor Red "Test failed"
+        exit 1
+    }
+
+    Invoke-Pester -ErrorAction Stop
 }
 
 # remove the other target in case switching between them

--- a/registry/src/main.rs
+++ b/registry/src/main.rs
@@ -6,8 +6,6 @@ use std::env;
 use args::Arguments;
 use atty::Stream;
 use clap::Parser;
-use ntreg::{registry_key::RegistryKey, registry_value::RegistryValueData, registry_value::RegistryValue};
-use ntstatuserror::NtStatusErrorKind;
 use std::{io::{self, Read}, process::exit};
 
 use crate::config::RegistryConfig;
@@ -16,6 +14,7 @@ mod args;
 #[cfg(onecore)]
 mod bcrypt;
 mod config;
+mod regconfighelper;
 
 const EXIT_SUCCESS: i32 = 0;
 const EXIT_INVALID_PARAMETER: i32 = 1;
@@ -91,21 +90,54 @@ fn main() {
         args::SubCommand::Config { subcommand } => {
             let json: String;
             let in_desired_state: bool;
-            validate_config(&config);
+            match regconfighelper::validate_config(&config) {
+                Ok(_) => {},
+                Err(err) => {
+                    eprintln!("Error validating config: {}", err);
+                    exit(EXIT_INVALID_INPUT);
+                }
+            }
+
             if config.ensure.is_none() {
                 config.ensure = Some(config::EnsureKind::Present);
             }
 
             match subcommand {
                 args::ConfigSubCommand::Get => {
-                    println!("{}", config_get(&config));
-                    exit(EXIT_SUCCESS);
+                    match regconfighelper::config_get(&config) {
+                        Ok(config) => {
+                            json = config;
+                            in_desired_state = true;
+                        },
+                        Err(err) => {
+                            eprintln!("Error getting config: {}", err);
+                            exit(EXIT_REGISTRY_ERROR);
+                        }
+                    }
                 },
                 args::ConfigSubCommand::Set => {
-                    (json, in_desired_state) = config_set(&config);
+                    match regconfighelper::config_set(&config) {
+                        Ok(result) => {
+                            json = result.0;
+                            in_desired_state = result.1;
+                        },
+                        Err(err) => {
+                            eprintln!("Error setting config: {}", err);
+                            exit(EXIT_REGISTRY_ERROR);
+                        }
+                    }
                 },
                 args::ConfigSubCommand::Test => {
-                    (json, in_desired_state) = config_test(&config);
+                    match regconfighelper::config_test(&config) {
+                        Ok(result) => {
+                            json = result.0;
+                            in_desired_state = result.1;
+                        },
+                        Err(err) => {
+                            eprintln!("Error testing config: {}", err);
+                            exit(EXIT_REGISTRY_ERROR);
+                        }
+                    }
                 },
             }
 
@@ -140,442 +172,4 @@ fn check_debug() {
             }
         }
     }
-}
-
-fn config_get(config: &RegistryConfig) -> String {
-    let reg_key = match RegistryKey::new(config.key_path.as_str()) {
-        Ok(reg_key) => reg_key,
-        Err(err) => {
-            eprintln!("Error: {}", err);
-            exit(EXIT_REGISTRY_ERROR);
-        }
-    };
-
-    let mut reg_result = RegistryConfig {
-        key_path: config.key_path.clone(),
-        value_name: None,
-        value_data: None,
-        ensure: None,
-        clobber: None,
-    };
-
-    if config.value_name.is_some() {
-        let reg_value = match reg_key.get_value(config.value_name.as_ref().unwrap().as_str()) {
-            Ok(reg_value) => reg_value,
-            Err(err) => {
-                eprintln!("Error: {}", err);
-                exit(EXIT_REGISTRY_ERROR);
-            }
-        };
-
-        reg_result.value_name = Some(reg_value.name);
-        reg_result.value_data = Some(convert_ntreg_data(&reg_value.data));
-    }
-
-    match serde_json::to_string(&reg_result) {
-        Ok(reg_json) => reg_json,
-        Err(err) => {
-            eprintln!("Error: {}", err);
-            exit(EXIT_REGISTRY_ERROR);
-        }
-    }
-}
-
-fn config_set(config: &RegistryConfig) -> (String, bool) {
-    let mut reg_result: RegistryConfig = Default::default();
-    reg_result.key_path = config.key_path.clone();
-    let in_desired_state = true;
-
-    let reg_key: RegistryKey;
-    match &config.value_name {
-        None => {
-            match config.ensure.as_ref().unwrap() {
-                config::EnsureKind::Present => {
-                    open_or_create_key(&config.key_path);
-                },
-                config::EnsureKind::Absent => {
-                    remove_key(&config.key_path);
-                },
-            }
-        },
-        Some(value_name) => {
-            reg_result.value_name = Some(value_name.clone());
-            match &config.ensure {
-                Some(config::EnsureKind::Present) | None => {
-                    reg_key = open_or_create_key(&config.key_path);
-                    match config.value_data.as_ref() {
-                        Some(value_data) => {
-                            reg_result.value_data = Some(value_data.clone());
-                            match reg_key.set_value(value_name, &convert_configreg_data(value_data)) {
-                                Ok(_) => {},
-                                Err(err) => {
-                                    eprintln!("Error: {}", err);
-                                    exit(EXIT_REGISTRY_ERROR);
-                                }
-                            }
-                        },
-                        None => {
-                            // just verify that the value exists
-                            match reg_key.get_value(value_name) {
-                                Ok(_reg_value) => {},
-                                Err(err) => {
-                                    match err.status {
-                                        NtStatusErrorKind::ObjectNameNotFound => {
-                                            match reg_key.set_value(value_name, &ntreg::registry_value::RegistryValueData::None) {
-                                                Ok(_) => {},
-                                                Err(err) => {
-                                                    eprintln!("Error: {}", err);
-                                                    exit(EXIT_REGISTRY_ERROR);
-                                                }
-                                            }
-                                        },
-                                        _ => {
-                                            eprintln!("Error: {}", err);
-                                            exit(EXIT_REGISTRY_ERROR);
-                                        },
-                                    }
-                                }
-                            }
-                        }
-                    }
-                },
-                Some(config::EnsureKind::Absent) => {
-                    reg_key = open_or_create_key(&config.key_path);
-                    match reg_key.delete_value(value_name) {
-                        Ok(_) => {},
-                        Err(err) => {
-                            match err.status {
-                                NtStatusErrorKind::ObjectNameNotFound => {},
-                                _ => {
-                                    eprintln!("Error: {}", err);
-                                    exit(EXIT_REGISTRY_ERROR);
-                                },
-                            }
-                        }
-                    }
-                },
-            }
-        }
-    }
-
-    let reg_json = match serde_json::to_string(&reg_result) {
-        Ok(reg_json) => reg_json,
-        Err(err) => {
-            eprintln!("Error: {}", err);
-            exit(EXIT_REGISTRY_ERROR);
-        }
-    };
-
-    (reg_json, in_desired_state)
-}
-
-fn get_parent_key_path(key_path: &str) -> &str {
-    match key_path.rfind('\\') {
-        Some(index) => &key_path[..index],
-        None => {
-            eprintln!("Error: Invalid key path: {}", key_path);
-            exit(EXIT_INVALID_INPUT);
-        }
-    }
-}
-
-fn remove_key(key_path: &str) {
-    match RegistryKey::new(key_path) {
-        Ok(key) => {
-            match key.delete(true) {
-                Ok(_) => {},
-                Err(err) => {
-                    eprintln!("Error: {}", err);
-                    exit(EXIT_REGISTRY_ERROR);
-                }
-            }
-        },
-        Err(err) => {
-            match err.status {
-                NtStatusErrorKind::ObjectNameNotFound => {},
-                _ => {
-                    eprintln!("Error: {}", err);
-                    exit(EXIT_REGISTRY_ERROR);
-                }
-            }
-        }
-    }
-}
-
-fn open_or_create_key(key_path: &str) -> RegistryKey {
-    let reg_key: RegistryKey;
-    match RegistryKey::new(key_path) {
-        Ok(key) => {
-            reg_key = key;
-        },
-        Err(err) => {
-            match err.status {
-                NtStatusErrorKind::ObjectNameNotFound =>{
-                    // need to handle case like `HKLM\1\2\3` where neither `1` nor `2` exist
-                    // so we need to find the top most parent that currently exists and then create the necessary subkeys in order
-                    let (parent_key, subkeys) = get_valid_parent_key_and_subkeys(key_path);
-                    let mut current_key = parent_key;
-                    for subkey in subkeys {
-                        match current_key.create_key(subkey) {
-                            Ok(key) => {
-                                current_key = key;
-                            },
-                            Err(err) => {
-                                eprintln!("Error: {}", err);
-                                exit(EXIT_REGISTRY_ERROR);
-                            }
-                        }
-                    }
-                    reg_key = current_key;
-                },
-                _ => {
-                    eprintln!("Error: {}", err);
-                    exit(EXIT_REGISTRY_ERROR);
-                }
-            }
-        }
-    }
-
-    reg_key
-}
-
-fn get_valid_parent_key_and_subkeys(key_path: &str) -> (RegistryKey, Vec<&str>) {
-    let parent_key: RegistryKey;
-    let mut subkeys: Vec<&str> = Vec::new();
-    let parent_key_path = get_parent_key_path(key_path);
-    let subkey_name = &key_path[parent_key_path.len() + 1..];
-    subkeys.push(subkey_name);
-    let mut current_key_path = parent_key_path;
-
-    loop {
-        match RegistryKey::new(current_key_path) {
-            Ok(key) => {
-                parent_key = key;
-                break;
-            },
-            Err(err) => {
-                match err.status {
-                    NtStatusErrorKind::ObjectNameNotFound => {
-                        let parent_key_path = get_parent_key_path(current_key_path);
-                        let subkey_name = &current_key_path[parent_key_path.len() + 1..];
-                        subkeys.insert(0, subkey_name);
-                        current_key_path = parent_key_path;
-                    },
-                    _ => {
-                        eprintln!("Error: {}", err);
-                        exit(EXIT_REGISTRY_ERROR);
-                    }
-                }
-            }
-        }
-    }
-
-    (parent_key, subkeys)
-}
-
-fn validate_config(config: &RegistryConfig) {
-    if config.value_data.is_some() && config.value_name.is_none() {
-        eprintln!("Error: value_name is required when value_data is specified.");
-        exit(EXIT_INVALID_INPUT);
-    }
-}
-
-fn config_test(config: &RegistryConfig) -> (String, bool) {
-    if config.value_name.is_none() {
-        test_key(config)
-    }
-    else {
-        test_value(config)
-    }
-}
-
-fn test_value(config: &RegistryConfig) -> (String, bool) {
-    let mut reg_result: RegistryConfig = Default::default();
-    let mut in_desired_state = true;
-
-    let reg_key: RegistryKey;
-    match RegistryKey::new(config.key_path.as_str()) {
-        Ok(key) => {
-            reg_key = key;
-        },
-        Err(err) => {
-            match err.status {
-                NtStatusErrorKind::ObjectNameNotFound =>{
-                    reg_result.key_path = String::new();
-                    return (reg_result.to_json(), false);
-                },
-                _ => {
-                    eprintln!("Error: {}", err);
-                    exit(EXIT_REGISTRY_ERROR);
-                }
-            }
-        }
-    };
-
-    reg_result.key_path = config.key_path.clone();
-
-    let value_name = config.value_name.as_ref().unwrap();
-    let mut value_exists = false;
-    let reg_value: RegistryValue = match reg_key.get_value(value_name) {
-        Ok(value) => {
-            value_exists = true;
-            reg_result.value_name = Some(value.name.clone());
-            reg_result.value_data = Some(convert_ntreg_data(&value.data));
-            value
-        },
-        Err(err) => {
-            match err.status {
-                NtStatusErrorKind::ObjectNameNotFound => {
-                    RegistryValue {
-                        key_path: config.key_path.clone(),
-                        name : String::new(),
-                        data : RegistryValueData::None,
-                    }
-                },
-                _ => {
-                    eprintln!("Error: {}", err);
-                    exit(EXIT_REGISTRY_ERROR);
-                }
-            }
-        }
-    };
-
-    match &config.ensure.as_ref().unwrap() {
-        config::EnsureKind::Present => {
-            if value_exists {
-                in_desired_state = reg_values_are_eq(config, &reg_value);
-            }
-            else {
-                in_desired_state = false;
-            }
-        },
-        config::EnsureKind::Absent => {
-            if value_exists {
-                in_desired_state = false;
-            }
-        }
-    }
-
-    (reg_result.to_json(), in_desired_state)
-}
-
-fn reg_values_are_eq(config: &RegistryConfig, reg_value: &RegistryValue) -> bool {
-    let mut in_desired_state = true;
-
-    if !reg_value.name.eq(config.value_name.as_ref().unwrap().as_str()) {
-        in_desired_state = false;
-    }
-
-    if config.value_data.is_some() && reg_value.data == RegistryValueData::None {
-        in_desired_state = false;
-    }
-    else if config.value_data.is_none() {
-        in_desired_state = true;
-    }
-    else {
-        let reg_value_data = convert_ntreg_data(&reg_value.data);
-        if reg_value_data != config.value_data.to_owned().unwrap() {
-            in_desired_state = false;
-        }
-    }
-
-    in_desired_state
-}
-
-fn test_key(config: &RegistryConfig) -> (String, bool) {
-    let mut reg_result: RegistryConfig = Default::default();
-
-    let key_exists;
-    match RegistryKey::new(config.key_path.as_str()) {
-        Ok( _ ) => {
-            key_exists = true;
-        },
-        Err(err) => {
-            match err.status {
-                NtStatusErrorKind::ObjectNameNotFound => {
-                    key_exists = false;
-                },
-                _ => {
-                    eprintln!("Error: {}", err);
-                    exit(EXIT_REGISTRY_ERROR);
-                }
-            }
-        }
-    };
-
-    let mut in_desired_state = true;
-    match &config.ensure.as_ref().unwrap() {
-        config::EnsureKind::Present => {
-            if !key_exists {
-                reg_result.key_path = String::new();
-                in_desired_state = false;
-            }
-        },
-        config::EnsureKind::Absent => {
-            if key_exists {
-                reg_result.key_path = config.key_path.clone();
-                in_desired_state = false;
-            }
-        }
-    }
-        
-    (reg_result.to_json(), in_desired_state)
-}
-
-fn convert_ntreg_data(reg_data: &ntreg::registry_value::RegistryValueData) -> config::RegistryValueData {
-    match reg_data {
-        RegistryValueData::String(data) => config::RegistryValueData::String(data.clone()),
-        RegistryValueData::MultiString(data) => config::RegistryValueData::MultiString(data.clone()),
-        RegistryValueData::Binary(data) => config::RegistryValueData::Binary(data.clone()),
-        RegistryValueData::DWord(data) => config::RegistryValueData::DWord(*data),
-        RegistryValueData::QWord(data) => config::RegistryValueData::QWord(*data),
-        RegistryValueData::ExpandString(data) => config::RegistryValueData::ExpandString(data.clone()),
-        _ => {
-            eprintln!("Error: Unsupported registry value type.");
-            exit(EXIT_REGISTRY_ERROR);
-        }
-    }
-}
-
-fn convert_configreg_data(reg_data: &config::RegistryValueData) -> ntreg::registry_value::RegistryValueData {
-    match reg_data {
-        config::RegistryValueData::String(data) => RegistryValueData::String(data.clone()),
-        config::RegistryValueData::MultiString(data) => RegistryValueData::MultiString(data.clone()),
-        config::RegistryValueData::Binary(data) => RegistryValueData::Binary(data.clone()),
-        config::RegistryValueData::DWord(data) => RegistryValueData::DWord(*data),
-        config::RegistryValueData::QWord(data) => RegistryValueData::QWord(*data),
-        config::RegistryValueData::ExpandString(data) => RegistryValueData::ExpandString(data.clone()),
-    }
-}
-
-#[test]
-fn test_registry_value_present() {
-    let input_json: &str = r#"
-    {
-        "keyPath": "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion",
-        "valueName": "ProgramFilesPath",
-        "_ensure": "Present"
-    }
-    "#;
-
-    let config: RegistryConfig = serde_json::from_str(input_json).unwrap();
-    let (json, in_desired_state) = config_test(&config);
-    assert!(in_desired_state);
-    assert_eq!(json, r#"{"keyPath":"HKLM\\Software\\Microsoft\\Windows\\CurrentVersion","valueName":"ProgramFilesPath","valueData":{"ExpandString":"%ProgramFiles%"}}"#);
-}
-
-#[test]
-fn test_registry_value_absent() {
-    let input_json: &str = r#"
-    {
-        "keyPath": "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion",
-        "valueName": "DoesNotExist",
-        "_ensure": "Absent"
-    }
-    "#;
-
-    let config: RegistryConfig = serde_json::from_str(input_json).unwrap();
-    let (json, in_desired_state) = config_test(&config);
-    assert!(in_desired_state);
-    assert_eq!(json, r#"{"keyPath":"HKLM\\Software\\Microsoft\\Windows\\CurrentVersion"}"#);
 }

--- a/registry/src/regconfighelper.rs
+++ b/registry/src/regconfighelper.rs
@@ -1,0 +1,450 @@
+use crate::config::{EnsureKind, RegistryConfig, RegistryValueData};
+use ntreg::{registry_key::RegistryKey, registry_value::RegistryValueData as NtRegistryValueData, registry_value::RegistryValue};
+use ntstatuserror::{NtStatusError, NtStatusErrorKind};
+use std::fmt::{Display, Formatter};
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum RegistryError {
+    NtStatus(NtStatusError),
+    Json(String),
+    Input(String),
+}
+
+impl Display for RegistryError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RegistryError::NtStatus(err) => write!(f, "{}", err),
+            RegistryError::Json(err) => write!(f, "{}", err),
+            RegistryError::Input(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+pub fn config_get(config: &RegistryConfig) -> Result<String, RegistryError> {
+    let reg_key = match RegistryKey::new(config.key_path.as_str()) {
+        Ok(reg_key) => reg_key,
+        Err(err) => {
+            return Err(RegistryError::NtStatus(err));
+        }
+    };
+
+    let mut reg_result = RegistryConfig {
+        key_path: config.key_path.clone(),
+        value_name: None,
+        value_data: None,
+        ensure: None,
+        clobber: None,
+    };
+
+    if config.value_name.is_some() {
+        let reg_value = match reg_key.get_value(config.value_name.as_ref().unwrap().as_str()) {
+            Ok(reg_value) => reg_value,
+            Err(err) => {
+                return Err(RegistryError::NtStatus(err));
+            }
+        };
+
+        reg_result.value_name = Some(reg_value.name);
+        reg_result.value_data = Some(convert_ntreg_data(&reg_value.data)?);
+    }
+
+    match serde_json::to_string(&reg_result) {
+        Ok(reg_json) => {
+            Ok(reg_json)
+        },
+        Err(err) => {
+            Err(RegistryError::Json(err.to_string()))
+        }
+    }
+}
+
+pub fn config_set(config: &RegistryConfig) -> Result<(String, bool), RegistryError> {
+    let mut reg_result: RegistryConfig = RegistryConfig {
+        key_path: config.key_path.clone(),
+        ..Default::default()
+    };
+    let in_desired_state = true;
+
+    let reg_key: RegistryKey;
+    match &config.value_name {
+        None => {
+            match config.ensure.as_ref().unwrap() {
+                EnsureKind::Present => {
+                    open_or_create_key(&config.key_path)?;
+                },
+                EnsureKind::Absent => {
+                    remove_key(&config.key_path)?;
+                },
+            }
+        },
+        Some(value_name) => {
+            reg_result.value_name = Some(value_name.clone());
+            match &config.ensure {
+                Some(EnsureKind::Present) | None => {
+                    reg_key = open_or_create_key(&config.key_path)?;
+                    match config.value_data.as_ref() {
+                        Some(value_data) => {
+                            reg_result.value_data = Some(value_data.clone());
+                            match reg_key.set_value(value_name, &convert_configreg_data(value_data)) {
+                                Ok(_) => {},
+                                Err(err) => {
+                                    return Err(RegistryError::NtStatus(err));
+                                }
+                            }
+                        },
+                        None => {
+                            // just verify that the value exists
+                            match reg_key.get_value(value_name) {
+                                Ok(_reg_value) => {},
+                                Err(err) => {
+                                    match err.status {
+                                        NtStatusErrorKind::ObjectNameNotFound => {
+                                            match reg_key.set_value(value_name, &NtRegistryValueData::None) {
+                                                Ok(_) => {},
+                                                Err(err) => {
+                                                    return Err(RegistryError::NtStatus(err));
+                                                }
+                                            }
+                                        },
+                                        _ => {
+                                            return Err(RegistryError::NtStatus(err));
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                Some(EnsureKind::Absent) => {
+                    reg_key = open_or_create_key(&config.key_path)?;
+                    match reg_key.delete_value(value_name) {
+                        Ok(_) => {},
+                        Err(err) => {
+                            match err.status {
+                                NtStatusErrorKind::ObjectNameNotFound => {},
+                                _ => {
+                                    return Err(RegistryError::NtStatus(err));
+                                },
+                            }
+                        }
+                    }
+                },
+            }
+        }
+    }
+
+    let reg_json = match serde_json::to_string(&reg_result) {
+        Ok(reg_json) => reg_json,
+        Err(err) => {
+            return Err(RegistryError::Json(err.to_string()));
+        }
+    };
+
+    Ok((reg_json, in_desired_state))
+}
+
+fn get_parent_key_path(key_path: &str) -> Result<&str, RegistryError> {
+    match key_path.rfind('\\') {
+        Some(index) => Ok(&key_path[..index]),
+        None => {
+            Err(RegistryError::Input(format!("Invalid key path: {}", key_path)))
+        }
+    }
+}
+
+fn remove_key(key_path: &str) -> Result<(), RegistryError> {
+    match RegistryKey::new(key_path) {
+        Ok(key) => {
+            match key.delete(true) {
+                Ok(_) => {
+                    Ok(())
+                },
+                Err(err) => {
+                    Err(RegistryError::NtStatus(err))
+                }
+            }
+        },
+        Err(err) => {
+            match err.status {
+                NtStatusErrorKind::ObjectNameNotFound => {
+                    Ok(()) // key doesn't exist, so we're good
+                },
+                _ => {
+                    Err(RegistryError::NtStatus(err))
+                }
+            }
+        }
+    }
+}
+
+fn open_or_create_key(key_path: &str) -> Result<RegistryKey, RegistryError> {
+    let reg_key: RegistryKey;
+    match RegistryKey::new(key_path) {
+        Ok(key) => {
+            reg_key = key;
+        },
+        Err(err) => {
+            match err.status {
+                NtStatusErrorKind::ObjectNameNotFound =>{
+                    // need to handle case like `HKLM\1\2\3` where neither `1` nor `2` exist
+                    // so we need to find the top most parent that currently exists and then create the necessary subkeys in order
+                    let (parent_key, subkeys) = get_valid_parent_key_and_subkeys(key_path)?;
+                    let mut current_key = parent_key;
+                    for subkey in subkeys {
+                        match current_key.create_key(subkey) {
+                            Ok(key) => {
+                                current_key = key;
+                            },
+                            Err(err) => {
+                                return Err(RegistryError::NtStatus(err));
+                            }
+                        }
+                    }
+                    reg_key = current_key;
+                },
+                _ => {
+                    return Err(RegistryError::NtStatus(err));
+                }
+            }
+        }
+    }
+
+    Ok(reg_key)
+}
+
+fn get_valid_parent_key_and_subkeys(key_path: &str) -> Result<(RegistryKey, Vec<&str>), RegistryError> {
+    let parent_key: RegistryKey;
+    let mut subkeys: Vec<&str> = Vec::new();
+    let parent_key_path = get_parent_key_path(key_path)?;
+    let subkey_name = &key_path[parent_key_path.len() + 1..];
+    subkeys.push(subkey_name);
+    let mut current_key_path = parent_key_path;
+
+    loop {
+        match RegistryKey::new(current_key_path) {
+            Ok(key) => {
+                parent_key = key;
+                break;
+            },
+            Err(err) => {
+                match err.status {
+                    NtStatusErrorKind::ObjectNameNotFound => {
+                        let parent_key_path = get_parent_key_path(current_key_path)?;
+                        let subkey_name = &current_key_path[parent_key_path.len() + 1..];
+                        subkeys.insert(0, subkey_name);
+                        current_key_path = parent_key_path;
+                    },
+                    _ => {
+                        return Err(RegistryError::NtStatus(err));
+                    }
+                }
+            }
+        }
+    }
+
+    Ok((parent_key, subkeys))
+}
+
+pub fn validate_config(config: &RegistryConfig) -> Result<(), RegistryError>{
+    if config.value_data.is_some() && config.value_name.is_none() {
+        return Err(RegistryError::Input("value_name is required when value_data is specified.".to_string()));
+    }
+
+    Ok(())
+}
+
+pub fn config_test(config: &RegistryConfig) -> Result<(String, bool), RegistryError> {
+    if config.value_name.is_none() {
+        Ok(test_key(config)?)
+    }
+    else {
+        Ok(test_value(config)?)
+    }
+}
+
+fn test_value(config: &RegistryConfig) -> Result<(String, bool), RegistryError> {
+    let mut reg_result: RegistryConfig = Default::default();
+    let mut in_desired_state = true;
+
+    let reg_key: RegistryKey;
+    match RegistryKey::new(config.key_path.as_str()) {
+        Ok(key) => {
+            reg_key = key;
+        },
+        Err(err) => {
+            match err.status {
+                NtStatusErrorKind::ObjectNameNotFound =>{
+                    reg_result.key_path = String::new();
+                    return Ok((reg_result.to_json(), false));
+                },
+                _ => {
+                    return Err(RegistryError::NtStatus(err));
+                }
+            }
+        }
+    };
+
+    reg_result.key_path = config.key_path.clone();
+
+    let value_name = config.value_name.as_ref().unwrap();
+    let mut value_exists = false;
+    let reg_value: RegistryValue = match reg_key.get_value(value_name) {
+        Ok(value) => {
+            value_exists = true;
+            reg_result.value_name = Some(value.name.clone());
+            reg_result.value_data = Some(convert_ntreg_data(&value.data)?);
+            value
+        },
+        Err(err) => {
+            match err.status {
+                NtStatusErrorKind::ObjectNameNotFound => {
+                    RegistryValue {
+                        key_path: config.key_path.clone(),
+                        name : String::new(),
+                        data : NtRegistryValueData::None,
+                    }
+                },
+                _ => {
+                    return Err(RegistryError::NtStatus(err));
+                }
+            }
+        }
+    };
+
+    match &config.ensure.as_ref().unwrap() {
+        EnsureKind::Present => {
+            if value_exists {
+                in_desired_state = reg_values_are_eq(config, &reg_value)?;
+            }
+            else {
+                in_desired_state = false;
+            }
+        },
+        EnsureKind::Absent => {
+            if value_exists {
+                in_desired_state = false;
+            }
+        }
+    }
+
+    Ok((reg_result.to_json(), in_desired_state))
+}
+
+fn reg_values_are_eq(config: &RegistryConfig, reg_value: &RegistryValue) -> Result<bool, RegistryError> {
+    let mut in_desired_state = true;
+
+    if !reg_value.name.eq(config.value_name.as_ref().unwrap().as_str()) {
+        in_desired_state = false;
+    }
+
+    if config.value_data.is_some() && reg_value.data == NtRegistryValueData::None {
+        in_desired_state = false;
+    }
+    else if config.value_data.is_none() {
+        in_desired_state = true;
+    }
+    else {
+        let reg_value_data = convert_ntreg_data(&reg_value.data)?;
+        if reg_value_data != config.value_data.to_owned().unwrap() {
+            in_desired_state = false;
+        }
+    }
+
+    Ok(in_desired_state)
+}
+
+fn test_key(config: &RegistryConfig) -> Result<(String, bool), RegistryError> {
+    let mut reg_result: RegistryConfig = Default::default();
+
+    let key_exists;
+    match RegistryKey::new(config.key_path.as_str()) {
+        Ok( _ ) => {
+            key_exists = true;
+        },
+        Err(err) => {
+            match err.status {
+                NtStatusErrorKind::ObjectNameNotFound => {
+                    key_exists = false;
+                },
+                _ => {
+                    return Err(RegistryError::NtStatus(err));
+                }
+            }
+        }
+    };
+
+    let mut in_desired_state = true;
+    match &config.ensure.as_ref().unwrap() {
+        EnsureKind::Present => {
+            if !key_exists {
+                reg_result.key_path = String::new();
+                in_desired_state = false;
+            }
+        },
+        EnsureKind::Absent => {
+            if key_exists {
+                reg_result.key_path = config.key_path.clone();
+                in_desired_state = false;
+            }
+        }
+    }
+        
+    Ok((reg_result.to_json(), in_desired_state))
+}
+
+fn convert_ntreg_data(reg_data: &NtRegistryValueData) -> Result<RegistryValueData, RegistryError> {
+    match reg_data {
+        NtRegistryValueData::String(data) => Ok(RegistryValueData::String(data.clone())),
+        NtRegistryValueData::MultiString(data) => Ok(RegistryValueData::MultiString(data.clone())),
+        NtRegistryValueData::Binary(data) => Ok(RegistryValueData::Binary(data.clone())),
+        NtRegistryValueData::DWord(data) => Ok(RegistryValueData::DWord(*data)),
+        NtRegistryValueData::QWord(data) => Ok(RegistryValueData::QWord(*data)),
+        NtRegistryValueData::ExpandString(data) => Ok(RegistryValueData::ExpandString(data.clone())),
+        _ => {
+            Err(RegistryError::Input("Unsupported registry value type".to_string()))
+        }
+    }
+}
+
+fn convert_configreg_data(reg_data: &RegistryValueData) -> NtRegistryValueData {
+    match reg_data {
+        RegistryValueData::String(data) => NtRegistryValueData::String(data.clone()),
+        RegistryValueData::MultiString(data) => NtRegistryValueData::MultiString(data.clone()),
+        RegistryValueData::Binary(data) => NtRegistryValueData::Binary(data.clone()),
+        RegistryValueData::DWord(data) => NtRegistryValueData::DWord(*data),
+        RegistryValueData::QWord(data) => NtRegistryValueData::QWord(*data),
+        RegistryValueData::ExpandString(data) => NtRegistryValueData::ExpandString(data.clone()),
+    }
+}
+
+#[test]
+fn test_registry_value_present() {
+    let input_json: &str = r#"
+    {
+        "keyPath": "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion",
+        "valueName": "ProgramFilesPath",
+        "_ensure": "Present"
+    }
+    "#;
+
+    let config: RegistryConfig = serde_json::from_str(input_json).unwrap();
+    let (json, in_desired_state) = config_test(&config).unwrap();
+    assert!(in_desired_state);
+    assert_eq!(json, r#"{"keyPath":"HKLM\\Software\\Microsoft\\Windows\\CurrentVersion","valueName":"ProgramFilesPath","valueData":{"ExpandString":"%ProgramFiles%"}}"#);
+}
+
+#[test]
+fn test_registry_value_absent() {
+    let input_json: &str = r#"
+    {
+        "keyPath": "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion",
+        "valueName": "DoesNotExist",
+        "_ensure": "Absent"
+    }
+    "#;
+
+    let config: RegistryConfig = serde_json::from_str(input_json).unwrap();
+    let (json, in_desired_state) = config_test(&config).unwrap();
+    assert!(in_desired_state);
+    assert_eq!(json, r#"{"keyPath":"HKLM\\Software\\Microsoft\\Windows\\CurrentVersion"}"#);
+}


### PR DESCRIPTION
Made `main` much smaller calling new regconfighelper
Exit and writing to stderr is only in `main` as all helper APIs now return Result<>
Enable `build.ps1 -test` to run Pester tests
