### PR TITLE
add `config` property to `provider` in schema

### DIFF
--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -134,6 +134,18 @@ pub struct ValidateMethod {
 pub struct Provider {
     /// The way to list provider supported resources.
     pub list: ListMethod,
+    /// Defines how the provider supports accepting configuraiton.
+    pub config: ConfigKind,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum ConfigKind {
+    /// The provider accepts full unprocessed configuration.
+    #[serde(rename = "full")]
+    Full,
+    /// The provider accepts configuration as a sequence.
+    #[serde(rename = "sequence")]
+    Sequence,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/test_group_resource/testGroup.resource.json
+++ b/test_group_resource/testGroup.resource.json
@@ -22,6 +22,7 @@
             "args": [
                 "list"
             ]
-        }
+        },
+        "config": "sequence"
     }
 }

--- a/test_group_resource/tests/provider.tests.ps1
+++ b/test_group_resource/tests/provider.tests.ps1
@@ -43,7 +43,8 @@ Describe 'Resource provider tests' {
                     "args": [
                         "listmissingrequires"
                     ]
-                }
+                },
+                "config": "sequence"
             }
         }
 '@


### PR DESCRIPTION
For providers that don't want to handle a dependency graph, it can indicate it only takes a sequence and `dsc` will generate the dependency graph and just pass through  a sequence of resources to execute for the provider