### PR TITLE
add `export` support to `osinfo`

### DIFF
--- a/osinfo/osinfo.dsc.resource.json
+++ b/osinfo/osinfo.dsc.resource.json
@@ -12,6 +12,9 @@
     "get": {
         "executable": "osinfo"
     },
+    "export": {
+        "executable": "osinfo"
+    },
     "schema": {
         "embedded": {
             "$schema": "http://json-schema.org/draft-07/schema#",

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -36,15 +36,15 @@ Describe 'osinfo resource tests' {
 
     It 'should support export' {
         $out = dsc resource export -r Microsoft/osinfo | ConvertFrom-Json
-        $out.actualState.'$id' | Should -BeExactly ' https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json'
+        $out.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json'
         if ($IsWindows) {
-            $out.actualState.family | Should -BeExactly 'Windows'
+            $out.resources[0].properties.family | Should -BeExactly 'Windows'
         }
         elseif ($IsLinux) {
-            $out.actualState.family | Should -BeExactly 'Linux'
+            $out.resources[0].properties.family | Should -BeExactly 'Linux'
         }
         elseif ($IsMacOS) {
-            $out.actualState.family | Should -BeExactly 'MacOS'
+            $out.resources[0].properties.family | Should -BeExactly 'MacOS'
         }
     }
 }

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -33,4 +33,18 @@ Describe 'osinfo resource tests' {
         $out.actualState.edition | Should -BeExactly $actual.actualState.edition
         $out.differingproperties | Should -Be @('family')
     }
+
+    It 'should support export' {
+        $out = dsc resource export -r Microsoft/osinfo | ConvertFrom-Json
+        $out.actualState.'$id' | Should -BeExactly ' https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json'
+        if ($IsWindows) {
+            $out.actualState.family | Should -BeExactly 'Windows'
+        }
+        elseif ($IsLinux) {
+            $out.actualState.family | Should -BeExactly 'Linux'
+        }
+        elseif ($IsMacOS) {
+            $out.actualState.family | Should -BeExactly 'MacOS'
+        }
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `export` section to `osinfo` manifest.  Added test.

## PR Context

fix https://github.com/PowerShell/DSC/issues/188
