### PR TITLE
(GH-96) Replace `jsonschema` crate with `boon`

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -22,3 +22,4 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = { version = "0.9" }
 syntect = { version = "5.0", features = ["default-fancy"], default-features = false }
 thiserror = "1.0"
+boon = "0.5.1"

--- a/dsc/tests/dsc_schema.tests.ps1
+++ b/dsc/tests/dsc_schema.tests.ps1
@@ -7,7 +7,7 @@ Describe 'config schema tests' {
         $LASTEXITCODE | Should -Be 0
         $schema | Should -Not -BeNullOrEmpty
         $schema = $schema | ConvertFrom-Json
-        $schema.'$schema' | Should -BeExactly 'http://json-schema.org/draft-07/schema#'
+        $schema.'$schema' | Should -BeExactly 'https://json-schema.org/draft/2019-09/schema'
     }
 
     It 'return dsc schema: <type>' -Skip:(!$IsWindows) -TestCases @(
@@ -26,6 +26,6 @@ Describe 'config schema tests' {
         $LASTEXITCODE | Should -Be 0
         $schema | Should -Not -BeNullOrEmpty
         $schema = $schema | ConvertFrom-Json
-        $schema.'$schema' | Should -BeExactly 'http://json-schema.org/draft-07/schema#'
+        $schema.'$schema' | Should -BeExactly 'https://json-schema.org/draft/2019-09/schema'
     }
 }

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -13,3 +13,4 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 thiserror = "1.0"
 chrono = "0.4.26"
+boon = "0.5.1"

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -28,6 +28,9 @@ pub enum DscError {
     #[error("JSON: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("JSON Schema compiling: {0}")]
+    JsonCompile(#[from] boon::CompileError),
+
     #[error("Manifest: {0}\nJSON: {1}")]
     Manifest(String, serde_json::Error),
 

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -15,6 +15,7 @@ lto = true
 
 [dependencies]
 atty = { version = "0.2" }
+boon = "0.5.1"
 clap = { version = "4.1", features = ["derive"] }
 crossterm = { version = "0.26" }
 ntreg = { path = "../ntreg" }

--- a/registry/src/config.rs
+++ b/registry/src/config.rs
@@ -4,6 +4,8 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+/// # Ensure
+/// The Ensure enum is used to specify whether a registry key or value should be present or absent.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum EnsureKind {
     /// The registry key and value should be present.
@@ -12,42 +14,66 @@ pub enum EnsureKind {
     Absent,
 }
 
+/// # Registry value data
+/// Defines the type and value for the registry value.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum RegistryValueData {
+    /// # String value data
+    /// The value is an arbitrary string that doesn't rely on expanded references to environment
+    /// variables.
     String(String),
+    /// # Expandable string value data
+    /// The value is a string that can contain references to environment variables that are expanded
+    /// from their reference, like `%SYSTEMROOT%\System32`.
     ExpandString(String),
+    /// # Binary value data
+    /// The value is any form of binary data.
     Binary(Vec<u8>),
+    /// # DWord value data
+    /// The value is a 32-bit unsigned integer.
     DWord(u32),
+    /// # Multi-string value data
+    /// The value is an array of arbitrary strings.
     MultiString(Vec<String>),
+    /// # QWord value data
+    /// The value is a 64-bit unsigned integer.
     QWord(u64),
 }
 
+/// # Microsoft.Windows/Registry resource instance schema
+/// An instance of the Registry resource represents a registry key or value. The resource can
+/// manage registry keys and values.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "Registry", deny_unknown_fields)]
 pub struct RegistryConfig {
-    /// The ID of the resource.  Value is ignored for input.
+    /// # Schema identifier
+    /// The ID of the resource instance schema. This property is read-only.
     #[serde(rename = "$id", skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
-    /// The path to the registry key.
+    /// # Key path
+    /// Defines the path to the registry key, like
+    /// `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion`.
     #[serde(rename = "keyPath")]
     pub key_path: String,
-    /// The name of the registry value.
+    /// # Value name
+    /// Defines the name of the registry value to manage in the key. This property is required when
+    /// `valueData` is specified.
     #[serde(rename = "valueName")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value_name: Option<String>,
-    /// The data of the registry value.
     #[serde(rename = "valueData")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub value_data: Option<RegistryValueData>,
-    /// Flag indicating whether the registry value should be present or absent.
     #[serde(rename = "_ensure")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ensure: Option<EnsureKind>,
-    /// Flag indicating whether the registry value should be overwritten if it already exists.
+    /// # Clobber
+    /// Indicates whether the registry value should be overwritten if it already exists.
     #[serde(rename = "_clobber")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub clobber: Option<bool>,
-    /// Flag indicating whether the resource is in the desired state.  Value is ignored for input.
+    /// # Instance is in the desired state
+    /// Indicates whether the instance is in the desired state. This property is read-only.
     #[serde(rename = "_inDesiredState")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub in_desired_state: Option<bool>,


### PR DESCRIPTION
# PR Summary

Prior to this change, the DSC library, CLI, and the Registry resource all relied on the `jsonschema` crate for schema compilation and validation.

As raised in #96, the `jsonschema` crate does not support newer versions of JSON Schema like drafts 2019-09 and 2020-12. Further, the implementation fails several of the tests designed by the JSON Schema organization to validate implementations for the newest dialect  it _does_ support (Draft 7).

This change prototypes the replacement of the `jsonschema` crate with the `boon` crate, which has full support for every released draft of JSON Schema and currently passes every test for implementation validation.

## PR Context


In this initial prototype change, the code includes duplicated behaviors that can be cleaned up or abstracted into helper functions.

Another benefit and possible avenue going forward is to turn the decomposed schemas in the repository into the source of truth for validating the incoming data. With Boon, DSC could pre-load the schemas and only have to compile schemas for resources on-demand thereafter.

In that model, the JSON schemas in the repository could be embedded in the binary or shipped alongside it.

This change also updates the use of Schemars to output Draft 2019-09 schemas for DSC and the Registry resource, to make them closer to the definitions for the schemas in the repository.

This change adds documentation to the structs in the Registry resource, showing how they can be used to provide improved documentation for the schema at author-time.
