### PR TITLE
(GH-181) Add semantic exit codes to `DSC/*` resource manifests

### DIFF
--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -31,7 +31,13 @@
     "return": "state"
   },
   "exitCodes": {
-    "0": "Success"
+    "0": "Success",
+    "1": "Invalid argument",
+    "2": "Resource error",
+    "3": "JSON Serialization error",
+    "4": "Invalid input format",
+    "5": "Resource instance failed schema validation",
+    "6": "Command cancelled"
   },
   "schema": {
     "command": {

--- a/dsc/group.dsc.resource.json
+++ b/dsc/group.dsc.resource.json
@@ -31,7 +31,13 @@
     "return": "state"
   },
   "exitCodes": {
-    "0": "Success"
+    "0": "Success",
+    "1": "Invalid argument",
+    "2": "Resource error",
+    "3": "JSON Serialization error",
+    "4": "Invalid input format",
+    "5": "Resource instance failed schema validation",
+    "6": "Command cancelled"
   },
   "validate": {
     "executable": "dsc",

--- a/dsc/parallel.dsc.resource.json
+++ b/dsc/parallel.dsc.resource.json
@@ -34,7 +34,13 @@
     "return": "state"
   },
   "exitCodes": {
-    "0": "Success"
+    "0": "Success",
+    "1": "Invalid argument",
+    "2": "Resource error",
+    "3": "JSON Serialization error",
+    "4": "Invalid input format",
+    "5": "Resource instance failed schema validation",
+    "6": "Command cancelled"
   },
   "validate": {
     "executable": "dsc",


### PR DESCRIPTION
# PR Summary

Prior to this change, the resource manifests for the built-in `DSC/*` group resources only defined the `0` exit code for success. This change:

- Adds the other exit codes to the manifests, based on #179
- Resolves #181

## PR Context

Syncs the annotation for the manifest to the implementation of the command.