### PR TITLE
Fixes PowerShell/DSC#159 resources should have enum labels

### DIFF
--- a/powershellgroup/Tests/PSTestModule/DscResources/TestPSRepository/TestPSRepository.psm1
+++ b/powershellgroup/Tests/PSTestModule/DscResources/TestPSRepository/TestPSRepository.psm1
@@ -1,3 +1,8 @@
+enum EnsureEnumeration {
+    Absent
+    Present
+}
+
 function Get-TargetResource {
     [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
@@ -9,7 +14,7 @@ function Get-TargetResource {
     )
 
     $returnValue = @{
-        Ensure                    = 'Absent'
+        Ensure                    = [EnsureEnumeration]::Absent
         Name                      = $Name
         SourceLocation            = $null
         ScriptSourceLocation      = $null
@@ -22,7 +27,7 @@ function Get-TargetResource {
     }
 
     if ($Name -eq "TestPSRepository1") {
-        $returnValue.Ensure = 'Present'
+        $returnValue.Ensure = [EnsureEnumeration]::Present
         $returnValue.SourceLocation = 'https://www.powershellgallery.com/api/v2'
         $returnValue.ScriptSourceLocation = 'https://www.powershellgallery.com/api/v2/items/psscript'
         $returnValue.PublishLocation = 'https://www.powershellgallery.com/api/v2/package/'

--- a/powershellgroup/Tests/PSTestModule/TestClassResource.psm1
+++ b/powershellgroup/Tests/PSTestModule/TestClassResource.psm1
@@ -1,3 +1,8 @@
+enum EnumPropEnumeration {
+    Unexpected
+    Expected
+}
+
 [DscResource()]
 class TestClassResource
 {
@@ -6,6 +11,9 @@ class TestClassResource
 
     [DscProperty()]
     [string] $Prop1
+
+    [DscProperty()]
+    [EnumPropEnumeration] $EnumProp
 
     [void] Set()
     {
@@ -29,6 +37,7 @@ class TestClassResource
         {
             $this.Prop1 = "ValueForProp1"
         }
+        $this.EnumProp = [EnumPropEnumeration]::Expected
         return $this
     }
 }

--- a/powershellgroup/Tests/powershellgroup.resource.tests.ps1
+++ b/powershellgroup/Tests/powershellgroup.resource.tests.ps1
@@ -36,6 +36,22 @@ Describe 'PowerShellGroup resource tests' {
         $res.actualState.PublishLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2/package/'
     }
 
+    It 'Get uses enum names on class-based resource' -Skip:(!$IsWindows){
+
+        $r = "{'Name':'TestClassResource1'}" | dsc resource get -r PSTestModule/TestClassResource
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.actualState.EnumProp | Should -BeExactly 'Expected'
+    }
+
+    It 'Get uses enum names on script-based resource' -Skip:(!$IsWindows){
+
+        $r = "{'Name':'TestPSRepository1'}" | dsc resource get -r PSTestModule/TestPSRepository
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.actualState.Ensure | Should -BeExactly 'Present'
+    }
+
     It 'Test works on class-based resource' -Skip:(!$IsWindows){
 
         $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource test -r PSTestModule/TestClassResource

--- a/powershellgroup/powershellgroup.resource.ps1
+++ b/powershellgroup/powershellgroup.resource.ps1
@@ -176,7 +176,7 @@ elseif ($Operation -eq 'Get')
         }
     }
 
-    $result | ConvertTo-Json
+    $result | ConvertTo-Json -EnumsAsStrings
 }
 elseif ($Operation -eq 'Set')
 {


### PR DESCRIPTION
This fixes #159. When converting JSON into PowerShell object, replace enum values with the string label names.