### PR TITLE
hide `validate` config subcommand

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -48,7 +48,7 @@ pub enum ConfigSubCommand {
     Set,
     #[clap(name = "test", about = "Test the current configuration")]
     Test,
-    #[clap(name = "validate", about = "Validate the current configuration")]
+    #[clap(name = "validate", about = "Validate the current configuration", hide = true)]
     Validate,
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The `validate` config subcommand is only intended to be used by `dsc` itself where `dsc` is used as a resource.  It is not intended to be used directly by end-users and isn't designed for such use.  We need to keep the subcommand, but fix is to hide it so it doesn't show up in the help.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
