### PR TITLE
Export scenario support

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -89,6 +89,11 @@ pub enum ResourceSubCommand {
         #[clap(short, long, help = "The name of the resource to get the JSON schema")]
         resource: String,
     },
+    #[clap(name = "export", about = "Retrieve all resource instances", arg_required_else_help = true)]
+    Export {
+        #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `export` on")]
+        resource: String,
+    },
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -50,6 +50,8 @@ pub enum ConfigSubCommand {
     Test,
     #[clap(name = "validate", about = "Validate the current configuration", hide = true)]
     Validate,
+    #[clap(name = "export", about = "Export the current configuration")]
+    Export
 }
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -67,6 +67,8 @@ pub enum ResourceSubCommand {
     },
     #[clap(name = "get", about = "Invoke the get operation to a resource", arg_required_else_help = true)]
     Get {
+        #[clap(short, long, help = "Get all instances of the resource")]
+        all: bool,
         #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `get` on")]
         resource: String,
         #[clap(short, long, help = "The input to pass to the resource as JSON")]

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -129,6 +129,30 @@ pub fn schema(dsc: &mut DscManager, resource: &str, format: &Option<OutputFormat
     }
 }
 
+pub fn export(dsc: &mut DscManager, resource: &str, format: &Option<OutputFormat>) {
+    let resource = get_resource(dsc, resource);
+
+    match resource.export() {
+        Ok(result) => {
+            for instance in result.actual_state
+            {
+                let json = match serde_json::to_string(&instance) {
+                    Ok(json) => json,
+                    Err(err) => {
+                        eprintln!("JSON Error: {err}");
+                        exit(EXIT_JSON_ERROR);
+                    }
+                };
+                write_output(&json, format);
+            }
+        }
+        Err(err) => {
+            eprintln!("Error: {err}");
+            exit(EXIT_DSC_ERROR);
+        }
+    }
+}
+
 pub fn get_resource(dsc: &mut DscManager, resource: &str) -> DscResource {
     // check if resource is JSON or just a name
     match serde_json::from_str(resource) {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -86,6 +86,35 @@ pub fn config_test(configurator: Configurator, format: &Option<OutputFormat>)
     }
 }
 
+pub fn config_export(configurator: Configurator, format: &Option<OutputFormat>)
+{
+    match configurator.invoke_export(ErrorAction::Continue, || { /* code */ }) {
+        Ok(result) => {
+            let json = match serde_json::to_string(&result.result) {
+                Ok(json) => json,
+                Err(err) => {
+                    eprintln!("JSON Error: {err}");
+                    exit(EXIT_JSON_ERROR);
+                }
+            };
+            write_output(&json, format);
+            if result.had_errors {
+
+                for msg in result.messages
+                {
+                    eprintln!("{:?} message {}", msg.level, msg.message);
+                };
+
+                exit(EXIT_DSC_ERROR);
+            }
+        },
+        Err(err) => {
+            eprintln!("Error: {err}");
+            exit(EXIT_DSC_ERROR);
+        }
+    }
+}
+
 pub fn config(subcommand: &ConfigSubCommand, format: &Option<OutputFormat>, stdin: &Option<String>) {
     if stdin.is_none() {
         eprintln!("Configuration must be piped to STDIN");
@@ -134,6 +163,9 @@ pub fn config(subcommand: &ConfigSubCommand, format: &Option<OutputFormat>, stdi
         },
         ConfigSubCommand::Validate => {
             validate_config(&json_string);
+        },
+        ConfigSubCommand::Export => {
+            config_export(configurator, format);
         }
     }
 }

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -385,8 +385,9 @@ pub fn resource(subcommand: &ResourceSubCommand, format: &Option<OutputFormat>, 
                 table.print();
             }
         },
-       ResourceSubCommand::Get { resource, input } => {
-            resource_command::get(&mut dsc, resource, input, stdin, format);
+       ResourceSubCommand::Get { resource, input, all } => {
+            if *all { resource_command::get_all(&mut dsc, resource, input, stdin, format); }
+            else { resource_command::get(&mut dsc, resource, input, stdin, format); };
         },
         ResourceSubCommand::Set { resource, input } => {
             resource_command::set(&mut dsc, resource, input, stdin, format);

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -365,5 +365,8 @@ pub fn resource(subcommand: &ResourceSubCommand, format: &Option<OutputFormat>, 
         ResourceSubCommand::Schema { resource } => {
             resource_command::schema(&mut dsc, resource, format);
         },
+        ResourceSubCommand::Export { resource} => {
+            resource_command::export(&mut dsc, resource, format);
+        },
     }
 }

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -51,4 +51,23 @@ Describe 'resource export tests' {
         $set_results.results.count | Should -BeGreaterThan 1
         $set_results.results[0].result.afterState.result | Should -BeExactly "Ok"
     }
+
+    It 'Duplicate resource types in Configuration Export should result in error' {
+
+        $yaml = @'
+            $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+            resources:
+            - name: Processes
+              type: Microsoft/Process
+              properties:
+                pid: 0
+            - name: Processes
+              type: Microsoft/Process
+              properties:
+                pid: 0
+'@
+        $out = $yaml | dsc config export 2>&1
+        $LASTEXITCODE | Should -Be 2
+        $out | Should -BeLike '*specified multiple times*'
+    }
 }

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -8,7 +8,7 @@ Describe 'resource export tests' {
         $out = dsc resource export -r Microsoft/Process
         $LASTEXITCODE | Should -Be 0
         $config_with_process_list = $out | ConvertFrom-Json
-        $config_with_process_list.'$schema' | Should -Not -BeNullOrEmpty
+        $config_with_process_list.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json'
         $config_with_process_list.'resources' | Should -Not -BeNullOrEmpty
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
     }
@@ -35,7 +35,7 @@ Describe 'resource export tests' {
         $out = $yaml | dsc config export
         $LASTEXITCODE | Should -Be 0
         $config_with_process_list = $out | ConvertFrom-Json
-        $config_with_process_list.'$schema' | Should -Not -BeNullOrEmpty
+        $config_with_process_list.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json'
         $config_with_process_list.'resources' | Should -Not -BeNullOrEmpty
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
     }

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -5,9 +5,18 @@ Describe 'resource export tests' {
     
     It 'Export can be called on individual resource' {
 
-        $processes = dsc resource export -r Microsoft/Process
+        $out = dsc resource export -r Microsoft/Process
         $LASTEXITCODE | Should -Be 0
-        $processes.count | Should -BeGreaterThan 1
+        $config_with_process_list = $out | ConvertFrom-Json
+        $config_with_process_list.resources.count | Should -BeGreaterThan 1
+    }
+
+    It 'get --all can be called on individual resource' {
+
+        $out = dsc resource get --all -r Microsoft/Process
+        $LASTEXITCODE | Should -Be 0
+        $process_list = $out | ConvertFrom-Json
+        $process_list.resources.count | Should -BeGreaterThan 1
     }
 
     It 'Export can be called on a configuration' {

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -12,7 +12,7 @@ Describe 'resource export tests' {
 
     It 'Export can be called on a configuration' {
 
-        $json = @'
+        $yaml = @'
             $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
             resources:
             - name: Processes
@@ -20,7 +20,7 @@ Describe 'resource export tests' {
               properties:
                 pid: 0
 '@
-        $out = $json | dsc config export
+        $out = $yaml | dsc config export
         $LASTEXITCODE | Should -Be 0
         $config_with_process_list = $out | ConvertFrom-Json
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
@@ -28,7 +28,7 @@ Describe 'resource export tests' {
 
     It 'Configuration Export can be piped to configuration Set' {
 
-        $json = @'
+        $yaml = @'
             $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
             resources:
             - name: Processes
@@ -36,7 +36,7 @@ Describe 'resource export tests' {
               properties:
                 pid: 0
 '@
-        $out = $json | dsc config export | dsc config set
+        $out = $yaml | dsc config export | dsc config set
         $LASTEXITCODE | Should -Be 0
         $set_results = $out | ConvertFrom-Json
         $set_results.results.count | Should -BeGreaterThan 1

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -8,6 +8,8 @@ Describe 'resource export tests' {
         $out = dsc resource export -r Microsoft/Process
         $LASTEXITCODE | Should -Be 0
         $config_with_process_list = $out | ConvertFrom-Json
+        $config_with_process_list.'$schema' | Should -Not -BeNullOrEmpty
+        $config_with_process_list.'resources' | Should -Not -BeNullOrEmpty
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
     }
 
@@ -17,6 +19,7 @@ Describe 'resource export tests' {
         $LASTEXITCODE | Should -Be 0
         $process_list = $out | ConvertFrom-Json
         $process_list.resources.count | Should -BeGreaterThan 1
+        $process_list | % {$_.actualState | Should -Not -BeNullOrEmpty}
     }
 
     It 'Export can be called on a configuration' {
@@ -32,6 +35,8 @@ Describe 'resource export tests' {
         $out = $yaml | dsc config export
         $LASTEXITCODE | Should -Be 0
         $config_with_process_list = $out | ConvertFrom-Json
+        $config_with_process_list.'$schema' | Should -Not -BeNullOrEmpty
+        $config_with_process_list.'resources' | Should -Not -BeNullOrEmpty
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
     }
 

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -49,7 +49,6 @@ Describe 'resource export tests' {
         $LASTEXITCODE | Should -Be 0
         $set_results = $out | ConvertFrom-Json
         $set_results.results.count | Should -BeGreaterThan 1
-        $set_results.results[0].result.afterState.result | Should -BeExactly "Ok"
     }
 
     It 'Duplicate resource types in Configuration Export should result in error' {

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -35,7 +35,7 @@ Describe 'resource export tests' {
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
     }
 
-    It 'Configuration Export can be piped to configuration Set' {
+    It 'Configuration Export can be piped to configuration Set' -Skip:(!$IsWindows) {
 
         $yaml = @'
             $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -1,0 +1,45 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'resource export tests' {
+    
+    It 'Export can be called on individual resource' {
+
+        $processes = dsc resource export -r Microsoft/Process
+        $LASTEXITCODE | Should -Be 0
+        $processes.count | Should -BeGreaterThan 1
+    }
+
+    It 'Export can be called on a configuration' {
+
+        $json = @'
+            $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+            resources:
+            - name: Processes
+              type: Microsoft/Process
+              properties:
+                pid: 0
+'@
+        $out = $json | dsc config export
+        $LASTEXITCODE | Should -Be 0
+        $config_with_process_list = $out | ConvertFrom-Json
+        $config_with_process_list.resources.count | Should -BeGreaterThan 1
+    }
+
+    It 'Configuration Export can be piped to configuration Set' {
+
+        $json = @'
+            $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+            resources:
+            - name: Processes
+              type: Microsoft/Process
+              properties:
+                pid: 0
+'@
+        $out = $json | dsc config export | dsc config set
+        $LASTEXITCODE | Should -Be 0
+        $set_results = $out | ConvertFrom-Json
+        $set_results.results.count | Should -BeGreaterThan 1
+        $set_results.results[0].result.afterState.result | Should -BeExactly "Ok"
+    }
+}

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -116,3 +116,9 @@ impl Resource {
         }
     }
 }
+
+impl Default for Resource {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -91,3 +91,28 @@ impl Default for Configuration {
         }
     }
 }
+
+impl Configuration {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            schema: SCHEMA.to_string(),
+            parameters: None,
+            variables: None,
+            resources: Vec::new(),
+            metadata: None,
+        }
+    }
+}
+
+impl Resource {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            resource_type: String::new(),
+            name: String::new(),
+            depends_on: None,
+            properties: None,
+        }
+    }
+}

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -3,11 +3,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-<<<<<<< HEAD
 use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult};
-=======
-use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult, ExportResult};
->>>>>>> 660b56b (Configuration export functionality and tests)
 use crate::configure::config_doc;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -3,7 +3,11 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+<<<<<<< HEAD
 use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult};
+=======
+use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult, ExportResult};
+>>>>>>> 660b56b (Configuration export functionality and tests)
 use crate::configure::config_doc;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -3,7 +3,8 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult};
+use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult, ExportResult};
+use crate::configure::config_doc;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum MessageLevel {
@@ -122,6 +123,41 @@ impl ConfigurationTestResult {
 }
 
 impl Default for ConfigurationTestResult {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ResourceExportResult {
+    pub name: String,
+    #[serde(rename="type")]
+    pub resource_type: String,
+    pub result: ExportResult,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ConfigurationExportResult {
+    pub result: Option<config_doc::Configuration>,
+    pub messages: Vec<ResourceMessage>,
+    #[serde(rename = "hadErrors")]
+    pub had_errors: bool,
+}
+
+impl ConfigurationExportResult {
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            result: None,
+            messages: Vec::new(),
+            had_errors: false,
+        }
+    }
+}
+
+impl Default for ConfigurationExportResult {
     fn default() -> Self {
         Self::new()
     }

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -3,7 +3,7 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult, ExportResult};
+use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult};
 use crate::configure::config_doc;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -126,15 +126,6 @@ impl Default for ConfigurationTestResult {
     fn default() -> Self {
         Self::new()
     }
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct ResourceExportResult {
-    pub name: String,
-    #[serde(rename="type")]
-    pub resource_type: String,
-    pub result: ExportResult,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -155,9 +155,13 @@ impl Configurator {
 
     pub fn invoke_export(&self, _error_action: ErrorAction, _progress_callback: impl Fn() + 'static) -> Result<ConfigurationExportResult, DscError> {
         let (config, messages, had_errors) = self.validate_config()?;
-        let mut result = ConfigurationExportResult::new();
-        result.messages = messages;
-        result.had_errors = had_errors;
+
+        let mut result = ConfigurationExportResult {
+            result: None,
+            messages,
+            had_errors
+        };
+
         if had_errors {
             return Ok(result);
         };

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -159,7 +159,7 @@ impl Configurator {
         let mut map: HashMap<&String, i32> = HashMap::new();
         let mut result: HashSet<String> = HashSet::new();
         let resource_list = &config.resources;
-        if resource_list.len() == 0 {
+        if resource_list.is_empty() {
             return Vec::new();
         }
 
@@ -178,8 +178,10 @@ impl Configurator {
     pub fn invoke_export(&self, _error_action: ErrorAction, _progress_callback: impl Fn() + 'static) -> Result<ConfigurationExportResult, DscError> {
         let (config, messages, had_errors) = self.validate_config()?;
 
-        for duplicate in Self::find_duplicate_resource_types(&config)
+        let duplicates = Self::find_duplicate_resource_types(&config);
+        if !duplicates.is_empty()
         {
+            let duplicate = &duplicates[0];
             return Err(DscError::Validation(format!("Resource {duplicate} specified multiple times")));
         }
 

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -263,7 +263,7 @@ pub fn invoke_export(resource: &ResourceManifest, cwd: &str) -> Result<ExportRes
     let mut instances: Vec<Value> = Vec::new();
     for line in stdout.lines()
     {
-        let instance: Value = match serde_json::from_str(&line){
+        let instance: Value = match serde_json::from_str(line){
             Result::Ok(r) => {r},
             Result::Err(err) => {
                 return Err(DscError::Operation(format!("Failed to parse json from export {}|{}|{} -> {err}", &resource.export.clone().unwrap().executable, stdout, stderr)))

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -69,7 +69,7 @@ pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str) -> Resu
             });
         }
     }
-    let (exit_code, stdout, stderr) = invoke_command(&set.executable, set.args.clone(), Some(desired), Some(cwd))?;
+    let (exit_code, stdout, stderr) = invoke_command(&resource.get.executable, resource.get.args.clone(), Some(desired), Some(cwd))?;
     let pre_state: Value = if exit_code == 0 {
         serde_json::from_str(&stdout)?
     }

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -256,6 +256,12 @@ pub fn get_schema(resource: &ResourceManifest, cwd: &str) -> Result<String, DscE
 }
 
 pub fn invoke_export(resource: &ResourceManifest, cwd: &str) -> Result<ExportResult, DscError> {
+
+    if resource.export.is_none()
+    {
+        return Err(DscError::Operation(format!("Export is not supported by resource {}", &resource.resource_type)))
+    }
+
     let (exit_code, stdout, stderr) = invoke_command(&resource.export.clone().unwrap().executable, resource.export.clone().unwrap().args.clone(), None, Some(cwd))?;
     if exit_code != 0 {
         return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));

--- a/dsc_lib/src/dscresources/invoke_result.rs
+++ b/dsc_lib/src/dscresources/invoke_result.rs
@@ -52,3 +52,11 @@ pub struct ValidateResult {
     /// Reason for the validation result.
     pub reason: Option<String>,
 }
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExportResult {
+    /// The state of the resource as it was returned by the Get method.
+    #[serde(rename = "actualState")]
+    pub actual_state: Vec<Value>,
+}

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -29,6 +29,9 @@ pub struct ResourceManifest {
     /// Details how to call the Test method of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub test: Option<TestMethod>,
+    /// Details how to call the Export method of the resource.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub export: Option<ExportMethod>,
     /// Details how to call the Validate method of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub validate: Option<ValidateMethod>,
@@ -129,6 +132,14 @@ pub struct ValidateMethod { // TODO: enable validation via schema or command
     /// The command to run to validate the state of the resource.
     pub executable: String,
     /// The arguments to pass to the command to perform a Validate.
+    pub args: Option<Vec<String>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct ExportMethod {
+    /// The command to run to enumerate instances of the resource.
+    pub executable: String,
+    /// The arguments to pass to the command to perform a Export.
     pub args: Option<Vec<String>>,
 }
 

--- a/process/ExportTest.dsc.yaml
+++ b/process/ExportTest.dsc.yaml
@@ -1,0 +1,7 @@
+# Example configuration mixing native app resources with classic PS resources
+$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+resources:
+- name: Processes
+  type: Microsoft/Process
+  properties:
+    pid: 0

--- a/process/process.dsc.resource.json
+++ b/process/process.dsc.resource.json
@@ -17,5 +17,11 @@
         "input": "stdin",
         "preTest": true,
         "return": "state"
+    },
+    "export": {
+      "executable": "process",
+      "args": [
+        "list"
+      ]
     }
 }

--- a/process/process.dsc.resource.json
+++ b/process/process.dsc.resource.json
@@ -1,7 +1,7 @@
 {
     "manifestVersion": "1.0",
     "description": "Returns information about running processes.",
-    "type": "Microsoft/ProcessList",
+    "type": "Microsoft/Process",
     "version": "0.1.0",
     "get": {
         "executable": "process",
@@ -23,5 +23,25 @@
       "args": [
         "list"
       ]
+    },
+    "schema": {
+      "embedded": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "Process",
+        "type": "object",
+        "required": [],
+        "properties": {
+            "pid": {
+              "type": "integer"
+            },
+            "name": {
+              "type": "string"
+            },
+            "cmdline": {
+              "type": "string"
+            }
+        },
+        "additionalProperties": false
+      }
     }
 }

--- a/process/process.dsc.resource.json
+++ b/process/process.dsc.resource.json
@@ -23,8 +23,9 @@
       "args": [
         "test"
       ],
-      "input": "stdin"
-  },
+      "input": "stdin",
+      "return": "state"
+    },
     "export": {
       "executable": "process",
       "args": [

--- a/process/process.dsc.resource.json
+++ b/process/process.dsc.resource.json
@@ -15,9 +15,16 @@
           "set"
         ],
         "input": "stdin",
-        "preTest": true,
+        "preTest": false,
         "return": "state"
     },
+    "test": {
+      "executable": "process",
+      "args": [
+        "test"
+      ],
+      "input": "stdin"
+  },
     "export": {
       "executable": "process",
       "args": [

--- a/process/src/main.rs
+++ b/process/src/main.rs
@@ -28,6 +28,13 @@ fn help() {
     println!("usage: process list");
 }
 
+fn print_input() {
+    let mut buffer: Vec<u8> = Vec::new();
+    io::stdin().read_to_end(&mut buffer).unwrap();
+    let input = String::from_utf8(buffer);
+    println!("{}", input.unwrap());
+}
+
 fn main() {
     let args: Vec<String> = env::args().collect();
     if args.len() == 2 {
@@ -42,17 +49,15 @@ fn main() {
                 exit(0);
             },
             "get" => { // used for testing only
-                let mut buffer: Vec<u8> = Vec::new();
-                io::stdin().read_to_end(&mut buffer).unwrap();
-                let input = String::from_utf8(buffer);
-                println!("{}", input.unwrap());
+                print_input();
                 exit(0);
             },
             "set" => { // used for testing only
-                let mut buffer: Vec<u8> = Vec::new();
-                io::stdin().read_to_end(&mut buffer).unwrap();
-                let input = String::from_utf8(buffer);
-                println!("{}", input.unwrap());
+                print_input();
+                exit(0);
+            },
+            "test" => { // used for testing only
+                print_input();
                 exit(0);
             },
             _ => {


### PR DESCRIPTION
# PR Summary

Fix #73 , #174

This adds support for enumeration of all resource instances.
Export support is declared in a resource manifest similar to Get/Set/Test methods:
```
    "export": {
      "executable": "process",
      "args": [
        "list"
      ]
    },
```
In response to this call a resource is expected to return JSONLINES - one per resource instance.

Not implemented yet:
1) Export for provider-based resources #183 
2) Export for classic PS DSC resources (this will need #183 plus new version of v2 `PSDesiredStateConfiguration` module)

## PR Context

Following scenarios supported:

1) Export of a single resource type.
    This returns a configuration document that can be piped to `dsc config set`
    For example:
```
dsc resource export -r Microsoft/Process | dsc config set
```

2) Export of all types in a configuration.
    This returns a configuration document that can be piped to `dsc config set`
    For example:
```
Get-Content -raw C:\DSCv3\process\ExportTest.dsc.yaml | dsc config export | dsc config set
```

3. "resource get --all" operation that returns `dsc config get` result for every instance of the specified resource type.
     For example:
```
dsc resource get --all -r Microsoft/Process
```
