### PR TITLE
(DOCS) Fix work item links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,37 @@
+---
+title: "Desired State Configuration changelog"
+description: >-
+  A log of the changes for releases of DSCv3.
+ms.date: 09/06/2023
+---
+
 # Changelog
 
-All notable changes to this project will be documented in this file. The format is based on
-[Keep a Changelog], and this project adheres to [Semantic Versioning].
+All notable changes to DSCv3 are documented in this file. The format is based on
+[Keep a Changelog][m1], and DSCv3 adheres to [Semantic Versioning][m2].
 
 <!-- Meta links -->
-[Keep a Changelog]:    https://keepachangelog.com/en/1.1.0/
-[Semantic Versioning]: https://semver.org/spec/v2.0.0.html
+[m1]: https://keepachangelog.com/en/1.1.0/
+[m2]: https://semver.org/spec/v2.0.0.html
 
-## [Unreleased]
+## Unreleased
+
+This section includes a summary of user-facing changes since the last release. For the full list of
+changes since the last release, see the [diff on GitHub][unreleased].
 
 <!-- Unreleased comparison link -->
-[Unreleased]:     https://github.com/PowerShell/DSC/compare/v3.0.0-alpha.2...main
+[unreleased]: https://github.com/PowerShell/DSC/compare/v3.0.0-alpha.2...main
+
 <!-- Add entries between releases under the appropriate section heading here  -->
 
-## [v3.0.0-alpha.2] - 2023-09-05
+## [v3.0.0-alpha.2][release-v3.0.0-alpha.2] - 2023-09-05
 
-<!-- Release comparison link -->
-[v3.0.0-alpha.2]: https://github.com/PowerShell/DSC/compare/v3.0.0-alpha.1...v3.0.0-alpha.2
+This section includes a summary of changes for the `alpha.2` release. For the full list of changes
+in this release, see the [diff on GitHub][compare-v3.0.0-alpha.2].
+
+<!-- Release links -->
+[release-v3.0.0-alpha.2]: https://github.com/PowerShell/DSC/releases/tag/v3.0.0-alpha.2 "Link to the DSC v3.0.0-alpha.2 release on GitHub"
+[compare-v3.0.0-alpha.2]: https://github.com/PowerShell/DSC/compare/v3.0.0-alpha.1...v3.0.0-alpha.2
 
 ### Added
 
@@ -26,8 +41,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - Issues: #45
-  - PRs: #175
+  - Issues: [#45][#45]
+  - PRs: [#175][#175]
 
   </details>
 
@@ -37,8 +52,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - Issues: #73
-  - PRs: #171
+  - Issues: [#73][#73]
+  - PRs: [#171][#171]
 
   </details>
 
@@ -48,8 +63,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - Issues: #73
-  - PRs: #171
+  - Issues: [#73][#73]
+  - PRs: [#171][#171]
 
   </details>
 
@@ -58,8 +73,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - Issues: #73
-  - PRs: #171
+  - Issues: [#73][#73]
+  - PRs: [#171][#171]
 
   </details>
 
@@ -69,9 +84,9 @@ All notable changes to this project will be documented in this file. The format 
   <details><summary>Related work items</summary>
 
   - Issues:
-    - #73
-    - #174
-  - PRs: #171
+    - [#73][#73]
+    - [#174][#174]
+  - PRs: [#171][#171]
 
   </details>
 
@@ -81,8 +96,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - PRs: #177
-  - Issues: #150
+  - PRs: [#177][#177]
+  - Issues: [#150][#150]
 
   </details>
 
@@ -92,8 +107,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - PRs: #176
-  - Issues: #133
+  - PRs: [#176][#176]
+  - Issues: [#133][#133]
 
   </details>
 
@@ -103,8 +118,8 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - PRs: #182
-  - Issues: #181
+  - PRs: [#182][#182]
+  - Issues: [#181][#181]
 
   </details>
 
@@ -112,6 +127,12 @@ All notable changes to this project will be documented in this file. The format 
   of [configuration document parameters][11] to improve the authoring experience. Now, when a
   parameter defines values for these properties that are incompatible with the defined data type,
   validation raises an error indicating that the values are invalid and why.
+
+  <details><summary>Related work items</summary>
+
+  - PRs: [#172][#172]
+
+  </details>
 
 - Enhanced VS Code-specific schemas for configuration documents and resource manifests to improve
   the authoring experience. The enhanced schemas use keywords only supported by VS Code to:
@@ -121,11 +142,11 @@ All notable changes to this project will be documented in this file. The format 
   - Define default snippets to autocomplete values.
 
   These schemas are non-canonical and should only be used for authoring. For more information, see
-  [Using the enhanced schemas for authoring][12].
+  [Authoring with enhanced schemas][12].
 
   <details><summary>Related work items</summary>
 
-  - PRs: #172
+  - PRs: [#172][#172]
 
   </details>
 
@@ -134,7 +155,7 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - PRs: #168
+  - PRs: [#168][#168]
 
   </details>
 
@@ -146,7 +167,7 @@ All notable changes to this project will be documented in this file. The format 
 
   <details><summary>Related work items</summary>
 
-  - PRs: #156
+  - PRs: [#156][#156]
 
   </details>
 
@@ -156,22 +177,31 @@ All notable changes to this project will be documented in this file. The format 
   `max*` keywords apply to the correct data types. Previously, the logic prevented them from ever
   applying.
 
+  <details><summary>Related work items</summary>
+
+  - PRs: [#172][#172]
+
+  </details>
+
 - Using the `registry find` command no longer raises a panic error due to conflicting option
   definitions on the command.
 
   <details><summary>Related work items</summary>
 
-  - PRs: #163
+  - PRs: [#163][#163]
 
   </details>
 
-## [v3.0.0-alpha.1] - 2023-08-04
-
-<!-- Release comparison link -->
-[v3.0.0-alpha.1]: https://github.com/PowerShell/DSC/compare/6090b1464bbf81fded5453351708482a4db35258...v3.0.0-alpha.1
+## [v3.0.0-alpha.1][release-v3.0.0-alpha.1] - 2023-08-04
 
 This is the first public release of DSC v3. Consider this release alpha quality. Use it only for
 development evaluation, as it has known issues and isn't feature complete.
+
+For the full list of changes in this release, see the [diff on GitHub][compare-v3.0.0-alpha.1].
+
+<!-- Release comparison link -->
+[release-v3.0.0-alpha.1]: https://github.com/PowerShell/DSC/releases/tag/v3.0.0-alpha.1 "Link to the DSC v3.0.0-alpha.1 release on GitHub"
+[compare-v3.0.0-alpha.1]: https://github.com/PowerShell/DSC/compare/6090b1464bbf81fded5453351708482a4db35258...v3.0.0-alpha.1
 
 <!-- alpha.2 links -->
 [01]: docs/reference/schemas/config/resource.md#dependson
@@ -185,6 +215,23 @@ development evaluation, as it has known issues and isn't feature complete.
 [09]: docs/reference/schemas/config/parameter.md#defaultvalue
 [10]: docs/reference/schemas/config/parameter.md#allowedvalues
 [11]: docs/reference/schemas/config/parameter.md
-[12]: https://learn.microsoft.com/powershell/dsc/concepts/using-enhanced-schemas?view=dsc-3.0&preserveView=true
-[13]: https://learn.microsoft.com/powershell/dsc/reference/microsoft/osinfo/resource?view=dsc-3.0&preserveView=true
+[12]: https://learn.microsoft.com/powershell/dsc/concepts/enhanced-authoring?view=dsc-3.0&preserve-view=true
+[13]: https://learn.microsoft.com/powershell/dsc/reference/microsoft/osinfo/resource?view=dsc-3.0&preserve-view=true
 [14]: docs/reference/schemas/config/document.md#schema
+
+<!-- Issue and PR links -->
+[#163]: https://github.com/PowerShell/DSC/163
+[#156]: https://github.com/PowerShell/DSC/156
+[#168]: https://github.com/PowerShell/DSC/168
+[#172]: https://github.com/PowerShell/DSC/172
+[#182]: https://github.com/PowerShell/DSC/182
+[#181]: https://github.com/PowerShell/DSC/181
+[#177]: https://github.com/PowerShell/DSC/177
+[#150]: https://github.com/PowerShell/DSC/150
+[#176]: https://github.com/PowerShell/DSC/176
+[#133]: https://github.com/PowerShell/DSC/133
+[#73]:  https://github.com/PowerShell/DSC/73
+[#174]: https://github.com/PowerShell/DSC/174
+[#171]: https://github.com/PowerShell/DSC/171
+[#45]:  https://github.com/PowerShell/DSC/45
+[#175]: https://github.com/PowerShell/DSC/175


### PR DESCRIPTION
# PR Summary

This change adds explicit links to the Changelog for the work items.

## PR Context

Prior to this change, the work item links in the changelog relied on the auto-linking GitHub feature. That feature doesn't work in Markdown documents on GitHub, only work item bodies and comments.