### PR TITLE
(MAINT) Update config schema

### DIFF
--- a/dsc/examples/assertion.dsc.yaml
+++ b/dsc/examples/assertion.dsc.yaml
@@ -1,10 +1,10 @@
 # Example configuration that uses assertions to validate the environment before running the configuration.
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 resources:
 - name: my assertions
   type: DSC/AssertionGroup
   properties:
-    $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
     resources:
     - name: os
       type: Microsoft/OSInfo

--- a/dsc/examples/invalid_schema.dsc.yaml
+++ b/dsc/examples/invalid_schema.dsc.yaml
@@ -1,5 +1,5 @@
 # Sample configuration with invalid properties that don't match the resource schema.
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 resources:
 - name: os
   type: Microsoft/OSInfo

--- a/dsc/examples/osinfo.dsc.json
+++ b/dsc/examples/osinfo.dsc.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json",
+    "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json",
     "resources": [
       {
         "name": "os",

--- a/dsc/examples/osinfo_registry.dsc.json
+++ b/dsc/examples/osinfo_registry.dsc.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json",
+    "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json",
     "metadata": {
         "description": "Simple example using two different resources and one of them twice."
     },

--- a/dsc/examples/osinfo_registry.dsc.yaml
+++ b/dsc/examples/osinfo_registry.dsc.yaml
@@ -1,5 +1,5 @@
 # Simple example using two different resources and one of them twice.
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 resources:
 - name: os
   type: Microsoft/OSInfo

--- a/dsc/examples/parallel.dsc.yaml
+++ b/dsc/examples/parallel.dsc.yaml
@@ -1,5 +1,5 @@
 # Example on how concurrency would be defined in the configuration.
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   _timeoutSeconds: 600 # example of setting timeout for orchestration, should be namespaced?
 resources:

--- a/dsc/examples/powershell.dsc.yaml
+++ b/dsc/examples/powershell.dsc.yaml
@@ -1,5 +1,5 @@
 # Example configuration mixing native app resources with classic PS resources
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 resources:
 - name: Use class PowerShell resources
   type: DSC/PowerShellGroup

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -77,7 +77,7 @@ pub struct Resource {
     pub properties: Option<HashMap<String, Value>>,
 }
 
-const SCHEMA: &str = "https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json";
+const SCHEMA: &str = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json";
 
 impl Default for Configuration {
     fn default() -> Self {


### PR DESCRIPTION
# PR Summary

This change updates the required `$schema` value for configuration documents to point to the canonical published schema URI. Currently, the canonical schema and documentation disagree with the implementation.

## PR Context

The implementation references a fictional URI.

This change updates the implementation and example documents to use the canonical published schema instead.
