### PR TITLE
exit program if ctrl+c is received

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -14,6 +14,7 @@ lto = true
 atty = { version = "0.2" }
 clap = { version = "4.1", features = ["derive"] }
 crossterm = { version = "0.26.1" }
+ctrlc = { version = "3.4.0" }
 dsc_lib = { path = "../dsc_lib" }
 jsonschema = "0.17"
 schemars = { version = "0.8.12" }

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -22,6 +22,10 @@ fn main() {
     #[cfg(debug_assertions)]
     check_debug();
 
+    if ctrlc::set_handler(ctrlc_handler).is_err() {
+        eprintln!("Error: Failed to set Ctrl-C handler");
+    }
+
     let args = Args::parse();
 
     let stdin: Option<String> = if atty::is(Stream::Stdin) {
@@ -60,6 +64,11 @@ fn main() {
     }
 
     exit(util::EXIT_SUCCESS);
+}
+
+fn ctrlc_handler() {
+    eprintln!("Ctrl-C received");
+    exit(util::EXIT_CTRL_C);
 }
 
 #[cfg(debug_assertions)]

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -32,6 +32,7 @@ pub const EXIT_DSC_ERROR: i32 = 2;
 pub const EXIT_JSON_ERROR: i32 = 3;
 pub const EXIT_INVALID_INPUT: i32 = 4;
 pub const EXIT_VALIDATION_FAILED: i32 = 5;
+pub const EXIT_CTRL_C: i32 = 6;
 
 pub fn serde_json_value_to_string(json: &serde_json::Value) -> String
 {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Program exits if `ctrl+c` (sigint) is received.  At this point, it's probably safer to let child processes continue to run and finish than to kill them mid-process.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/150