### PR TITLE
Add `--input` and `--input-file` to `dsc`

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -12,7 +12,7 @@ lto = true
 
 [dependencies]
 atty = { version = "0.2" }
-clap = { version = "4.1", features = ["derive"] }
+clap = { version = "4.4", features = ["derive"] }
 clap_complete = { version = "4.4" }
 crossterm = { version = "0.27" }
 ctrlc = { version = "3.4.0" }

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -20,6 +20,10 @@ pub struct Args {
     /// The output format to use
     #[clap(short = 'f', long)]
     pub format: Option<OutputFormat>,
+    #[clap(short = 'i', long, help = "The input to pass to the configuration or resource", conflicts_with = "input_file")]
+    pub input: Option<String>,
+    #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource")]
+    pub input_file: Option<String>,
 }
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -90,7 +90,6 @@ actualState:
         $out.Trim() | Should -BeExactly $expected
     }
 
-<<<<<<< HEAD
     It 'can generate PowerShell completer' {
         $out = dsc completer powershell | Out-String
         Invoke-Expression $out
@@ -99,7 +98,7 @@ actualState:
         $completions.CompletionMatches[0].CompletionText | Should -Be 'completer'
         $completions.CompletionMatches[1].CompletionText | Should -Be 'config'
     }
-=======
+
     It 'input can be passed using <parameter>' -TestCases @(
         @{ parameter = '-i' }
         @{ parameter = '--input' }
@@ -148,5 +147,4 @@ resources:
         $LASTEXITCODE | Should -Be 2
     }
 
->>>>>>> 2332df9 (Add `--input` and `--input-file` to `dsc`)
 }

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -90,6 +90,7 @@ actualState:
         $out.Trim() | Should -BeExactly $expected
     }
 
+<<<<<<< HEAD
     It 'can generate PowerShell completer' {
         $out = dsc completer powershell | Out-String
         Invoke-Expression $out
@@ -98,4 +99,54 @@ actualState:
         $completions.CompletionMatches[0].CompletionText | Should -Be 'completer'
         $completions.CompletionMatches[1].CompletionText | Should -Be 'config'
     }
+=======
+    It 'input can be passed using <parameter>' -TestCases @(
+        @{ parameter = '-i' }
+        @{ parameter = '--input' }
+    ) {
+        param($parameter)
+
+        $yaml = @'
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+resources:
+- name: os
+  type: Microsoft/OSInfo
+  properties:
+    family: Windows
+'@
+
+        $out = dsc $parameter "$yaml" config get | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].type | Should -BeExactly 'Microsoft/OSInfo'
+    }
+
+    It 'input can be passed using <parameter>' -TestCases @(
+        @{ parameter = '-p' }
+        @{ parameter = '--input-file' }
+    ) {
+        param($parameter)
+
+        $yaml = @'
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+resources:
+- name: os
+  type: Microsoft/OSInfo
+  properties:
+    family: Windows
+'@
+
+        Set-Content -Path $TestDrive/foo.yaml -Value $yaml
+        $out = dsc $parameter "$TestDrive/foo.yaml" config get | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].type | Should -BeExactly 'Microsoft/OSInfo'
+    }
+
+    It '--input and --input-file cannot be used together' {
+        dsc --input 1 --input-file foo.json config get 2> $TestDrive/error.txt
+        $err = Get-Content $testdrive/error.txt -Raw
+        $err.Length | Should -Not -Be 0
+        $LASTEXITCODE | Should -Be 2
+    }
+
+>>>>>>> 2332df9 (Add `--input` and `--input-file` to `dsc`)
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `-i | --input` and `-p | --input-file` as ways to pass input to `dsc` instead of just via stdin.  The two parameters are mutually exclusive.  Currently, stdin is ignored if either of these parameters are used.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/130
