### PR TITLE
(DOCS) Document `DSC_RESOURCE_PATH` and `PATH`

### DIFF
--- a/docs/reference/cli/dsc.md
+++ b/docs/reference/cli/dsc.md
@@ -99,6 +99,16 @@ Type:      Boolean
 Mandatory: false
 ```
 
+## Environment Variables
+
+By default, the `dsc` command searches for command-based DSC Resource manifests in the folders
+defined by the `PATH` environment variable. If the `DSC_RESOURCE_PATH` environment variable is
+defined, `dsc` searches the folders in `DSC_RESOURCE_PATH` instead of `PATH`.
+
+The `DSC_RESOURCE_PATH` environment must be an environment variable that follows the same
+conventions as the `PATH` environment variable for the operating system. Separate folder paths with
+a semicolon (`;`) on Windows and a colon (`:`) on other platforms.
+
 ## Exit Codes
 
 The `dsc` command uses semantic exit codes. Each exit code represents a different result for the

--- a/docs/reference/cli/resource/list.md
+++ b/docs/reference/cli/resource/list.md
@@ -20,9 +20,12 @@ dsc resource list [Options] <RESOURCE_NAME>
 ## Description
 
 The `list` subcommand searches for available DSC Resources and returns their information. DSC
-discovers resources by first searching the `PATH` for `.dsc.resource.json` files. If any of the
-discovered resources are resource providers, DSC then calls the providers to list their resources,
-too.
+discovers resources by first searching the `PATH` or `DSC_RESOURCE_PATH` environment variable for
+`.dsc.resource.json` files. For more information about the environment variables DSC uses, see
+[Environment variables][01]
+
+If any of the discovered resources are resource providers, DSC then calls the providers to list
+their resources, too.
 
 DSC returns the list of discovered resources with their implementation information and metadata. If
 the command includes the `RESOURCE_NAME` argument, DSC filters the list of discovered resources
@@ -178,6 +181,7 @@ Mandatory: false
 
 This command returns a JSON object for each resource that includes the resource's type, version,
 manifest settings, and other metadata. For more information, see
-[dsc resource list result schema][01].
+[dsc resource list result schema][02].
 
-[01]: ../../schemas/outputs/resource/list.md
+[01]: ../dsc.md#environment-variables
+[02]: ../../schemas/outputs/resource/list.md


### PR DESCRIPTION
# PR Summary

This change:

- Adds a new section for environment variables to the root command documentation.
- Updates the description for `dsc resource list` to clarify the search process and use of the new `DSC_RESOURCE_PATH` environment variable.

## PR Context

Prior to this change, the documentation for the `dsc` and `dsc resource list` commands only obliquely touched on the use of the `PATH` environment variable to discover command-based DSC Resource manifests.
