### PR TITLE
implement synthetic test for resource

### DIFF
--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -27,8 +27,8 @@ pub enum DscError {
     #[error("Schema missing from manifest: {0}")]
     MissingSchema(String),
 
-    #[error("Not implemented")]
-    NotImplemented,
+    #[error("Not implemented: {0}")]
+    NotImplemented(String),
 
     #[error("Operation: {0}")]
     Operation(String),

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -22,10 +22,10 @@ pub struct ResourceManifest {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum InputKind {
-    #[serde(rename = "stdin")]
-    Stdin,
     #[serde(rename = "args")]
     Args,
+    #[serde(rename = "stdin")]
+    Stdin,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/osinfo/README.md
+++ b/osinfo/README.md
@@ -1,0 +1,71 @@
+# osinfo resource
+
+This resource only supports `get` and returns basic information about the OS.
+It is intended to be an example of a assertion type resource where `test` is
+synthetically implemented by DSC.
+
+As this resource is, by design, very basic, it doesn't even include JSON schema
+as it's not intended to accept any input.
+
+## direct execution
+
+This command takes no arguments so when run will simply output basic info as JSON:
+
+```powershell
+osinfo
+```
+
+Example output (note in this doc it's formatted, but the command outputs as one line):
+
+```json
+{
+  "$id": "https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json",
+  "type": "Windows",
+  "version": "10.0.25309",
+  "edition": "Windows 11 Professional",
+  "bitness": "X64"
+}
+```
+
+## performing a `get`
+
+Since this resource takes no input, you can simply run:
+
+```powershell
+dsc resource get -r osinfo
+```
+
+Example output as YAML:
+
+```yaml
+actual_state:
+  $id: https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json
+  type: Windows
+  version: 10.0.25309
+  edition: Windows 11 Professional
+  bitness: X64
+```
+
+## performing a `test`
+
+A `test` does require input, but keep in mind this resource doesn't implement schema so the input
+is not validated:
+
+```powershell
+'{"type":"Unknown"}' | dsc resource test -r osinfo
+```
+
+Example output as YAML:
+
+```yaml
+expected_state:
+  type: unknown
+actual_state:
+  $id: https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json
+  type: Windows
+  version: 10.0.25309
+  edition: Windows 11 Professional
+  bitness: X64
+diff_properties:
+- type
+```

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -1,8 +1,7 @@
 Describe 'osinfo resource tests' {
     It 'should get osinfo' {
-        $out = dsc resource get -r osinfo
+        $out = dsc resource get -r osinfo | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out = $out | ConvertFrom-Json
         if ($IsWindows) {
             $out.actual_state.type | Should -BeExactly 'Windows'
         }
@@ -20,5 +19,15 @@ Describe 'osinfo resource tests' {
         else {
             $out.actual_state.bitness | Should -BeExactly 'X32'
         }
+    }
+
+    It 'should perform synthetic test' {
+        $out = '{"type": "does_not_exist"}' | dsc resource test -r osinfo | ConvertFrom-Json
+        $actual = dsc resource get -r osinfo | ConvertFrom-Json
+        $out.actual_state.type | Should -BeExactly $actual.actual_state.type
+        $out.actual_state.version | Should -BeExactly $actual.actual_state.version
+        $out.actual_state.bitness | Should -BeExactly $actual.actual_state.bitness
+        $out.actual_state.edition | Should -BeExactly $actual.actual_state.edition
+        $out.diff_properties | Should -Be @('type')
     }
 }


### PR DESCRIPTION
A resource can only implement `get` and the new `osinfo` resource was designed just for this case.  The README.md has examples of usage.

However, `dsc` will now perform a synthetic `test` by comparing the input and actual states.  Changes allow for `get` to not accept any input.

Also updated the NotImplemented error to include a field describing what exactly isn't implemented.
