### PR TITLE
Converted resource list to be sorted

### DIFF
--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -6,14 +6,14 @@ use crate::dscresources::dscresource::{DscResource, ImplementedAs};
 use crate::dscresources::resource_manifest::ResourceManifest;
 use crate::dscresources::command_resource::invoke_command;
 use crate::dscerror::DscError;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::env;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::Path;
 
 pub struct CommandDiscovery {
-    pub resources: HashMap<String, DscResource>,
+    pub resources: BTreeMap<String, DscResource>,
     provider_resources: Vec<String>,
     initialized: bool,
 }
@@ -21,7 +21,7 @@ pub struct CommandDiscovery {
 impl CommandDiscovery {
     pub fn new() -> CommandDiscovery {
         CommandDiscovery {
-            resources: HashMap::new(),
+            resources: BTreeMap::new(),
             provider_resources: Vec::new(),
             initialized: false,
         }


### PR DESCRIPTION
# PR Summary
Old `HashMap` was very annoying when looking through results of `dsc.exe resource list` because two similarly named resources from the same module could be placed in opposite sides of the list.
Changing storage collection to a B-Tree automatically solves this problem while maintaining good performance.

Before change:
```
PS C:\DSCv3> dsc.exe resource list

Type                                                     Version  Requires             Description
--------------------------------------------------------------------------------------------------------------------------------------------------------------
PsDesiredStateConfiguration/MSFT_WaitForSome                      DSC/PowerShellGroup
DSC/ParallelGroup                                        0.1.0                         All resources in the supplied configuration run concurrently.
Test/TestGroup                                           0.1.0
Microsoft/OSInfo                                         0.1.0                         Returns information about the operating system.
DSC/AssertionGroup                                       0.1.0                         `test` will be invoked for all resources in the supplied configuration.
Test/TestResource2                                       1.0.1    Test/TestGroup       This is a test resource.
PsDesiredStateConfiguration/MSFT_EnvironmentResource              DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_GroupResource                    DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ScriptResource                   DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ArchiveResource                  DSC/PowerShellGroup
PackageManagement/MSFT_PackageManagementSource           1.4.8.1  DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_RegistryResource                 DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_LogResource                      DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WaitForAll                       DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ServiceResource                  DSC/PowerShellGroup
PowerShellGet/MSFT_PSRepository                          2.2.5    DSC/PowerShellGroup
DSC/Group                                                0.1.0                         All resources in the supplied configuration is treated as a group.
Test/TestResource1                                       1.0.0    Test/TestGroup       This is a test resource.
PsDesiredStateConfiguration/MSFT_UserResource                     DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ProcessResource                  DSC/PowerShellGroup
DSC/PowerShellGroup                                      0.1.0                         Resource provider to classic DSC Powershell resources.
PowerShellGet/MSFT_PSModule                              2.2.5    DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WaitForAny                       DSC/PowerShellGroup
PackageManagement/MSFT_PackageManagement                 1.0.0.1  DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_RoleResource                     DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WindowsOptionalFeature           DSC/PowerShellGroup
Microsoft.Windows/Registry                               0.1.0                         Registry configuration provider for the Windows Registry
PsDesiredStateConfiguration/MSFT_PackageResource                  DSC/PowerShellGroup
```

After change:
```
PS C:\DSCv3> dsc.exe resource list

Type                                                     Version  Requires             Description
--------------------------------------------------------------------------------------------------------------------------------------------------------------
DSC/AssertionGroup                                       0.1.0                         `test` will be invoked for all resources in the supplied configuration.
DSC/Group                                                0.1.0                         All resources in the supplied configuration is treated as a group.
DSC/ParallelGroup                                        0.1.0                         All resources in the supplied configuration run concurrently.
DSC/PowerShellGroup                                      0.1.0                         Resource provider to classic DSC Powershell resources.
Microsoft.Windows/Registry                               0.1.0                         Registry configuration provider for the Windows Registry
Microsoft/OSInfo                                         0.1.0                         Returns information about the operating system.
PackageManagement/MSFT_PackageManagement                 1.0.0.1  DSC/PowerShellGroup
PackageManagement/MSFT_PackageManagementSource           1.4.8.1  DSC/PowerShellGroup
PowerShellGet/MSFT_PSModule                              2.2.5    DSC/PowerShellGroup
PowerShellGet/MSFT_PSRepository                          2.2.5    DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ArchiveResource                  DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_EnvironmentResource              DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_GroupResource                    DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_LogResource                      DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_PackageResource                  DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ProcessResource                  DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_RegistryResource                 DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_RoleResource                     DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ScriptResource                   DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_ServiceResource                  DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_UserResource                     DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WaitForAll                       DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WaitForAny                       DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WaitForSome                      DSC/PowerShellGroup
PsDesiredStateConfiguration/MSFT_WindowsOptionalFeature           DSC/PowerShellGroup
Test/TestGroup                                           0.1.0
Test/TestResource1                                       1.0.0    Test/TestGroup       This is a test resource.
Test/TestResource2                                       1.0.1    Test/TestGroup       This is a test resource.
```