### PR TITLE
Document `dependsOn` update

### DIFF
--- a/docs/reference/cli/dsc.md
+++ b/docs/reference/cli/dsc.md
@@ -73,13 +73,10 @@ To set the output format for a command or subcommand, specify this option before
 `dsc --format pretty-json resource list`.
 
 ```yaml
-Type:          String
-Mandatory:     false
-Default Value: yaml
-Valid Values:
-  - json
-  - pretty-json
-  - yaml
+Type:         String
+Mandatory:    false
+DefaultValue: yaml
+ValidValues:  [json, pretty-json, yaml]
 ```
 
 ### -h, --help

--- a/docs/reference/cli/schema/command.md
+++ b/docs/reference/cli/schema/command.md
@@ -73,18 +73,19 @@ schema the application returns:
   `dsc config test` command.
 
 ```yaml
-Type:      String
-Mandatory: true
-Valid Values:
-  - dsc-resource
-  - resource-manifest
-  - get-result
-  - set-result
-  - test-result
-  - configuration
-  - configuration-get-result
-  - configuration-set-result
-  - configuration-test-result
+Type:        String
+Mandatory:   true
+ValidValues: [
+               dsc-resource,
+               resource-manifest,
+               get-result,
+               set-result,
+               test-result,
+               configuration,
+               configuration-get-result,
+               configuration-set-result,
+               configuration-test-result
+             ]
 ```
 
 ### -h, --help

--- a/docs/reference/schemas/config/document.md
+++ b/docs/reference/schemas/config/document.md
@@ -14,9 +14,9 @@ The YAML or JSON file that defines a DSC Configuration.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+Type:          object
 ```
 
 ## Description
@@ -55,11 +55,12 @@ adheres to. DSC uses this property when validating the configuration document be
 configuration operations.
 
 ```yaml
-Type:     string
-Required: true
-Format:   URI
-Valid Values:
-  - https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+Type:        string
+Required:    true
+Format:      URI
+ValidValues: [
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+             ]
 ```
 
 ### metadata
@@ -90,9 +91,9 @@ For more information about defining parameters in a configuration, see
 [DSC Configuration parameters][03] -->
 
 ```yaml
-Type:                  object
-Required:              false
-Valid Property Schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
+Type:                object
+Required:            false
+ValidPropertySchema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
 ```
 
 ### variables
@@ -125,10 +126,10 @@ For more information about defining a valid resource instance in a configuration
 [DSC Configuration resources][06] and [DSC Configuration resource groups][07]. -->
 
 ```yaml
-Type:               array
-Required:           true
-Minimum Item Count: 1
-Valid Item Schema:  https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
+Type:             array
+Required:         true
+MinimumItemCount: 1
+ValidItemSchema:  https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
 ```
 
 <!-- [01]: ../../../configurations/overview.md -->

--- a/docs/reference/schemas/config/parameter.md
+++ b/docs/reference/schemas/config/parameter.md
@@ -14,9 +14,9 @@ Defines runtime options for a configuration.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
+Type:          object
 ```
 
 ## Description
@@ -75,16 +75,9 @@ For more information about data types, see
 [DSC configuration parameter data type schema reference][02].
 
 ```yaml
-Type:     string
-Required: true
-Valid Values:
-  - string
-  - securestring
-  - int
-  - bool
-  - object
-  - secureobject
-  - array
+Type:        string
+Required:    true
+ValidValues: [string, securestring, int, bool, object, secureobject, array]
 ```
 
 ### defaultValue
@@ -95,13 +88,8 @@ runtime and no default value is defined, DSC raises an error. The value must be 
 parameter's `type`.
 
 ```yaml
-Required: false
-Valid JSON Types:
-  - string
-  - integer
-  - object
-  - array
-  - boolean
+Required:       false
+ValidJSONTypes: [string, integer, object, array, boolean]
 ```
 
 ### allowedValues
@@ -114,14 +102,9 @@ This property is always an array. If this property is defined, it must include a
 the list of values.
 
 ```yaml
-Type:     array
-Required: false
-Valid Item JSON Types:
-  - string
-  - integer
-  - object
-  - array
-  - boolean
+Type:               array
+Required:           false
+ValidItemJSONTypes: [string, integer, object, array, boolean]
 ```
 
 ### minLength
@@ -137,9 +120,9 @@ If this property is defined with the `maxLength` property, this property must be
 `maxLength`. If it isn't, DSC raises an error.
 
 ```yaml
-Type:          int
-Required:      false
-Minimum Value: 0
+Type:         int
+Required:     false
+MinimumValue: 0
 ```
 
 ### maxLength
@@ -155,9 +138,9 @@ If this property is defined with the `minLength` property, this property must be
 `minLength`. If it isn't, DSC raises an error.
 
 ```yaml
-Type:          int
-Required:      false
-Minimum Value: 0
+Type:         int
+Required:     false
+MinimumValue: 0
 ```
 
 ### minValue

--- a/docs/reference/schemas/config/resource.md
+++ b/docs/reference/schemas/config/resource.md
@@ -14,9 +14,9 @@ Defines a DSC Resource instance in a configuration document.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
+Type:          object
 ```
 
 ## Description
@@ -131,11 +131,11 @@ resource named `Tailspin Key`:
 <!-- For more information, see [Configuration resource dependencies][04]. -->
 
 ```yaml
-Type:                 array
-Required:             false
-Items Must be Unique: true
-Valid Items Type:     string
-Valid Items Pattern:  ^\[resourceId\(\s*'\w+(\.\w+){0,2}\/\w+'\s*,\s*'[a-zA-Z0-9 ]+'\s*\)\]$
+Type:              array
+Required:          false
+ItemsMustBeUnique: true
+ItemsType:         string
+ItemsPattern:      ^\[resourceId\(\s*'\w+(\.\w+){0,2}\/\w+'\s*,\s*'[a-zA-Z0-9 ]+'\s*\)\]$
 ```
 
 [01]: ../definitions/resourceType.md

--- a/docs/reference/schemas/config/resource.md
+++ b/docs/reference/schemas/config/resource.md
@@ -45,9 +45,13 @@ The `name` property of a resource instance defines the short, human-readable nam
 Resource instance. This property must be unique within a DSC Configuration document. If any
 resource instances share the same name, DSC raises an error.
 
+The instance name must be a non-empty string containing only letters, numbers, and spaces.
+
 ```yaml
-Type:     string
-Required: true
+Type:          string
+Required:      true
+MinimumLength: 1
+Pattern:       ^[a-zA-Z0-9 ]+$
 ```
 
 ### type
@@ -80,18 +84,49 @@ Required: true
 To declare that a resource instance is dependent on another instance in the configuration, define
 the `dependsOn` property.
 
-This property must be an array of dependency declarations. Each dependency must use this
-syntax:
+This property defines a list of DSC Resource instances that DSC must successfully process before
+processing this instance. Each value for this property must be the `resourceID()` lookup for
+another instance in the configuration. Multiple instances can depend on the same instance, but
+every dependency for an instance must be unique in that instance's `dependsOn` property.
+
+The `resourceID()` function uses this syntax:
 
 ```yaml
-"[<resource-type-name>]<instance-name>"
+"[resourceId('<resource-type-name>', '<instance-name>']"
 ```
 
-In the dependency syntax, `<resource-type-name>` is the `type` property of the dependent resource
-and `<instance-name>` is the dependency's `name` property.
+The `<resource-type-name>` value is the `type` property of the dependent resource and
+`<instance-name>` is the dependency's `name` property. When adding a dependency in a YAML-format
+configuration document, always wrap the `resourceID()` lookup in double quotes (`"`).
 
-Multiple instances can depend on the same instance, but every dependency for an instance must be
-unique in that instance's `dependsOn` property.
+For example, this instance depends on an instance of the `Microsoft.Windows/Registry`
+resource named `Tailspin Key`:
+
+```yaml
+- name: Tailspin Key
+  type: Microsoft.Windows/Registry
+  properties:
+    keyPath: HKCU\tailspin
+    _ensure: Present
+- name: Update Tailspin Automatically
+  type: Microsoft.Windows/Registry
+  properties:
+    keyPath:   HKCU\tailspin\updates
+    valueName: automatic
+    valueData:
+      String: enable
+  dependsOn:
+    - "[resourceId('Microsoft.Windows/Registry', 'Tailspin Key')]"
+```
+
+> [!NOTE]
+> When defining dependencies for [nested resource instances][02], instances can only reference
+> dependencies in the same resource provider or group instance. They can't use the `resourceId()`
+> function to lookup instances at the top-level of the configuration document or inside another
+> provider or group instance.
+>
+> If a top-level instance depends on a nested instance, use the `resourceId()` function to lookup
+> the instance of the provider or group containing the dependency instance instead.
 
 <!-- For more information, see [Configuration resource dependencies][04]. -->
 
@@ -100,10 +135,11 @@ Type:                 array
 Required:             false
 Items Must be Unique: true
 Valid Items Type:     string
-Valid Items Pattern:  ^\[\w+(\.\w+){0,2}\/\w+\].+$
+Valid Items Pattern:  ^\[resourceId\(\s*'\w+(\.\w+){0,2}\/\w+'\s*,\s*'[a-zA-Z0-9 ]+'\s*\)\]$
 ```
 
 [01]: ../definitions/resourceType.md
+[02]: /powershell/dsc/glossary#nested-resource-instance
 <!-- [02]: ../../../resources/concepts/assertion-resources.md -->
 <!-- [03]: ../../../resources/concepts/schemas.md -->
 <!-- [04]: ../../../configurations/concepts/dependencies.md -->

--- a/docs/reference/schemas/definitions/message.md
+++ b/docs/reference/schemas/definitions/message.md
@@ -14,9 +14,9 @@ A message emitted by a DSC Resource with associated metadata.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/message.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/message.json
+Type:          object
 ```
 
 ## Description
@@ -67,12 +67,9 @@ Required: true
 Indicates the severity of the message.
 
 ```yaml
-Type:     string
-Required: true
-Valid Values:
-  - Error
-  - Warning
-  - Information
+Type:         string
+Required:     true
+Valid Values: [Error, Warning, Information]
 ```
 
 [01]: resourceType.md

--- a/docs/reference/schemas/definitions/parameters/dataTypes.md
+++ b/docs/reference/schemas/definitions/parameters/dataTypes.md
@@ -14,17 +14,10 @@ Defines valid data types for a DSC configuration parameter
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/parameters/dataTypes.json
-Type           : string
-Valid Values:
-  - array
-  - bool
-  - int
-  - object
-  - string
-  - secureobject
-  - securestring
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/parameters/dataTypes.json
+Type:          string
+ValidValues:   [array, bool, int, object, string, secureobject, securestring]
 ```
 
 ## Description

--- a/docs/reference/schemas/definitions/resourceType.md
+++ b/docs/reference/schemas/definitions/resourceType.md
@@ -14,10 +14,10 @@ Identifies a DSC Resource.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json
-Type           : string
-Pattern        : ^\w+(\.\w+){0,2}\/\w+$
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json
+Type:          string
+Pattern:       ^\w+(\.\w+){0,2}\/\w+$
 ```
 
 ## Description

--- a/docs/reference/schemas/outputs/config/get.md
+++ b/docs/reference/schemas/outputs/config/get.md
@@ -14,9 +14,9 @@ The result output from the `dsc config get` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/get.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/get.json
+Type:          object
 ```
 
 ## Description
@@ -41,9 +41,9 @@ configuration document. Every entry in the list includes the resource's type nam
 and the result data for an instance.
 
 ```yaml
-Type:     array
-Required: true
-Items Type: object
+Type:      array
+Required:  true
+ItemsType: object
 ```
 
 #### type

--- a/docs/reference/schemas/outputs/config/set.md
+++ b/docs/reference/schemas/outputs/config/set.md
@@ -14,9 +14,9 @@ The result output from the `dsc config set` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/set.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/set.json
+Type:          object
 ```
 
 ## Description
@@ -42,9 +42,9 @@ configuration document. Every entry in the list includes the resource's type nam
 and the result data for an instance.
 
 ```yaml
-Type:     array
-Required: true
-Items Type: object
+Type:      array
+Required:  true
+ItemsType: object
 ```
 
 #### type

--- a/docs/reference/schemas/outputs/config/test.md
+++ b/docs/reference/schemas/outputs/config/test.md
@@ -14,9 +14,9 @@ The result output from the `dsc config test` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/test.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/test.json
+Type:          object
 ```
 
 ## Description
@@ -42,9 +42,9 @@ configuration document. Every entry in the list includes the resource's type nam
 and the result data for an instance.
 
 ```yaml
-Type:     array
-Required: true
-Items Type: object
+Type:      array
+Required:  true
+ItemsType: object
 ```
 
 #### type

--- a/docs/reference/schemas/outputs/resource/get.md
+++ b/docs/reference/schemas/outputs/resource/get.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource get` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/get.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/get.json
+Type:          object
 ```
 
 ## Description

--- a/docs/reference/schemas/outputs/resource/list.md
+++ b/docs/reference/schemas/outputs/resource/list.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource list` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/list.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/list.json
+Type:          object
 ```
 
 ## Description
@@ -133,10 +133,10 @@ resources, this property is an empty array.
 -->
 
 ```yaml
-Type:          array
-Required:      true
-Items Type:    string
-Items Pattern: ^\w+$
+Type:         array
+Required:     true
+ItemsType:    string
+ItemsPattern: ^\w+$
 ```
 
 ### requires

--- a/docs/reference/schemas/outputs/resource/set.md
+++ b/docs/reference/schemas/outputs/resource/set.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource set` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/set.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/set.json
+Type:          object
 ```
 
 ## Description
@@ -60,7 +60,7 @@ Defines the names of the properties the set operation enforced. If this value is
 the resource made no changes during the set operation.
 
 ```yaml
-Type:       array
-Required:   true
-Items Type: string
+Type:      array
+Required:  true
+ItemsType: string
 ```

--- a/docs/reference/schemas/outputs/resource/test.md
+++ b/docs/reference/schemas/outputs/resource/test.md
@@ -14,9 +14,9 @@ The result output from the `dsc resource test` command.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/test.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/test.json
+Type:          object
 ```
 
 ## Description
@@ -68,7 +68,7 @@ Defines the names of the properties that aren't in the desired state. If this va
 array, the instance's properties are in the desired state.
 
 ```yaml
-Type:       array
-Required:   true
-Items Type: string
+Type:      array
+Required:  true
+ItemsType: string
 ```

--- a/docs/reference/schemas/resource/manifest/get.md
+++ b/docs/reference/schemas/resource/manifest/get.md
@@ -14,9 +14,9 @@ Defines how to retrieve a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json
+Type:          object
 ```
 
 ## Description
@@ -112,10 +112,8 @@ be one of the following strings:
 - `stdin` - Indicates that the resource expects a JSON blob representing an instance from `stdin`.
 
 ```yaml
-Type:     string
-Required: false
-Default:  stdin
-Valid Values:
-  - args
-  - stdin
+Type:        string
+Required:    false
+Default:     stdin
+ValidValues: [args, stdin]
 ```

--- a/docs/reference/schemas/resource/manifest/provider.md
+++ b/docs/reference/schemas/resource/manifest/provider.md
@@ -14,9 +14,9 @@ Defines a DSC Resource as a DSC Resource Provider.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.provider.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.provider.json
+Type:          object
 ```
 
 ## Description
@@ -85,10 +85,8 @@ value must be one of the following options:
   a [JSON Line][01] over `stdin`.
 
 ```yaml
-Type: string
-Valid Values:
-  - full
-  - sequence
+Type:        string
+ValidValues: [full, sequence]
 ```
 
 ### list
@@ -97,10 +95,9 @@ The `list` property defines how to call the provider to list the resources it su
 of this property must be an object and define the `executable` subproperty.
 
 ```yaml
-Type:     object
-Required: true
-Required Properties:
-  - executable
+Type:               object
+Required:           true
+RequiredProperties: [executable]
 ```
 
 #### executable

--- a/docs/reference/schemas/resource/manifest/root.md
+++ b/docs/reference/schemas/resource/manifest/root.md
@@ -14,9 +14,9 @@ The JSON file that defines a command-based DSC Resource.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json
+Type:          object
 ```
 
 ## Description
@@ -47,11 +47,10 @@ manifest validates against. This property is mandatory. DSC uses this value to v
 manifest against the correct JSON schema.
 
 ```yaml
-Type:     string
-Required: true
-Pattern:  ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
-Valid Values:
-  - '1.0'
+Type:        string
+Required:    true
+Pattern:     ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+([0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$
+ValidValues: ['1.0']
 ```
 
 ### type
@@ -95,12 +94,11 @@ property must be an array of strings. Each tag must contain only alphanumeric ch
 underscores. No other characters are permitted. Each tag must be unique.
 
 ```yaml
-Type:     array
-Required: false
-Valid Items:
-  Type:    string
-  Pattern: ^\w+$
-  Unique:  true
+Type:              array
+Required:          false
+ItemsMustBeUnique: true
+ItemsType:         string
+ItemsPattern:      ^\w+$
 ```
 
 ### get
@@ -182,11 +180,10 @@ Define this property as a set of key-value pairs where:
 DSC interprets exit code `0` as a successful operation and any other exit code as an error.
 
 ```yaml
-Type:     object
-Required: false
-Valid Properties:
-  Name Pattern: ^[0-9]+#
-  Value Type:   string
+Type:                object
+Required:            false
+PropertyNamePattern: ^[0-9]+#
+PropertyValueType:   string
 ```
 
 ### schema

--- a/docs/reference/schemas/resource/manifest/schema/embedded.md
+++ b/docs/reference/schemas/resource/manifest/schema/embedded.md
@@ -14,9 +14,9 @@ Defines a JSON Schema that validates a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json#/properties/embedded
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json#/properties/embedded
+Type:          object
 ```
 
 ## Description
@@ -47,13 +47,14 @@ how to interpret them.
 DSC only supports JSON Schema Draft 07 and later.
 
 ```yaml
-Type:     string
-Required: true
-Format:   uri-reference
-Valid Values:
-  - https://json-schema.org/draft/2020-12/schema
-  - https://json-schema.org/draft/2019-09/schema
-  - http://json-schema.org/draft-07/schema#
+Type:        string
+Required:    true
+Format:      uri-reference
+ValidValues: [
+                https://json-schema.org/draft/2020-12/schema
+                https://json-schema.org/draft/2019-09/schema
+                http://json-schema.org/draft-07/schema#
+              ]
 ```
 
 ### $id
@@ -73,9 +74,9 @@ The `type` keyword defines what kind of value the instance is. Instances must be
 keyword to `object`.
 
 ```yaml
-Type:        string
-Required:    true
-Valid Value: object
+Type:       string
+Required:   true
+ValidValue: object
 ```
 
 ### properties

--- a/docs/reference/schemas/resource/manifest/schema/property.md
+++ b/docs/reference/schemas/resource/manifest/schema/property.md
@@ -14,9 +14,9 @@ Defines how to retrieve the JSON Schema that validates a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json
+Type:          object
 ```
 
 ## Description
@@ -108,9 +108,8 @@ authoring tools and other integrating applications to validate instances without
 command locally.
 
 ```yaml
-Type:     object
-Required Properties:
-  - executable
+Type:               object
+RequiredProperties: [executable]
 ```
 
 #### executable
@@ -143,8 +142,8 @@ Resource. The value for this property must be a valid JSON schema that defines t
 `type`, and `properties` keywords.
 
 ```yaml
-Type: object
-Minimum Property Count: 1
+Type:                 object
+MinimumPropertyCount: 1
 ```
 
 ### url

--- a/docs/reference/schemas/resource/manifest/set.md
+++ b/docs/reference/schemas/resource/manifest/set.md
@@ -14,9 +14,9 @@ Defines how to enforce state for a DSC Resource instance.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json
+Type:          object
 ```
 
 ## Description
@@ -109,12 +109,10 @@ be one of the following strings:
   `stdin`.
 
 ```yaml
-Type:     string
-Required: false
-Default:  stdin
-Valid Values:
-  - args
-  - stdin
+Type:        string
+Required:    false
+Default:     stdin
+ValidValues: [args, stdin]
 ```
 
 ### preTest
@@ -143,10 +141,8 @@ property must be one of the following strings:
 The default value is `state`.
 
 ```yaml
-Type: string
-Required: false
-Default:  state
-Valid Values:
-  - state
-  - stateAndDiff
+Type:        string
+Required:    false
+Default:     state
+ValidValues: [state, stateAndDiff]
 ```

--- a/docs/reference/schemas/resource/manifest/test.md
+++ b/docs/reference/schemas/resource/manifest/test.md
@@ -14,9 +14,9 @@ Defines how to test whether a DSC Resource instance is in the desired state.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.test.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.test.json
+Type:          object
 ```
 
 ## Description
@@ -117,12 +117,10 @@ be one of the following strings:
   `stdin`.
 
 ```yaml
-Type:     string
-Required: false
-Default:  stdin
-Valid Values:
-  - args
-  - stdin
+Type:        string
+Required:    false
+Default:     stdin
+ValidValues: [args, stdin]
 ```
 
 ### return
@@ -137,10 +135,8 @@ property must be one of the following strings:
 The default value is `state`.
 
 ```yaml
-Type: string
-Required: false
-Default:  state
-Valid Values:
-  - state
-  - stateAndDiff
+Type:        string
+Required:    false
+Default:     state
+ValidValues: [state, stateAndDiff]
 ```

--- a/docs/reference/schemas/resource/manifest/validate.md
+++ b/docs/reference/schemas/resource/manifest/validate.md
@@ -14,9 +14,9 @@ This property
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.validate.json
-Type           : object
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.validate.json
+Type:          object
 ```
 
 ## Description

--- a/docs/reference/schemas/resource/properties/ensure.md
+++ b/docs/reference/schemas/resource/properties/ensure.md
@@ -14,10 +14,10 @@ Indicates whether an instance should exist.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/ensure.json
-Type           : string
-Valid Values   : [Absent, Present]
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/ensure.json
+Type:          string
+ValidValues:   [Absent, Present]
 ```
 
 ## Description

--- a/docs/reference/schemas/resource/properties/inDesiredState.md
+++ b/docs/reference/schemas/resource/properties/inDesiredState.md
@@ -14,10 +14,10 @@ Indicates whether an instance is in the desired state.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json
-Type           : [boolean, 'null']
-Read Only      : true
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json
+Type:          [boolean, 'null']
+ReadOnly:      true
 ```
 
 ## Description

--- a/docs/reference/schemas/resource/properties/purge.md
+++ b/docs/reference/schemas/resource/properties/purge.md
@@ -14,10 +14,10 @@ Indicates that the resource should treat non-defined entries in a list as invali
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json
-Type           : [boolean, 'null']
-Write Only     : true
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json
+Type:          [boolean, 'null']
+WriteOnly:     true
 ```
 
 ## Description

--- a/docs/reference/schemas/resource/properties/rebootRequested.md
+++ b/docs/reference/schemas/resource/properties/rebootRequested.md
@@ -14,10 +14,10 @@ Indicates whether an instance is in the desired state.
 ## Metadata
 
 ```yaml
-Schema Dialect : https://json-schema.org/draft/2020-12/schema
-Schema ID      : https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json
-Type           : [boolean, 'null']
-Read Only      : true
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json
+Type:          [boolean, 'null']
+ReadOnly:      true
 ```
 
 ## Description

--- a/schemas/2023/08/bundled/config/document.json
+++ b/schemas/2023/08/bundled/config/document.json
@@ -14,7 +14,7 @@
       "description": "This property must be the canonical URL of the DSC Configuration Document schema that the document is implemented for.",
       "type": "string",
       "format": "uri",
-      "enum": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json"
+      "enum": ["https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json"]
     },
     "parameters": {
       "title": "DSC Configuration document parameters",
@@ -290,12 +290,12 @@
         },
         "dependsOn": {
           "title": "Instance depends on",
-          "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the value of another DSC Resource instance's `name` property.",
+          "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the `resourceID()` lookup for another instance in the configuration. Multiple instances can depend on the same instance, but every dependency for an instance must be unique in that instance's `dependsOn` property.",
           "type": "array",
           "items": {
             "type": "string",
             "uniqueItems": true,
-            "pattern": "^\\[\\w+(\\.\\w+){0,2}\\/\\w+\\].+$"
+            "pattern": "^\\[resourceId\\(\\s*'\\w+(\\.\\w+){0,2}\\/\\w+'\\s*,\\s*'[a-zA-Z0-9 ]+'\\s*\\)\\]$"
           }
         },
         "properties": {
@@ -345,8 +345,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/instanceName.json",
       "title": "Instance name",
-      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document.",
-      "type": "string"
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
     }
   }
 }

--- a/schemas/2023/08/bundled/config/document.vscode.json
+++ b/schemas/2023/08/bundled/config/document.vscode.json
@@ -432,15 +432,15 @@
                       },
                       "dependsOn": {
                         "title": "Instance depends on",
-                        "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the value of another DSC Resource instance's `name` property.",
+                        "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the `resourceID()` lookup for another instance in the configuration. Multiple instances can depend on the same instance, but every dependency for an instance must be unique in that instance's `dependsOn` property.",
                         "type": "array",
                         "items": {
                           "type": "string",
                           "uniqueItems": true,
-                          "pattern": "^\\[\\w+(\\.\\w+){0,2}\\/\\w+\\].+$",
-                          "patternErrorMessage": "Invalid value, must be a value like `[<type>]<name>`, such as `[Microsoft/OSInfo]Foo`.\n\nThe `<type>` and `<name>` should be the fully qualified type of the resource and its\nfriendly name in the configuration.\n"
+                          "pattern": "^\\[resourceId\\(\\s*'\\w+(\\.\\w+){0,2}\\/\\w+'\\s*,\\s*'[a-zA-Z0-9 ]+'\\s*\\)\\]$",
+                          "patternErrorMessage": "Invalid value, must be a value like `[resourceId('<type>', '<name>`)], such as\n`[resourceId('Microsoft/OSInfo', 'Foo')]`.\n\nThe `<type>` and `<name>` should be the fully qualified type of the resource and its\nfriendly name in the configuration.\n"
                         },
-                        "markdownDescription": "> [Online Documentation][01]\n\nDefines a list of DSC Resource instances that DSC must successfully process before processing\nthis instance. Each value for this property must be the value of another DSC Resource\ninstance's `name` property.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserveView=true#properties-1\n"
+                        "markdownDescription": "> [Online Documentation][01]\n\nDefines a list of DSC Resource instances that DSC must successfully process before processing\nthis instance. Each value for this property must be the `resourceID()` lookup for another\ninstance in the configuration. Multiple instances can depend on the same instance, but every\ndependency for an instance must be unique in that instance's `dependsOn` property.\n\nThe `resourceID()` function uses this syntax:\n\n```yaml\n\"[resourceId('<resource-type-name>', '']<instance-name>\"\n```\n\nThe `<resource-type-name>` value is the `type` property of the dependent resource and\n`<instance-name>` is the dependency's `name` property. When adding a dependency in a\nYAML-format configuration document, always wrap the `resourceID()` lookup in double quotes\n(`\"`).\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserveView=true#properties-1\n"
                       },
                       "properties": {
                         "title": "Managed instance properties",
@@ -532,9 +532,12 @@
                     "$schema": "https://json-schema.org/draft/2020-12/schema",
                     "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/instanceName.json",
                     "title": "Instance name",
-                    "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document.",
+                    "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
                     "type": "string",
-                    "markdownDescription": "> [Online Documentation][01]\n\nThe short, human-readable name for a DSC Resource instance. Must be unique within a DSC\nConfiguration document.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserveView=true#name\n"
+                    "pattern": "^[a-zA-Z0-9 ]+$",
+                    "minLength": 1,
+                    "patternErrorMessage": "Invalid value for instance name. An instance name must be a non-empty string containing only\nletters, numbers, and spaces.\n",
+                    "markdownDescription": "> [Online Documentation][01]\n\nDefines the short, human-readable name for a DSC Resource instance. This property must be unique\nwithin a DSC Configuration document. If any resource instances share the same name, DSC raises an\nerror.\n\nThe instance name must be a non-empty string containing only letters, numbers, and spaces.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserveView=true#name\n"
                   }
                 }
               }

--- a/schemas/2023/08/bundled/outputs/config/get.json
+++ b/schemas/2023/08/bundled/outputs/config/get.json
@@ -47,8 +47,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/instanceName.json",
       "title": "Instance name",
-      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document.",
-      "type": "string"
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
     },
     "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/2023/08/bundled/outputs/config/set.json
+++ b/schemas/2023/08/bundled/outputs/config/set.json
@@ -47,8 +47,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/instanceName.json",
       "title": "Instance name",
-      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document.",
-      "type": "string"
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
     },
     "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/2023/08/bundled/outputs/config/test.json
+++ b/schemas/2023/08/bundled/outputs/config/test.json
@@ -47,8 +47,10 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/instanceName.json",
       "title": "Instance name",
-      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document.",
-      "type": "string"
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
     },
     "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/2023/08/config/document.resource.json
+++ b/schemas/2023/08/config/document.resource.json
@@ -17,12 +17,12 @@
     },
     "dependsOn": {
       "title": "Instance depends on",
-      "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the value of another DSC Resource instance's `name` property.",
+      "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the `resourceID()` lookup for another instance in the configuration. Multiple instances can depend on the same instance, but every dependency for an instance must be unique in that instance's `dependsOn` property.",
       "type": "array",
       "items": {
         "type": "string",
         "uniqueItems": true,
-        "pattern": "^\\[\\w+(\\.\\w+){0,2}\\/\\w+\\].+$"
+        "pattern": "^\\[resourceId\\(\\s*'\\w+(\\.\\w+){0,2}\\/\\w+'\\s*,\\s*'[a-zA-Z0-9 ]+'\\s*\\)\\]$"
       }
     },
     "properties": {

--- a/schemas/2023/08/definitions/instanceName.json
+++ b/schemas/2023/08/definitions/instanceName.json
@@ -2,6 +2,8 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/instanceName.json",
   "title": "Instance name",
-  "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document.",
-  "type": "string"
+  "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+  "type": "string",
+  "pattern": "^[a-zA-Z0-9 ]+$",
+  "minLength": 1
 }

--- a/schemas/src/config/document.resource.yaml
+++ b/schemas/src/config/document.resource.yaml
@@ -17,16 +17,18 @@ properties:
     title: Instance depends on
     description: >-
       Defines a list of DSC Resource instances that DSC must successfully process before processing
-      this instance. Each value for this property must be the value of another DSC Resource
-      instance's `name` property.
+      this instance. Each value for this property must be the `resourceID()` lookup for another
+      instance in the configuration. Multiple instances can depend on the same instance, but every
+      dependency for an instance must be unique in that instance's `dependsOn` property.
     type: array
     items:
       type: string
       uniqueItems: true
-      pattern: ^\[\w+(\.\w+){0,2}\/\w+\].+$
+      pattern: ^\[resourceId\(\s*'\w+(\.\w+){0,2}\/\w+'\s*,\s*'[a-zA-Z0-9 ]+'\s*\)\]$
       # VS Code only
       patternErrorMessage: |
-        Invalid value, must be a value like `[<type>]<name>`, such as `[Microsoft/OSInfo]Foo`.
+        Invalid value, must be a value like `[resourceId('<type>', '<name>`)], such as
+        `[resourceId('Microsoft/OSInfo', 'Foo')]`.
 
         The `<type>` and `<name>` should be the fully qualified type of the resource and its
         friendly name in the configuration.
@@ -34,8 +36,20 @@ properties:
       > [Online Documentation][01]
 
       Defines a list of DSC Resource instances that DSC must successfully process before processing
-      this instance. Each value for this property must be the value of another DSC Resource
-      instance's `name` property.
+      this instance. Each value for this property must be the `resourceID()` lookup for another
+      instance in the configuration. Multiple instances can depend on the same instance, but every
+      dependency for an instance must be unique in that instance's `dependsOn` property.
+
+      The `resourceID()` function uses this syntax:
+
+      ```yaml
+      "[resourceId('<resource-type-name>', '']<instance-name>"
+      ```
+
+      The `<resource-type-name>` value is the `type` property of the dependent resource and
+      `<instance-name>` is the dependency's `name` property. When adding a dependency in a
+      YAML-format configuration document, always wrap the `resourceID()` lookup in double quotes
+      (`"`).
 
       [01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserveView=true#properties-1
   properties:

--- a/schemas/src/definitions/instanceName.yaml
+++ b/schemas/src/definitions/instanceName.yaml
@@ -4,15 +4,23 @@ $id:     <HOST>/<PREFIX>/<VERSION>/definitions/instanceName.yaml
 
 title: Instance name
 description: >-
-  The short, human-readable name for a DSC Resource instance. Must be unique
-  within a DSC Configuration document.
-type: string
+  The short, human-readable name for a DSC Resource instance. Must be unique within a DSC
+  Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.
+type:      string
+pattern:   ^[a-zA-Z0-9 ]+$
+minLength: 1
 
 # VS Code only
+patternErrorMessage: |
+  Invalid value for instance name. An instance name must be a non-empty string containing only
+  letters, numbers, and spaces.
 markdownDescription: |
   > [Online Documentation][01]
 
-  The short, human-readable name for a DSC Resource instance. Must be unique within a DSC
-  Configuration document.
+  Defines the short, human-readable name for a DSC Resource instance. This property must be unique
+  within a DSC Configuration document. If any resource instances share the same name, DSC raises an
+  error.
+
+  The instance name must be a non-empty string containing only letters, numbers, and spaces.
 
   [01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserveView=true#name


### PR DESCRIPTION
# PR Summary

This change:

- Updates the schema and documentation for instance names to clarify that they must be non-empty strings containing only letters, numbers, and spaces.
- Updates the schema and documentation for the `dependsOn` property to use the new `resourceId()` function syntax as added in #175.
- Regenerates the schemas with the updated definitions for `2023/08`
- Updates the YAML metadata blocks in the reference documentation to match the updated blocks on the learn platform.

## PR Context

Prior to this change, the schema for the `dependsOn` keyword used the PSDSC syntax and the schema for instance names allowed arbitrary strings.

For now, this change does not define new reference documentation for the configuration functions. When more configuration functions are added, we can define a separate set of reference documentation for those functions.