### PR TITLE
Temporary disable PowerShellGroup resource on PS 7.4

### DIFF
--- a/powershellgroup/powershellgroup.resource.ps1
+++ b/powershellgroup/powershellgroup.resource.ps1
@@ -33,6 +33,11 @@ function RefreshCache
     }
 }
 
+if (($PSVersionTable.PSVersion.Major -ge 7) -and ($PSVersionTable.PSVersion.Minor -ge 4))
+{
+    throw "PowerShell 7.4 is not currently supported by PowerShellGroup resource; please use PS 7.3.  Tracking issue: https://github.com/PowerShell/DSC/issues/128"
+}
+
 $DscModule = Get-Module -Name PSDesiredStateConfiguration -ListAvailable |
     Sort-Object -Property Version -Descending |
     Select-Object -First 1


### PR DESCRIPTION
# PR Summary

Temporary workaround for issue #128 
If `PowerShellGroup` resource detects that it is launched in PS 7.4 then it aborts with error message instructing to use 7.3 and a link to issue @128