### PR TITLE
WIP: Updated regex in DependsOn

### DIFF
--- a/dsc_lib/src/configure/depends_on.rs
+++ b/dsc_lib/src/configure/depends_on.rs
@@ -22,7 +22,7 @@ use crate::DscError;
 /// * `DscError::Validation` - The configuration is invalid
 pub fn get_resource_invocation_order(config: &Configuration) -> Result<Vec<Resource>, DscError> {
     let mut order: Vec<Resource> = Vec::new();
-    let depends_on_regex = Regex::new(r"^\[resourceId\(\s*'(?<type>[a-zA-Z0-9\.]+/[a-zA-Z0-9]+)'\s*,\s*'(?<name>[a-zA-Z0-9 ]+)'\s*\)]$")?;
+    let depends_on_regex = Regex::new(r"^\[resourceId\(\s*'(<type>[a-zA-Z0-9\.]+/[a-zA-Z0-9]+)'\s*,\s*'(<name>[a-zA-Z0-9 ]+)'\s*\)]$")?;
     for resource in &config.resources {
         // validate that the resource isn't specified more than once in the config
         if config.resources.iter().filter(|r| r.name == resource.name && r.resource_type == resource.resource_type).count() > 1 {


### PR DESCRIPTION
# PR Summary

Regex in `DependsOn` has an error:
```
PS C:\DSCv3> gc -raw C:\DSCv3\powershellgroup\Tests\native_and_powershell.dsc.yaml | dsc config get
  2023-10-04T20:14:57.096723Z ERROR dsc::subcommand: Error: Regex: regex parse error:
    ^\[resourceId\(\s*'(?<type>[a-zA-Z0-9\.]+/[a-zA-Z0-9]+)'\s*,\s*'(?<name>[a-zA-Z0-9 ]+)'\s*\)]$
                         ^
error: unrecognized flag
    at src\subcommand.rs:38
```

`https://regex101.com/` in RUST flavor says to remove question marks:

![RegExError](https://github.com/PowerShell/DSC/assets/11860095/ec440057-6d98-46d8-ba72-fca9dfb1c3e0)
