### PR TITLE
(MAINT) Fix the `registry find` command options

### DIFF
--- a/registry/src/args.rs
+++ b/registry/src/args.rs
@@ -58,9 +58,9 @@ pub enum SubCommand {
         find: String,
         #[clap(short, long, help = "Recursively find.")]
         recurse: bool,
-        #[clap(short, long, help = "Only find keys.")]
+        #[clap(long, help = "Only find keys.")]
         keys_only: bool,
-        #[clap(short, long, help = "Only find values.")]
+        #[clap(long, help = "Only find values.")]
         values_only: bool,
     },
     #[clap(name = "config", about = "Manage registry configuration.", arg_required_else_help = true)]


### PR DESCRIPTION
# PR Summary

This change removes the short form for the `--keys_only` and `--values_only` options, removing the conflict so the command doesn't panic.

The new options from `registry find --help` display as:

```console
Find a registry key or value.

Usage: registry.exe find [OPTIONS] --key-path <KEY_PATH> --find <FIND>

Options:
  -k, --key-path <KEY_PATH>  The registry key path to start find.
  -f, --find <FIND>          The string to find.
  -r, --recurse              Recursively find.
      --keys-only            Only find keys.
      --values-only          Only find values.
  -h, --help                 Print help
```

## PR Context

Prior to this change, the `registry find` command panicked because the `key_path` and `keys_only` options both declared the default short form for the options. Clap resolved both options to short form `-k`, leading to a conflict and panic.