### PR TITLE
add support to pass JSON as env var

### DIFF
--- a/dsc/tests/dsc_resource_input.tests.ps1
+++ b/dsc/tests/dsc_resource_input.tests.ps1
@@ -1,0 +1,120 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'tests for resource input' {
+    BeforeAll {
+        $manifest = @'
+    {
+        "manifestVersion": "1.0.0",
+        "type": "Test/EnvVarInput",
+        "version": "0.1.0",
+        "get": {
+            "executable": "pwsh",
+            "input": "env",
+            "args": [
+                "-NoLogo",
+                "-NonInteractive",
+                "-NoProfile",
+                "-Command",
+                "\"{ `\"Hello`\": `\"$env:Hello`\", `\"World`\": `\"$env:World`\", `\"Boolean`\": `\"$env:Boolean`\", `\"StringArray`\": `\"$env:StringArray`\", `\"NumberArray`\": `\"$env:NumberArray`\" }\""
+            ]
+        },
+        "set": {
+            "executable": "pwsh",
+            "input": "env",
+            "args": [
+                "-NoLogo",
+                "-NonInteractive",
+                "-NoProfile",
+                "-Command",
+                "\"{ `\"Hello`\": `\"$env:Hello`\", `\"World`\": `\"$env:World`\", `\"Boolean`\": `\"$env:Boolean`\", `\"StringArray`\": `\"$env:StringArray`\", `\"NumberArray`\": `\"$env:NumberArray`\" }\""
+            ],
+            "return": "state",
+            "implementsPretest": true
+        },
+        "test": {
+            "executable": "pwsh",
+            "input": "env",
+            "args": [
+                "-NoLogo",
+                "-NonInteractive",
+                "-NoProfile",
+                "-Command",
+                "\"{ `\"Hello`\": `\"$env:Hello`\", `\"World`\": `\"$env:World`\", `\"Boolean`\": `\"$env:Boolean`\", `\"StringArray`\": `\"$env:StringArray`\", `\"NumberArray`\": `\"$env:NumberArray`\" }\""
+            ]
+        },
+        "schema": {
+            "embedded": {
+                "$schema": "http://json-schema.org/draft-07/schema#",
+                "$id": "https://test",
+                "title": "test",
+                "description": "test",
+                "type": "object",
+                "required": [],
+                "additionalProperties": false,
+                "properties": {
+                    "Hello": {
+                        "type": "string",
+                        "description": "test"
+                    },
+                    "World": {
+                        "type": "number",
+                        "description": "test"
+                    },
+                    "Boolean": {
+                        "type": "boolean",
+                        "description": "test"
+                    },
+                    "StringArray": {
+                        "type": "array",
+                        "description": "test",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "NumberArray": {
+                        "type": "array",
+                        "description": "test",
+                        "items": {
+                            "type": "number"
+                        }
+                    }
+                }
+            }
+        }
+    }
+'@
+        $oldPath = $env:DSC_RESOURCE_PATH
+        $env:DSC_RESOURCE_PATH = $TestDrive
+        Set-Content $TestDrive/EnvVarInput.dsc.resource.json -Value $manifest
+    }
+
+    AfterAll {
+        $env:DSC_RESOURCE_PATH = $oldPath
+    }
+
+    It 'Input can be sent to the resource for: <operation>' -TestCases @(
+        @{ operation = 'get'; member = 'actualState' }
+        @{ operation = 'set'; member = 'afterState' }
+        @{ operation = 'test'; member = 'actualState' }
+    ) {
+        param($operation, $member)
+
+        $json = @"
+        {
+            "Hello": "foo",
+            "World": 2,
+            "Boolean": true,
+            "StringArray": ["foo", "bar"],
+            "NumberArray": [1, 2, 3]
+        }
+"@
+
+        $result = $json | dsc resource $operation -r Test/EnvVarInput | ConvertFrom-Json
+        $result.$member.Hello | Should -BeExactly 'foo'
+        $result.$member.World | Should -Be 2
+        $result.$member.Boolean | Should -Be 'true'
+        $result.$member.StringArray | Should -BeExactly 'foo,bar'
+        $result.$member.NumberArray | Should -BeExactly '1,2,3'
+    }
+}

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -93,7 +93,7 @@ impl ResourceDiscovery for CommandDiscovery {
             let manifest = serde_json::from_value::<ResourceManifest>(provider_resource.manifest.clone().unwrap())?;
             // invoke the list command
             let list_command = manifest.provider.unwrap().list;
-            let (exit_code, stdout, stderr) = match invoke_command(&list_command.executable, list_command.args, None, Some(&provider_resource.directory))
+            let (exit_code, stdout, stderr) = match invoke_command(&list_command.executable, list_command.args, None, Some(&provider_resource.directory), None)
             {
                 Ok((exit_code, stdout, stderr)) => (exit_code, stdout, stderr),
                 Err(e) => {

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -48,9 +48,9 @@ pub struct ResourceManifest {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum InputKind {
-    /// The input is accepted as named parameters.
-    #[serde(rename = "args")]
-    Args,
+    /// The input is accepted as environmental variables.
+    #[serde(rename = "env")]
+    Env,
     /// The input is accepted as a JSON object via STDIN.
     #[serde(rename = "stdin")]
     Stdin,

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -25,7 +25,13 @@ Describe 'osinfo resource tests' {
     }
 
     It 'should perform synthetic test' {
-        $out = '{"family": "does_not_exist"}' | dsc resource test -r '*osinfo' | ConvertFrom-Json
+        if ($IsWindows) {
+            $invalid = 'Linux'
+        }
+        else {
+            $invalid = 'Windows'
+        }
+        $out = "{`"family`": `"$invalid`"}" | dsc resource test -r '*osinfo' | ConvertFrom-Json
         $actual = dsc resource get -r Microsoft/OSInfo | ConvertFrom-Json
         $out.actualState.family | Should -BeExactly $actual.actualState.family
         $out.actualState.version | Should -BeExactly $actual.actualState.version

--- a/powershellgroup/powershellgroup.dsc.resource.json
+++ b/powershellgroup/powershellgroup.dsc.resource.json
@@ -27,7 +27,8 @@
         "-NoProfile",
         "-Command",
         "$Input | ./powershellgroup.resource.ps1 Get"
-      ]
+      ],
+      "input": "stdin"
       },
     "set": {
       "executable": "pwsh",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enable passing JSON as env vars to command resource.  Only strings, numbers, array of strings, array of numbers, or booleans are supported.  Boolean array is excluded as it doesn't seem useful.

Note there is a change in behavior in that previously if `get` in the resource manifest didn't specify `input`, it was assumed `stdin` and still passed through.  However, if `input` is not defined, it's now assuming no input even if it was sent via `stdin`.

## PR Context

Fix #98 