### PR TITLE
fix `--format` to work with redirection

### DIFF
--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -40,7 +40,8 @@ Describe 'config argument tests' {
 
         Set-Content -Path "$TestDrive/Hello.dsc.resource.json" -Value $manifest
         $oldPath = $env:DSC_RESOURCE_PATH
-        $env:DSC_RESOURCE_PATH = $TestDrive
+        $sep = [System.IO.Path]::PathSeparator
+        $env:DSC_RESOURCE_PATH = $env:PATH + $sep + $TestDrive
     }
 
     AfterAll {

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -40,6 +40,7 @@ Describe 'config argument tests' {
 
         Set-Content -Path "$TestDrive/Hello.dsc.resource.json" -Value $manifest
         $oldPath = $env:DSC_RESOURCE_PATH
+        $env:DSC_RESOURCE_PATH = $TestDrive
     }
 
     AfterAll {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The original logic for when to apply `--format` was only taking the interactive scenario into account, so redirecting, you'd only ever get json.  Changed so that the default for interactive, if not specified is yaml, and the default for redirection, if not specified is json.
