### PR TITLE
Direct resource `set` no longer requires `test`

### DIFF
--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -18,7 +18,7 @@
       "test"
     ],
     "input": "stdin",
-    "implementsPreTest": true,
+    "implementsPretest": true,
     "return": "state"
   },
   "test": {

--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -18,7 +18,7 @@
       "test"
     ],
     "input": "stdin",
-    "preTest": true,
+    "implementsPreTest": true,
     "return": "state"
   },
   "test": {

--- a/dsc/group.dsc.resource.json
+++ b/dsc/group.dsc.resource.json
@@ -18,7 +18,7 @@
       "set"
     ],
     "input": "stdin",
-    "implementsPreTest": true,
+    "implementsPretest": true,
     "return": "state"
   },
   "test": {

--- a/dsc/group.dsc.resource.json
+++ b/dsc/group.dsc.resource.json
@@ -18,7 +18,7 @@
       "set"
     ],
     "input": "stdin",
-    "preTest": true,
+    "implementsPreTest": true,
     "return": "state"
   },
   "test": {

--- a/dsc/parallel.dsc.resource.json
+++ b/dsc/parallel.dsc.resource.json
@@ -20,7 +20,7 @@
       "set"
     ],
     "input": "stdin",
-    "preTest": true,
+    "implementsPreTest": true,
     "return": "state"
   },
   "test": {

--- a/dsc/parallel.dsc.resource.json
+++ b/dsc/parallel.dsc.resource.json
@@ -20,7 +20,7 @@
       "set"
     ],
     "input": "stdin",
-    "implementsPreTest": true,
+    "implementsPretest": true,
     "return": "state"
   },
   "test": {

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -20,7 +20,7 @@ pub fn get(dsc: &mut DscManager, resource: &str, input: &Option<String>, stdin: 
     //TODO: add to debug stream: println!("handle_resource_get - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
     if let Some(requires) = resource.requires {
         input = add_type_name_to_json(input, resource.type_name);
-        resource = get_resource(dsc, &requires.clone());
+        resource = get_resource(dsc, &requires);
     }
 
     //TODO: add to debug stream: println!("handle_resource_get - input - {}", input);
@@ -85,7 +85,7 @@ pub fn set(dsc: &mut DscManager, resource: &str, input: &Option<String>, stdin: 
 
     if let Some(requires) = resource.requires {
         input = add_type_name_to_json(input, resource.type_name);
-        resource = get_resource(dsc, &requires.clone());
+        resource = get_resource(dsc, &requires);
     }
 
     //TODO: add to debug stream: println!("handle_resource_get - input - {}", input);
@@ -117,7 +117,7 @@ pub fn test(dsc: &mut DscManager, resource: &str, input: &Option<String>, stdin:
 
     if let Some(requires) = resource.requires {
         input = add_type_name_to_json(input, resource.type_name);
-        resource = get_resource(dsc, &requires.clone());
+        resource = get_resource(dsc, &requires);
     }
 
     //TODO: add to debug stream: println!("handle_resource_test - input - {}", input);

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -74,6 +74,11 @@ pub fn get_all(dsc: &mut DscManager, resource: &str, _input: &Option<String>, _s
 
 pub fn set(dsc: &mut DscManager, resource: &str, input: &Option<String>, stdin: &Option<String>, format: &Option<OutputFormat>) {
     let mut input = get_input(input, stdin);
+    if input.is_empty() {
+        eprintln!("Error: Input is empty");
+        exit(EXIT_INVALID_ARGS);
+    }
+
     let mut resource = get_resource(dsc, resource);
 
     //TODO: add to debug stream: println!("handle_resource_set - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
@@ -85,7 +90,7 @@ pub fn set(dsc: &mut DscManager, resource: &str, input: &Option<String>, stdin: 
 
     //TODO: add to debug stream: println!("handle_resource_get - input - {}", input);
 
-    match resource.set(input.as_str()) {
+    match resource.set(input.as_str(), true) {
         Ok(result) => {
             // convert to json
             let json = match serde_json::to_string(&result) {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -42,7 +42,7 @@ pub fn config_get(configurator: &Configurator, format: &Option<OutputFormat>)
 
 pub fn config_set(configurator: &Configurator, format: &Option<OutputFormat>)
 {
-    match configurator.invoke_set(ErrorAction::Continue, || { /* code */ }) {
+    match configurator.invoke_set(false, ErrorAction::Continue, || { /* code */ }) {
         Ok(result) => {
             let json = match serde_json::to_string(&result) {
                 Ok(json) => json,

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -28,14 +28,14 @@ pub enum ErrorAction {
 }
 
 /// Add the results of an export operation to a configuration.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `resource` - The resource to export.
 /// * `conf` - The configuration to add the results to.
 ///
 /// # Errors
-/// 
+///
 /// This function will return an error if the underlying resource fails.
 pub fn add_resource_export_results_to_configuration(resource: &DscResource, conf: &mut Configuration) -> Result<(), DscError> {
     let export_result = resource.export()?;
@@ -119,7 +119,7 @@ impl Configurator {
     /// # Errors
     ///
     /// This function will return an error if the underlying resource fails.
-    pub fn invoke_set(&self, _error_action: ErrorAction, _progress_callback: impl Fn() + 'static) -> Result<ConfigurationSetResult, DscError> {
+    pub fn invoke_set(&self, skip_test: bool, _error_action: ErrorAction, _progress_callback: impl Fn() + 'static) -> Result<ConfigurationSetResult, DscError> {
         let (config, messages, had_errors) = self.validate_config()?;
         let mut result = ConfigurationSetResult::new();
         result.messages = messages;
@@ -133,7 +133,7 @@ impl Configurator {
             };
             //TODO: add to debug stream:println!("{}", &resource.resource_type);
             let desired = serde_json::to_string(&resource.properties)?;
-            let set_result = dsc_resource.set(&desired)?;
+            let set_result = dsc_resource.set(&desired, skip_test)?;
             let resource_result = config_result::ResourceSetResult {
                 name: resource.name.clone(),
                 resource_type: resource.resource_type.clone(),
@@ -203,18 +203,18 @@ impl Configurator {
     }
 
     /// Invoke the export operation on a configuration.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `error_action` - The error action to use.
     /// * `progress_callback` - A callback to call when progress is made.
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// * `ConfigurationExportResult` - The result of the export operation.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// This function will return an error if the underlying resource fails.
     pub fn invoke_export(&self, _error_action: ErrorAction, _progress_callback: impl Fn() + 'static) -> Result<ConfigurationExportResult, DscError> {
         let (config, messages, had_errors) = self.validate_config()?;

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -49,17 +49,18 @@ pub fn invoke_get(resource: &ResourceManifest, cwd: &str, filter: &str) -> Resul
 ///
 /// * `resource` - The resource manifest
 /// * `desired` - The desired state of the resource in JSON
+/// * `skip_test` - If true, skip the test and directly invoke the set operation
 ///
 /// # Errors
 ///
 /// Error returned if the resource does not successfully set the desired state
-pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str) -> Result<SetResult, DscError> {
+pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str, skip_test: bool) -> Result<SetResult, DscError> {
     let Some(set) = resource.set.as_ref() else {
         return Err(DscError::NotImplemented("set".to_string()));
     };
     verify_json(resource, cwd, desired)?;
     // if resource doesn't implement a pre-test, we execute test first to see if a set is needed
-    if !set.pre_test.unwrap_or_default() {
+    if !skip_test && !set.pre_test.unwrap_or_default() {
         let test_result = invoke_test(resource, cwd, desired)?;
         if test_result.in_desired_state {
             return Ok(SetResult {
@@ -201,19 +202,19 @@ pub fn invoke_test(resource: &ResourceManifest, cwd: &str, expected: &str) -> Re
 }
 
 /// Invoke the validate operation against a command resource.
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `resource` - The resource manifest for the command resource.
 /// * `cwd` - The current working directory.
 /// * `config` - The configuration to validate in JSON.
-/// 
+///
 /// # Returns
-/// 
+///
 /// * `ValidateResult` - The result of the validate operation.
-/// 
+///
 /// # Errors
-/// 
+///
 /// Error is returned if the underlying command returns a non-zero exit code.
 pub fn invoke_validate(resource: &ResourceManifest, cwd: &str, config: &str) -> Result<ValidateResult, DscError> {
     // TODO: use schema to validate config if validate is not implemented
@@ -271,18 +272,18 @@ pub fn get_schema(resource: &ResourceManifest, cwd: &str) -> Result<String, DscE
 }
 
 /// Invoke the export operation on a resource
-/// 
+///
 /// # Arguments
-/// 
+///
 /// * `resource` - The resource manifest
 /// * `cwd` - The current working directory
-/// 
+///
 /// # Returns
-/// 
+///
 /// * `ExportResult` - The result of the export operation
-/// 
+///
 /// # Errors
-/// 
+///
 /// Error returned if the resource does not successfully export the current state
 pub fn invoke_export(resource: &ResourceManifest, cwd: &str) -> Result<ExportResult, DscError> {
 

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -86,11 +86,12 @@ pub trait Invoke {
     /// # Arguments
     ///
     /// * `desired` - The desired state as JSON to apply to the resource.
+    /// * `skip_test` - Whether to skip the test operation.
     ///
     /// # Errors
     ///
     /// This function will return an error if the underlying resource fails.
-    fn set(&self, desired: &str) -> Result<SetResult, DscError>;
+    fn set(&self, desired: &str, skip_test: bool) -> Result<SetResult, DscError>;
 
     /// Invoke the test operation on the resource.
     ///
@@ -145,7 +146,7 @@ impl Invoke for DscResource {
         }
     }
 
-    fn set(&self, desired: &str) -> Result<SetResult, DscError> {
+    fn set(&self, desired: &str, skip_test: bool) -> Result<SetResult, DscError> {
         match &self.implemented_as {
             ImplementedAs::Custom(_custom) => {
                 Err(DscError::NotImplemented("set custom resources".to_string()))
@@ -155,7 +156,7 @@ impl Invoke for DscResource {
                     return Err(DscError::MissingManifest(self.type_name.clone()));
                 };
                 let resource_manifest = serde_json::from_value::<ResourceManifest>(manifest.clone())?;
-                command_resource::invoke_set(&resource_manifest, &self.directory, desired)
+                command_resource::invoke_set(&resource_manifest, &self.directory, desired, skip_test)
             },
         }
     }

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -107,7 +107,7 @@ pub struct SetMethod {
     /// How to pass required input for a Set.
     pub input: InputKind,
     /// Whether to run the Test method before the Set method.  True means the resource will perform its own test before running the Set method.
-    #[serde(rename = "preTest", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "implementsPreTest", skip_serializing_if = "Option::is_none")]
     pub pre_test: Option<bool>,
     /// The type of return value expected from the Set method.
     #[serde(rename = "return", skip_serializing_if = "Option::is_none")]

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -107,7 +107,7 @@ pub struct SetMethod {
     /// How to pass required input for a Set.
     pub input: InputKind,
     /// Whether to run the Test method before the Set method.  True means the resource will perform its own test before running the Set method.
-    #[serde(rename = "implementsPreTest", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "implementsPretest", skip_serializing_if = "Option::is_none")]
     pub pre_test: Option<bool>,
     /// The type of return value expected from the Set method.
     #[serde(rename = "return", skip_serializing_if = "Option::is_none")]

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -16,11 +16,11 @@ pub struct DscManager {
 
 impl DscManager {
     /// Create a new `DscManager` instance.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// This function will return an error if the underlying discovery fails.
-    /// 
+    ///
     pub fn new() -> Result<Self, DscError> {
         Ok(Self {
             discovery: discovery::Discovery::new()?,
@@ -30,65 +30,66 @@ impl DscManager {
     /// Initialize the discovery process.
     ///
     /// # Errors
-    /// 
+    ///
     /// This function will return an error if the underlying discovery fails.
-    /// 
+    ///
     pub fn initialize_discovery(&mut self) -> Result<(), DscError> {
         self.discovery.initialize()
     }
 
     /// Find a resource by name.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `name` - The name of the resource to find, can have wildcards.
-    /// 
+    ///
     #[must_use]
     pub fn find_resource(&self, name: &str) -> ResourceIterator {
         self.discovery.find_resource(name)
     }
 
     /// Invoke the get operation on a resource.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `resource` - The resource to invoke the operation on.
     /// * `input` - The input to the operation.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// This function will return an error if the underlying resource fails.
-    /// 
+    ///
     pub fn resource_get(&self, resource: &DscResource, input: &str) -> Result<GetResult, DscError> {
         resource.get(input)
     }
 
     /// Invoke the set operation on a resource.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `resource` - The resource to invoke the operation on.
     /// * `input` - The input to the operation.
-    /// 
+    /// * `skip_test` - Whether to skip the test operation.
+    ///
     /// # Errors
-    /// 
+    ///
     /// This function will return an error if the underlying resource fails.
-    /// 
-    pub fn resource_set(&self, resource: &DscResource, input: &str) -> Result<SetResult, DscError> {
-        resource.set(input)
+    ///
+    pub fn resource_set(&self, resource: &DscResource, input: &str, skip_test: bool) -> Result<SetResult, DscError> {
+        resource.set(input, skip_test)
     }
 
     /// Invoke the test operation on a resource.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `resource` - The resource to invoke the operation on.
     /// * `input` - The input to the operation.
-    /// 
+    ///
     /// # Errors
-    /// 
+    ///
     /// This function will return an error if the underlying resource fails.
-    /// 
+    ///
     pub fn resource_test(&self, resource: &DscResource, input: &str) -> Result<TestResult, DscError> {
         resource.test(input)
     }

--- a/powershellgroup/powershellgroup.dsc.resource.json
+++ b/powershellgroup/powershellgroup.dsc.resource.json
@@ -39,7 +39,7 @@
         "$Input | ./powershellgroup.resource.ps1 Set"
       ],
       "input": "stdin",
-      "preTest": true,
+      "implementsPreTest": true,
       "return": "state"
       },
     "test": {

--- a/powershellgroup/powershellgroup.dsc.resource.json
+++ b/powershellgroup/powershellgroup.dsc.resource.json
@@ -39,7 +39,7 @@
         "$Input | ./powershellgroup.resource.ps1 Set"
       ],
       "input": "stdin",
-      "implementsPreTest": true,
+      "implementsPretest": true,
       "return": "state"
       },
     "test": {

--- a/process/process.dsc.resource.json
+++ b/process/process.dsc.resource.json
@@ -15,7 +15,7 @@
           "set"
         ],
         "input": "stdin",
-        "preTest": false,
+        "implementsPreTest": false,
         "return": "state"
     },
     "test": {

--- a/process/process.dsc.resource.json
+++ b/process/process.dsc.resource.json
@@ -15,7 +15,7 @@
           "set"
         ],
         "input": "stdin",
-        "implementsPreTest": false,
+        "implementsPretest": false,
         "return": "state"
     },
     "test": {

--- a/registry/registry.dsc.resource.json
+++ b/registry/registry.dsc.resource.json
@@ -22,7 +22,7 @@
       "set"
     ],
     "input": "stdin",
-    "implementsPreTest": true,
+    "implementsPretest": true,
     "return": "state"
   },
   "test": {

--- a/registry/registry.dsc.resource.json
+++ b/registry/registry.dsc.resource.json
@@ -22,7 +22,7 @@
       "set"
     ],
     "input": "stdin",
-    "preTest": true,
+    "implementsPreTest": true,
     "return": "state"
   },
   "test": {

--- a/schemas/2023/08/bundled/outputs/resource/list.json
+++ b/schemas/2023/08/bundled/outputs/resource/list.json
@@ -259,7 +259,7 @@
         "input": {
           "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
         },
-        "implementsPreTest": {
+        "implementsPretest": {
           "title": "Resource Performs Pre-Test",
           "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
           "type": "boolean",
@@ -277,7 +277,7 @@
           "set"
         ],
         "input": "stdin",
-        "implementsPreTest": true,
+        "implementsPretest": true,
         "return": "state"
       }
     },

--- a/schemas/2023/08/bundled/outputs/resource/list.json
+++ b/schemas/2023/08/bundled/outputs/resource/list.json
@@ -259,7 +259,7 @@
         "input": {
           "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
         },
-        "preTest": {
+        "implementsPreTest": {
           "title": "Resource Performs Pre-Test",
           "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
           "type": "boolean",
@@ -277,7 +277,7 @@
           "set"
         ],
         "input": "stdin",
-        "preTest": true,
+        "implementsPreTest": true,
         "return": "state"
       }
     },

--- a/schemas/2023/08/bundled/resource/manifest.json
+++ b/schemas/2023/08/bundled/resource/manifest.json
@@ -172,7 +172,7 @@
         "input": {
           "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
         },
-        "preTest": {
+        "implementsPreTest": {
           "title": "Resource Performs Pre-Test",
           "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
           "type": "boolean",
@@ -190,7 +190,7 @@
           "set"
         ],
         "input": "stdin",
-        "preTest": true,
+        "implementsPreTest": true,
         "return": "state"
       }
     },

--- a/schemas/2023/08/bundled/resource/manifest.json
+++ b/schemas/2023/08/bundled/resource/manifest.json
@@ -172,7 +172,7 @@
         "input": {
           "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
         },
-        "implementsPreTest": {
+        "implementsPretest": {
           "title": "Resource Performs Pre-Test",
           "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
           "type": "boolean",
@@ -190,7 +190,7 @@
           "set"
         ],
         "input": "stdin",
-        "implementsPreTest": true,
+        "implementsPretest": true,
         "return": "state"
       }
     },

--- a/schemas/2023/08/bundled/resource/manifest.vscode.json
+++ b/schemas/2023/08/bundled/resource/manifest.vscode.json
@@ -255,12 +255,12 @@
                       "input": {
                         "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
                       },
-                      "preTest": {
+                      "implementsPreTest": {
                         "title": "Resource Performs Pre-Test",
                         "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
                         "type": "boolean",
                         "default": false,
-                        "markdownDescription": "> [Online Documentation][01]\n\nDefines whether the DSC Resource performs its own test to ensure idempotency when calling the\n`set` command. Set this value to `true` if the DSC Resource tests input before modifying\nsystem state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserveView=true#pretest\n"
+                        "markdownDescription": "> [Online Documentation][01]\n\nDefines whether the DSC Resource performs its own test to ensure idempotency when calling the\n`set` command. Set this value to `true` if the DSC Resource tests input before modifying\nsystem state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserveView=true#implementsPreTest\n"
                       },
                       "return": {
                         "description": "Defines whether the command returns a JSON blob of the DSC Resource's state after the set operation or the state and an array of the properties the DSC Resource modified.",
@@ -280,7 +280,7 @@
                           "set"
                         ],
                         "input": "stdin",
-                        "preTest": true,
+                        "implementsPreTest": true,
                         "return": "state"
                       }
                     ]

--- a/schemas/2023/08/bundled/resource/manifest.vscode.json
+++ b/schemas/2023/08/bundled/resource/manifest.vscode.json
@@ -255,12 +255,12 @@
                       "input": {
                         "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
                       },
-                      "implementsPreTest": {
+                      "implementsPretest": {
                         "title": "Resource Performs Pre-Test",
                         "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
                         "type": "boolean",
                         "default": false,
-                        "markdownDescription": "> [Online Documentation][01]\n\nDefines whether the DSC Resource performs its own test to ensure idempotency when calling the\n`set` command. Set this value to `true` if the DSC Resource tests input before modifying\nsystem state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserveView=true#implementsPreTest\n"
+                        "markdownDescription": "> [Online Documentation][01]\n\nDefines whether the DSC Resource performs its own test to ensure idempotency when calling the\n`set` command. Set this value to `true` if the DSC Resource tests input before modifying\nsystem state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserveView=true#implementsPretest\n"
                       },
                       "return": {
                         "description": "Defines whether the command returns a JSON blob of the DSC Resource's state after the set operation or the state and an array of the properties the DSC Resource modified.",
@@ -280,7 +280,7 @@
                           "set"
                         ],
                         "input": "stdin",
-                        "implementsPreTest": true,
+                        "implementsPretest": true,
                         "return": "state"
                       }
                     ]

--- a/schemas/2023/08/resource/manifest.set.json
+++ b/schemas/2023/08/resource/manifest.set.json
@@ -18,7 +18,7 @@
     "input": {
       "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
     },
-    "implementsPreTest": {
+    "implementsPretest": {
       "title": "Resource Performs Pre-Test",
       "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
       "type": "boolean",
@@ -36,7 +36,7 @@
       "set"
     ],
     "input": "stdin",
-    "implementsPreTest": true,
+    "implementsPretest": true,
     "return": "state"
   }
 }

--- a/schemas/2023/08/resource/manifest.set.json
+++ b/schemas/2023/08/resource/manifest.set.json
@@ -18,7 +18,7 @@
     "input": {
       "$ref": "/PowerShell/DSC/main/schemas/2023/08/definitions/inputKind.json"
     },
-    "preTest": {
+    "implementsPreTest": {
       "title": "Resource Performs Pre-Test",
       "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
       "type": "boolean",
@@ -36,7 +36,7 @@
       "set"
     ],
     "input": "stdin",
-    "preTest": true,
+    "implementsPreTest": true,
     "return": "state"
   }
 }

--- a/schemas/examples/foo.dsc.resource.json
+++ b/schemas/examples/foo.dsc.resource.json
@@ -20,7 +20,7 @@
             "set"
         ],
         "input": "stdin",
-        "implementsPreTest": false,
+        "implementsPretest": false,
         "return": "state"
     },
     "schema": {

--- a/schemas/examples/foo.dsc.resource.json
+++ b/schemas/examples/foo.dsc.resource.json
@@ -20,7 +20,7 @@
             "set"
         ],
         "input": "stdin",
-        "preTest": false,
+        "implementsPreTest": false,
         "return": "state"
     },
     "schema": {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Better error message when using `set` and no input is provided
- Make `dsc resource set` no longer tries a `test` before
- Rename `preTest` to `implementsPretest` to make it more clear it's the resource implementing it or not

## PR Context

Some usability issues identified when @mgreenegit was writing a bash resource example