### PR TITLE
Add `dsc new` sub-command to generate example configuration or resource manifest

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -13,11 +13,12 @@ lto = true
 [dependencies]
 atty = { version = "0.2" }
 clap = { version = "4.1", features = ["derive"] }
-crossterm = { version = "0.26.1" }
+crossterm = { version = "0.27" }
 ctrlc = { version = "3.4.0" }
 dsc_lib = { path = "../dsc_lib" }
-jsonschema = "0.17"
-schemars = { version = "0.8.12" }
+jsonschema = { version = "0.17", features = ["draft202012"]}
+schemars = { version = "0.8", features = ["semver"]}
+semver = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = { version = "0.9" }

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -10,6 +10,12 @@ pub enum OutputFormat {
     Yaml,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+pub enum NewType {
+    Configuration,
+    ResourceManifest,
+}
+
 #[derive(Debug, Parser)]
 #[clap(name = "dsc", version = "3.0.0-alpha.4", about = "Apply configuration or invoke specific DSC resources", long_about = None)]
 pub struct Args {
@@ -27,6 +33,11 @@ pub enum SubCommand {
     Config {
         #[clap(subcommand)]
         subcommand: ConfigSubCommand,
+    },
+    #[clap(name = "new", about = "Create an empty document")]
+    New {
+        #[clap(name = "type", short, long, help = "The type of document to create")]
+        type_name: NewType,
     },
     #[clap(name = "resource", about = "Invoke a specific DSC resource")]
     Resource {

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -53,7 +53,7 @@ fn main() {
             subcommand::config(&subcommand, &args.format, &stdin);
         },
         SubCommand::New { type_name } => {
-            subcommand::new(type_name, &args.format);
+            subcommand::new(&type_name, &args.format);
         },
         SubCommand::Resource { subcommand } => {
             subcommand::resource(&subcommand, &args.format, &stdin);

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -52,6 +52,9 @@ fn main() {
         SubCommand::Config { subcommand } => {
             subcommand::config(&subcommand, &args.format, &stdin);
         },
+        SubCommand::New { type_name } => {
+            subcommand::new(type_name, &args.format);
+        },
         SubCommand::Resource { subcommand } => {
             subcommand::resource(&subcommand, &args.format, &stdin);
         },

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -405,7 +405,7 @@ pub fn resource(subcommand: &ResourceSubCommand, format: &Option<OutputFormat>, 
     }
 }
 
-pub fn new(type_name: NewType, format: &Option<OutputFormat>) {
+pub fn new(type_name: &NewType, format: &Option<OutputFormat>) {
     let mut output_format = format.clone();
     let json = match type_name {
         NewType::Configuration => {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -430,7 +430,7 @@ pub fn new(type_name: &NewType, format: &Option<OutputFormat>) {
                             ("Property2".to_string(), Value::String("Value2".to_string())),
                         ]
                         )),
-                        depends_on: Some(vec!["[resourceId(\"Company/Dependency\",\"Dependency Resource\")]".to_string()]),
+                        depends_on: Some(vec!["[resourceId('Company/Dependency','Dependency Resource')]".to_string()]),
                     },
                 ],
                 metadata: None,

--- a/dsc/tests/dsc_new.tests.ps1
+++ b/dsc/tests/dsc_new.tests.ps1
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'dsc new tests' {
+    It 'dsc new -t configuration' {
+        $out = dsc new -t configuration | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json'
+    }
+
+    It 'dsc new -t resource-manifest' {
+        $out = dsc new -t resource-manifest | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json'
+    }
+}

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -5,10 +5,11 @@ edition = "2021"
 
 [dependencies]
 derive_builder ="0.12"
-jsonschema = "0.17"
+jsonschema = { version = "0.17", features = ["draft202012"] }
 regex = "1.7"
-reqwest = { version = "0.11", features = ["blocking"] }
-schemars = { version = "0.8.12", features = ["preserve_order"] }
+reqwest = { version = "0.11", features = ["blocking", "rustls-tls"] }
+schemars = { version = "0.8", features = ["preserve_order", "semver"] }
+semver = { version = "1.0" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
 thiserror = "1.0"

--- a/test_group_resource/Cargo.toml
+++ b/test_group_resource/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.1", features = ["derive"] }
 dsc_lib = { path = "../dsc_lib" }
-schemars = { version = "0.8.12" }
+schemars = { version = "0.8" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As I'm writing test configurations and test resources often, it would be easier to generate a simple one I can modify rather than finding an existing file to modify.

Open to suggestions on the content.  cc @michaeltlombardi 

`dsc new -t configuration` returns:

```yaml
$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
resources:
- type: Company/Dependency
  name: Dependency Resource
  properties:
    Property1: Value1
    Property2: Value2
- type: Company/Resource
  name: My Resource Instance
  dependsOn:
  - '[resourceId("Company/Dependency","Dependency Resource")]'
  properties:
    Property2: Value2
    Property1: Value1
```

`dsc new -t resource-manifest` returns:

```json
{
  "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
  "type": "Company/Resource",
  "version": "1.0.0",
  "description": "My Resource",
  "tags": [
    "Windows",
    "Linux"
  ],
  "get": {
    "executable": "myexe",
    "args": [
      "get"
    ],
    "input": "stdin"
  },
  "set": {
    "executable": "myexe",
    "args": [
      "set"
    ],
    "input": "stdin",
    "implementsPretest": false,
    "return": "state"
  },
  "test": {
    "executable": "myexe",
    "args": [
      "test"
    ],
    "input": "stdin",
    "return": "state"
  },
  "exitCodes": {
    "0": "Success",
    "1": "Failure"
  },
  "schema": {
    "embedded": {
      "$schema": "http://json-schema.org/draft-07/schema#"
    }
  }
}
```
