### PR TITLE
Fixed invoke_command to support resources with more than 64 char output

### DIFF
--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -258,18 +258,20 @@ pub fn invoke_command(executable: &str, args: Option<Vec<String>>, input: Option
         child_stdin.write_all(input.unwrap_or_default().as_bytes())?;
         child_stdin.flush()?;
     }
-    let exit_status = child.wait()?;
 
     let Some(mut child_stdout) = child.stdout.take() else {
         return Err(DscError::CommandOperation("Failed to open stdout".to_string(), executable.to_string()));
     };
+    let mut stdout_buf = Vec::new();
+    child_stdout.read_to_end(&mut stdout_buf)?;
+
     let Some(mut child_stderr) = child.stderr.take() else {
         return Err(DscError::CommandOperation("Failed to open stderr".to_string(), executable.to_string()));
     };
-    let mut stdout_buf = Vec::new();
-    child_stdout.read_to_end(&mut stdout_buf)?;
     let mut stderr_buf = Vec::new();
     child_stderr.read_to_end(&mut stderr_buf)?;
+
+    let exit_status = child.wait()?;
 
     let exit_code = exit_status.code().unwrap_or(EXIT_PROCESS_TERMINATED);
     let stdout = String::from_utf8_lossy(&stdout_buf).to_string();


### PR DESCRIPTION
# PR Summary
`std::process::Command` hangs in `child.wait()` if the subprocess prints more than 64K characters to stdout.
The fix is to read the output (therefore making space for the child process to put put more data) before waiting for the child process exit.

Verified the fix by running `pwsh` with  `Get-DscResource | ConvertTo-Json -Depth 3`, which was hanging previously.