### PR TITLE
fix build and add resource type to command error

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -25,7 +25,7 @@ else {
 }
 
 $windows_projects = @("ntreg","ntstatuserror","ntuserinfo","registry")
-$projects = @("dsc","osinfo","y2j") 
+$projects = @("dsc","osinfo","y2j")
 if ($IsWindows) {
     $projects += $windows_projects
 }
@@ -54,15 +54,9 @@ foreach ($project in $projects) {
             Copy-Item "$path/$project" $target -ErrorAction Ignore
         }
 
-        if (Test-Path "$project.resource.json") {
-            Copy-Item "$project.resource.json" $target -ErrorAction Ignore
-        }
+        Copy-Item "*.resource.json" $target -Force -ErrorAction Ignore
+        Copy-Item "*.command.json" $target -Force -ErrorAction Ignore
 
-        if (Test-Path "$project.command.json") {
-            Copy-Item "$project.command.json" $target -ErrorAction Ignore
-        }
-
-        Copy-Item *.command.json $target
     } finally {
         Pop-Location
     }
@@ -107,7 +101,7 @@ if ($Test) {
         try {
             Push-Location "$PSScriptRoot/$project"
             cargo test
-    
+
             if ($LASTEXITCODE -ne 0) {
                 $failed = $true
             }

--- a/dsc/examples/osinfo.dsc.json
+++ b/dsc/examples/osinfo.dsc.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json",
+    "resources": [
+      {
+        "name": "os",
+        "type": "Microsoft/OSInfo",
+        "properties": {
+            "family": "Windows"
+        }
+      }
+    ]
+  }

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -3,8 +3,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DscError {
-    #[error("Command: [{0}] {1}")]
-    Command(i32, String),
+    #[error("Command: Resource '{0}' [Exit code {1}] {2}")]
+    Command(String, i32, String),
 
     #[error("HTTP: {0}")]
     Http(#[from] reqwest::Error),

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -14,7 +14,7 @@ pub fn invoke_get(resource: &ResourceManifest, filter: &str) -> Result<GetResult
 
     let (exit_code, stdout, stderr) = invoke_command(&resource.get.executable, resource.get.args.clone().unwrap_or_default(), Some(filter))?;
     if exit_code != 0 {
-        return Err(DscError::Command(exit_code, stderr.to_string()));
+        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr.to_string()));
     }
 
     let result: Value = serde_json::from_str(&stdout)?;
@@ -46,7 +46,7 @@ pub fn invoke_set(resource: &ResourceManifest, desired: &str) -> Result<SetResul
     let pre_state: Value;
     let (exit_code, stdout, stderr) = invoke_command(&resource.get.executable, resource.get.args.clone().unwrap_or_default(), Some(desired))?;
     if exit_code != 0 {
-        return Err(DscError::Command(exit_code, stderr.to_string()));
+        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr.to_string()));
     }
     else {
         pre_state = serde_json::from_str(&stdout)?;
@@ -54,7 +54,7 @@ pub fn invoke_set(resource: &ResourceManifest, desired: &str) -> Result<SetResul
 
     let (exit_code, stdout, stderr) = invoke_command(&set.executable, set.args.clone().unwrap_or_default(), Some(desired))?;
     if exit_code != 0 {
-        return Err(DscError::Command(exit_code, stderr.to_string()));
+        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr.to_string()));
     }
 
     match set.returns {
@@ -104,7 +104,7 @@ pub fn invoke_test(resource: &ResourceManifest, expected: &str) -> Result<TestRe
     let test = resource.test.as_ref().unwrap();
     let (exit_code, stdout, stderr) = invoke_command(&test.executable, test.args.clone().unwrap_or_default(), Some(expected))?;
     if exit_code != 0 {
-        return Err(DscError::Command(exit_code, stderr.to_string()));
+        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr.to_string()));
     }
 
     let expected_value: Value = serde_json::from_str(expected)?;
@@ -151,7 +151,7 @@ pub fn get_schema(resource: &ResourceManifest) -> Result<String, DscError> {
         SchemaKind::Command(ref command) => {
             let (exit_code, stdout, stderr) = invoke_command(&command.executable, command.args.clone().unwrap_or_default(), None)?;
             if exit_code != 0 {
-                return Err(DscError::Command(exit_code, stderr.to_string()));
+                return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr.to_string()));
             }
             Ok(stdout)
         },


### PR DESCRIPTION
Fix build so that all resource and command manifests are copied
add OSInfo config example
add field to Command error to include the resource type