### PR TITLE
(DOCS) Update documentation & schemas for `export`

### DIFF
--- a/docs/reference/cli/config/command.md
+++ b/docs/reference/cli/config/command.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc config' command
-ms.date:     08/04/2023
+ms.date:     09/06/2023
 ms.topic:    reference
 title:       dsc config
 ---
@@ -24,20 +24,25 @@ configuration document. To manage resources directly, see the [dsc resource][01]
 
 ## Commands
 
+### export
+
+The `export` command generates a configuration document that defines the existing instances of a
+set of resources. For more information, see [dsc config export][02].
+
 ### get
 
 The `get` command retrieves the current state of the resource instances in a configuration
-document. For more information, see [dsc config get][02].
+document. For more information, see [dsc config get][03].
 
 ### set
 
 The `set` command enforces the desired state of the resource instances in a configuration document.
-For more information, see [dsc config set][03].
+For more information, see [dsc config set][04].
 
 ### test
 
 The `test` command verifies whether the resource instances in a configuration document are in the
-desired state. For more information, see [dsc config test][04].
+desired state. For more information, see [dsc config test][05].
 
 ### help
 
@@ -68,6 +73,7 @@ Mandatory: false
 ```
 
 [01]: ../resource/command.md
-[02]: get.md
-[03]: set.md
-[04]: test.md
+[02]: export.md
+[03]: get.md
+[04]: set.md
+[05]: test.md

--- a/docs/reference/cli/config/export.md
+++ b/docs/reference/cli/config/export.md
@@ -1,0 +1,53 @@
+---
+description: Command line reference for the 'dsc config export' command
+ms.date:     09/06/2023
+ms.topic:    reference
+title:       dsc config export
+---
+
+# dsc config export
+
+## Synopsis
+
+Generates a configuration document that defines the existing instances of a set of resources.
+
+## Syntax
+
+```sh
+dsc config export [Options]
+```
+
+## Description
+
+The `export` subcommand generates a configuration document that includes every instance of a set of
+resources. This command expects a configuration document formatted as JSON or YAML over stdin. The
+input configuration defines the resources to export. DSC ignores any properties specified for the
+resources in the input configuration for the operation, but the input document and any properties
+for resource instances must still validate against the configuration document and resource instance
+schemas.
+
+Only specify resources with a resource manifest that defines the [export][01] section in the input
+configuration. Only define each resource type once. If the configuration document includes any
+resource instance where the resource type isn't exportable or has already been declared in the
+configuration, DSC raises an error.
+
+## Options
+
+### -h, --help
+
+Displays the help for the current command or subcommand. When you specify this option, the
+application ignores all options and arguments after this one.
+
+```yaml
+Type:      Boolean
+Mandatory: false
+```
+
+## Output
+
+This command returns JSON output that defines a configuration document including every instance of
+the resources declared in the input configuration. For more information, see
+[DSC Configuration document schema reference][02].
+
+[01]: ../../schemas/resource/manifest/export.md
+[02]: ../../schemas/config/document.md

--- a/docs/reference/cli/resource/command.md
+++ b/docs/reference/cli/resource/command.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc resource' command
-ms.date:     08/04/2023
+ms.date:     09/06/2023
 ms.topic:    reference
 title:       dsc resource
 ---
@@ -29,27 +29,32 @@ directly. To manage resource instances in a configuration, see the [dsc config][
 The `list` command returns the list of available DSC Resources with an optional filter. For more
 information, see [dsc resource list][02].
 
+### export
+
+The `export` command generates a configuration document that defines the current state of every
+instance for a specified resource. For more information, see [dsc resource export][03].
+
 ### get
 
 The `get` command invokes the get operation for a resource, returning the current state of a
-resource instance. For more information, see [dsc resource get][03].
+resource instance. For more information, see [dsc resource get][04].
 
 ### set
 
 The `set` command invokes the set operation for a resource, enforcing the desired state of a
-resource instance and returning the final state. For more information, see [dsc resource set][04].
+resource instance and returning the final state. For more information, see [dsc resource set][05].
 
 ### test
 
 The `test` command invokes the test operation for a resource, returning the expected and actual
 state of an instance and an array of properties that are out of the desired state. For more
-information, see [dsc resource test][05].
+information, see [dsc resource test][06].
 
 ### schema
 
 The `schema` command returns the JSON Schema for instances of a resource. This schema validates an
 instance before any operations are sent to the resource. For more information, see
-[dsc resource schema][06].
+[dsc resource schema][07].
 
 ### help
 
@@ -81,7 +86,8 @@ Mandatory: false
 
 [01]: ../config/command.md
 [02]: list.md
-[03]: get.md
-[04]: set.md
-[05]: test.md
-[06]: schema.md
+[03]: export.md
+[04]: get.md
+[05]: set.md
+[06]: test.md
+[07]: schema.md

--- a/docs/reference/cli/resource/export.md
+++ b/docs/reference/cli/resource/export.md
@@ -1,0 +1,63 @@
+---
+description: Command line reference for the 'dsc resource export' command
+ms.date:     09/06/2023
+ms.topic:    reference
+title:       dsc resource export
+---
+
+# dsc resource export
+
+## Synopsis
+
+Generates a configuration document that defines the existing instances of a resource.
+
+## Syntax
+
+```sh
+dsc resource export [Options] --resource <RESOURCE>
+```
+
+## Description
+
+The `export` subcommand generates a configuration document that includes every instance of a
+specific resource. The resource must be specified with the `--resource` option.
+
+Only specify exportable resources with a resource manifest that defines the [export][01] section in
+the input configuration. If the specified resource type isn't exportable, DSC raises an error.
+
+## Options
+
+### -r, --resource
+
+Specifies the fully qualified type name of the DSC Resource to export, like
+`Microsoft.Windows/Registry`.
+
+The fully qualified type name syntax is: `<owner>[.<group>][.<area>]/<name>`, where:
+
+- The `owner` is the maintaining author or organization for the resource.
+- The `group` and `area` are optional name components that enable namespacing for a resource.
+- The `name` identifies the component the resource manages.
+
+```yaml
+Type:      String
+Mandatory: true
+```
+
+### -h, --help
+
+Displays the help for the current command or subcommand. When you specify this option, the
+application ignores all options and arguments after this one.
+
+```yaml
+Type:      Boolean
+Mandatory: false
+```
+
+## Output
+
+This command returns JSON output that defines a configuration document including every instance of
+the resources declared in the input configuration. For more information, see
+[DSC Configuration document schema reference][02].
+
+[01]: ../../schemas/resource/manifest/export.md
+[02]: ../../schemas/config/document.md

--- a/docs/reference/cli/resource/get.md
+++ b/docs/reference/cli/resource/get.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc resource get' command
-ms.date:     08/04/2023
+ms.date:     09/06/2023
 ms.topic:    reference
 title:       dsc resource get
 ---
@@ -21,8 +21,8 @@ dsc resource get [Options] --resource <RESOURCE>
 
 The `get` subcommand returns the current state of a resource instance.
 
-This subcommand returns one instance from a specific DSC Resource. To return multiple resources,
-use a resource group or the [dsc config get][01] command.
+By default, this subcommand returns one instance from a specific DSC Resource. To return multiple
+resources, use the `--all` parameter, a resource group, or the [dsc config get][01] command.
 
 Any properties the resource requires for retrieving the state of an instance must be passed to this
 command as JSON. The JSON can be passed to this command from stdin or with the `--input` option.
@@ -91,6 +91,23 @@ actualState:
 
 ## Options
 
+### -a, --all
+
+Specifies that the command should return every instance of the specified DSC Resource instead of a
+specific instance.
+
+This option is only valid when the Resource is an exportable resource that defines the
+[export][02] section in the input configuration. If the resource type isn't exportable, DSC raises
+an error.
+
+When this option is specified, DSC ignores the `--input` option and any JSON sent to the command
+from stdin.
+
+```yaml
+Type:      Boolean
+Mandatory: false
+```
+
 ### -r, --resource
 
 Specifies the fully qualified type name of the DSC Resource to use, like
@@ -116,6 +133,8 @@ an error.
 This option can't be used with JSON over stdin. Choose whether to pass the instance JSON to the
 command over stdin or with the `--input` flag.
 
+DSC ignores this option when the `--all` option is specified.
+
 ```yaml
 Type:      String
 Mandatory: false
@@ -133,8 +152,14 @@ Mandatory: false
 
 ## Output
 
-This command returns JSON output that includes the actual state of the instance. For more
-information, see [dsc resource get result schema][02].
+By default, this command returns JSON output that includes the actual state of the instance. When
+the `--all` option is specified, the command returns the JSON output for each instance as
+[JSON Lines][03].
+
+For more information about the structure of the output JSON, see
+[dsc resource get result schema][04].
 
 [01]: ../config/get.md
-[02]: ../../schemas/outputs/resource/get.md
+[02]: ../../schemas/resource/manifest/export.md
+[03]: https://jsonlines.org/
+[04]: ../../schemas/outputs/resource/get.md

--- a/docs/reference/schemas/resource/manifest/export.md
+++ b/docs/reference/schemas/resource/manifest/export.md
@@ -1,0 +1,75 @@
+---
+description: JSON schema reference for the 'export' property in a DSC Resource manifest
+ms.date:     09/06/2023
+ms.topic:    reference
+title:       DSC Resource manifest export property schema reference
+---
+
+# DSC Resource manifest export property schema reference
+
+## Synopsis
+
+Defines how to retrieve the current state of every instance for a DSC Resource.
+
+## Metadata
+
+```yaml
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json
+Type:          object
+```
+
+## Description
+
+A command-based DSC Resource that can enumerate every instance of itself with a single command
+should define the `export` property in its manifest. This property defines how DSC can get the
+current state for every resource instance. When this property is defined, users can:
+
+- Specify an instance of the resource in the input configuration for the [dsc config export][01]
+  command to generate an usable configuration document.
+- Specify the resource with the [dsc resource export][02] command to generate a configuration
+  document that defines every instance of the resource.
+- Specify the resource with the [dsc resource get][03] command and the [--all][04] option to return
+  the current state for every instance of the resource.
+
+When the DSC calls the command defined by this property, the resource must return the current state
+of every instance as [JSON lines][05]. Each JSON Line should be an object representing the instance
+and validate against the [defined resource instance schema][06].
+
+## Required Properties
+
+The `export` definition must include these properties:
+
+- [executable](#executable)
+
+## Properties
+
+### executable
+
+The `executable` property defines the name of the command to run. The value must be the name of a
+command discoverable in the system's `PATH` environment variable or the full path to the command. A
+file extension is only required when the command isn't recognizable by the operating system as an
+executable.
+
+```yaml
+Type:     string
+Required: true
+```
+
+### args
+
+The `args` property defines an array of strings to pass as arguments to the command. DSC passes the
+arguments to the command in the order they're specified.
+
+```yaml
+Type:     array
+Required: false
+Default:  []
+```
+
+[01]: ../../../cli/config/export.md
+[02]: ../../../cli/resource/export.md
+[03]: ../../../cli/resource/get.md
+[04]: ../../../cli/resource/get.md#a---all
+[05]: https://jsonlines.org/
+[06]: schema/property.md

--- a/docs/reference/schemas/resource/manifest/root.md
+++ b/docs/reference/schemas/resource/manifest/root.md
@@ -101,6 +101,27 @@ ItemsType:         string
 ItemsPattern:      ^\w+$
 ```
 
+### export
+
+The `export` property defines how to call the resource to get the current state of every instance.
+When this property is defined, users can:
+
+- Specify an instance of the resource in the input configuration for the [dsc config export][02]
+  command to generate an usable configuration document.
+- Specify the resource with the [dsc resource export][03] command to generate a configuration
+  document that defines every instance of the resource.
+- Specify the resource with the [dsc resource get][04] command and the [--all][05] option to return
+  the current state for every instance of the resource.
+
+The value of this property must be an object. The object's `executable` property, defining the name
+of the command to call, is mandatory. The `args` property is optional. For more
+information, see [DSC Resource manifest export property schema reference][06].
+
+```yaml
+Type:     object
+Required: true
+```
+
 ### get
 
 The `get` property defines how to call the resource to get the current state of an instance. This
@@ -108,7 +129,7 @@ property is mandatory for all resources.
 
 The value of this property must be an object. The object's `executable` property, defining the name
 of the command to call, is mandatory. The `args` and `input` properties are optional. For more
-information, see [DSC Resource manifest get property schema reference][02].
+information, see [DSC Resource manifest get property schema reference][07].
 
 ```yaml
 Type:     object
@@ -124,7 +145,7 @@ test whether the instance is in the desired state.
 
 The value of this property must be an object. The `executable` property, defining the name of the
 command to call, is mandatory. The `args` `input`, `preTest`, and `returns` properties are
-optional. For more information, see [DSC Resource manifest set property schema reference][03].
+optional. For more information, see [DSC Resource manifest set property schema reference][08].
 
 ```yaml
 Type:     object
@@ -139,7 +160,7 @@ property isn't defined, DSC performs a basic synthetic test for instances of the
 
 The value of this property must be an object. The object's `executable` property, defining the name
 of the command to call, is mandatory. The `args` `input`, and `returns` properties are optional.
-For more information, see [DSC Resource manifest test property schema reference][04].
+For more information, see [DSC Resource manifest test property schema reference][09].
 
 ```yaml
 Type:     object
@@ -153,7 +174,7 @@ property is mandatory for DSC Group Resources. DSC ignores this property for all
 
 The value of this property must be an object. The object's `executable` property, defining the name
 of the command to call, is mandatory. The `args` property is optional. For more information, see
-[DSC Resource manifest validate property schema reference][05].
+[DSC Resource manifest validate property schema reference][10].
 
 ```yaml
 Type:     object
@@ -167,7 +188,7 @@ When specified, the `provider` property defines the resource as a DSC Resource P
 The value of this property must be an object. The object's `list` and `config` properties are
 mandatory. The `list` property defines how to call the provider to return the resources that the
 provider can manage. The `config` property defines how the provider expects input. For more
-information, see the [DSC Resource manifest provider property schema reference][06].
+information, see the [DSC Resource manifest provider property schema reference][11].
 
 ### exitCodes
 
@@ -196,7 +217,7 @@ resource. This property must always be an object that defines one of the followi
 - `embedded` - When you specify the `embedded` property, DSC uses the defined value as the JSON
   schema.
 
-For more information, see [DSC Resource manifest schema property reference][07].
+For more information, see [DSC Resource manifest schema property reference][12].
 
 ```yaml
 Type:     object
@@ -204,9 +225,14 @@ Required: true
 ```
 
 [01]: ../../definitions/resourceType.md
-[02]: get.md
-[03]: set.md
-[04]: test.md
-[05]: validate.md
-[06]: provider.md
-[07]: schema/property.md
+[02]: ../../../cli/config/export.md
+[03]: ../../../cli/resource/export.md
+[04]: ../../../cli/resource/get.md
+[05]: ../../../cli/resource/get.md#a---all
+[06]: export.md
+[07]: get.md
+[08]: set.md
+[09]: test.md
+[10]: validate.md
+[11]: provider.md
+[12]: schema/property.md

--- a/schemas/2023/08/bundled/outputs/resource/list.json
+++ b/schemas/2023/08/bundled/outputs/resource/list.json
@@ -146,6 +146,9 @@
         "get": {
           "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json"
         },
+        "export": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json"
+        },
         "set": {
           "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json"
         },
@@ -219,6 +222,22 @@
           "executable": "osinfo"
         }
       ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json",
+      "title": "Get Method",
+      "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+      "type": "object",
+      "required": "executable",
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/commandArgs.json"
+        }
+      }
     },
     "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/2023/08/bundled/resource/manifest.json
+++ b/schemas/2023/08/bundled/resource/manifest.json
@@ -43,6 +43,9 @@
     "get": {
       "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json"
     },
+    "export": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json"
+    },
     "set": {
       "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json"
     },
@@ -132,6 +135,22 @@
           "executable": "osinfo"
         }
       ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json",
+      "title": "Get Method",
+      "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+      "type": "object",
+      "required": "executable",
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/commandArgs.json"
+        }
+      }
     },
     "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/2023/08/bundled/resource/manifest.vscode.json
+++ b/schemas/2023/08/bundled/resource/manifest.vscode.json
@@ -54,6 +54,9 @@
     "get": {
       "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json"
     },
+    "export": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json"
+    },
     "set": {
       "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json"
     },
@@ -182,7 +185,7 @@
                     "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json",
                     "title": "Get Method",
                     "description": "Defines how DSC must call the DSC Resource to get the current state of an instance.",
-                    "markdownDescription": "> [Online Documentation][01]\n\nDefines how DSC must call the DSC Resource to get the current state of an instance.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserveView=true\n",
+                    "markdownDescription": "> [Online Documentation][01]\n\nDefines how DSC must call the DSC Resource to get the current state of an instance.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/get?view=dsc-3.0&preserveView=true\n",
                     "type": "object",
                     "required": [
                       "executable"
@@ -211,6 +214,25 @@
                         "executable": "osinfo"
                       }
                     ]
+                  },
+                  "manifest.export.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json",
+                    "title": "Get Method",
+                    "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+                    "markdownDescription": "> [Online Documentation][01]\n\nDefines how DSC must call the DSC Resource to get the current state of every instance.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/export?view=dsc-3.0&preserveView=true\n",
+                    "type": "object",
+                    "required": [
+                      "executable"
+                    ],
+                    "properties": {
+                      "executable": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/definitions/commandExecutable.json"
+                      },
+                      "args": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/definitions/commandArgs.json"
+                      }
+                    }
                   },
                   "manifest.set.json": {
                     "$schema": "https://json-schema.org/draft/2020-12/schema",

--- a/schemas/2023/08/resource/manifest.export.json
+++ b/schemas/2023/08/resource/manifest.export.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json",
+  "title": "Get Method",
+  "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+  "type": "object",
+  "required": "executable",
+  "properties": {
+    "executable": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/commandExecutable.json"
+    },
+    "args": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/commandArgs.json"
+    }
+  }
+}

--- a/schemas/2023/08/resource/manifest.json
+++ b/schemas/2023/08/resource/manifest.json
@@ -43,6 +43,9 @@
     "get": {
       "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json"
     },
+    "export": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json"
+    },
     "set": {
       "$ref": "/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json"
     },

--- a/schemas/src/resource/manifest.export.yaml
+++ b/schemas/src/resource/manifest.export.yaml
@@ -1,0 +1,22 @@
+# yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
+$schema: https://json-schema.org/draft/2020-12/schema
+$id:     <HOST>/<PREFIX>/<VERSION>/resource/manifest.export.yaml
+
+title: Get Method
+description: >-
+  Defines how DSC must call the DSC Resource to get the current state of every instance.
+markdownDescription: | # VS Code only
+  > [Online Documentation][01]
+
+  Defines how DSC must call the DSC Resource to get the current state of every instance.
+
+  [01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/export?view=dsc-3.0&preserveView=true
+
+type: object
+required:
+  - executable
+properties:
+  executable:
+    $ref: /<PREFIX>/<VERSION>/definitions/commandExecutable.yaml
+  args:
+    $ref: /<PREFIX>/<VERSION>/definitions/commandArgs.yaml

--- a/schemas/src/resource/manifest.get.yaml
+++ b/schemas/src/resource/manifest.get.yaml
@@ -10,7 +10,7 @@ markdownDescription: | # VS Code only
 
   Defines how DSC must call the DSC Resource to get the current state of an instance.
 
-  [01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserveView=true
+  [01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/get?view=dsc-3.0&preserveView=true
 
 type: object
 required:
@@ -26,7 +26,7 @@ properties:
 examples:
   - executable: registry
     args:
-        - config
-        - get
+      - config
+      - get
     input: stdin
   - executable: osinfo

--- a/schemas/src/resource/manifest.yaml
+++ b/schemas/src/resource/manifest.yaml
@@ -110,6 +110,8 @@ properties:
         characters are permitted.
   get:
     $ref: /<PREFIX>/<VERSION>/resource/manifest.get.yaml
+  export:
+    $ref: /<PREFIX>/<VERSION>/resource/manifest.export.yaml
   set:
     $ref: /<PREFIX>/<VERSION>/resource/manifest.set.yaml
   test:


### PR DESCRIPTION
# PR Summary

This change:

- Updates the resource manifest schemas to include the `export` property.
- Updates the documentation for the manifest schemas to reflect the change.
- Adds documentation for the new `dsc config export` command.
- Adds documentation for the new `dsc resource export` command.
- Adds documentation for the new `--all` option for the `dsc resource get` command.

## PR Context

In #171, DSC was updated to support the `export` commands and `dsc resource get --all` functionality.
