### PR TITLE
Fix `add-path.ps1` to use $PSScriptRoot instead of $PWD

### DIFF
--- a/tools/add-path.ps1
+++ b/tools/add-path.ps1
@@ -1,12 +1,12 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-# This script will add the current directory to the PATH environment variable
+# This script will add the script directory to the PATH environment variable
 # for the current user. This is useful for development purposes.
 
 $pathSeparator = [System.IO.Path]::PathSeparator
 $paths = $env:PATH.Split($pathSeparator)
-if ($paths -notcontains $PWD) {
-    $env:PATH = "$PWD" + $pathSeparator + $env:PATH
-    Write-Host -ForegroundColor Green "Added $PWD to `$env:PATH"
+if ($paths -notcontains $PSScriptRoot) {
+    $env:PATH = "$PSScriptRoot" + $pathSeparator + $env:PATH
+    Write-Host -ForegroundColor Green "Added $PSScriptRoot to `$env:PATH"
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Script accidentally used $PWD and was tested from the bin folder, but it should have been $PSScriptRoot

## PR Context

Fix https://github.com/PowerShell/DSC/issues/152
