### PR TITLE
(DOCS) Update changelog, documentation, & schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 title: "Desired State Configuration changelog"
 description: >-
   A log of the changes for releases of DSCv3.
-ms.date: 09/27/2023
+ms.date: 10/05/2023
 ---
 
 # Changelog
+
+<!-- markdownlint-disable-file MD033 -->
 
 All notable changes to DSCv3 are documented in this file. The format is based on
 [Keep a Changelog][m1], and DSCv3 adheres to [Semantic Versioning][m2].
@@ -23,6 +25,106 @@ changes since the last release, see the [diff on GitHub][unreleased].
 [unreleased]: https://github.com/PowerShell/DSC/compare/v3.0.0-alpha.3...main
 
 <!-- Add entries between releases under the appropriate section heading here  -->
+
+### Changed
+
+- Replaced the `_ensure` well-known property with the boolean [_exist][21] property. This improves
+  the semantics for users and simplifies implementation for resources, replacing the string enum
+  values `Present` and `Absent` with `true` and `false` respectively.
+
+  <details><summary>Related work items</summary>
+
+  - Issues: [#202][#202]
+  - PRs: [#206][#206]
+
+  </details>
+
+- Updated the `Microsoft.Windows/Registry` resource to use the `_exist` property instead of
+  `_ensure` and updated the output to be idiomatic for a DSC Resource.
+
+  <details><summary>Related work items</summary>
+
+  - Issues: [#162][#162]
+  - PRs: [#206][#206]
+
+  </details>
+
+- When a user presses the <kbd>Ctrl</kbd>+<kbd>C</kbd> key combination, DSC now recursively
+  terminates all child processes before exiting. This helps prevent dangling processes that were
+  previously unhandled by the interrupt event.
+
+  <details><summary>Related work items</summary>
+
+  - PRs: [#213][#213]
+
+  </details>
+
+### Added
+
+- Added the [--input][22] and [--input-file][23] global options to the root `dsc` command. Now, you
+  can pass input to DSC from a variable or file instead of piping from stdin.
+
+  <details><summary>Related work items</summary>
+
+  - Issues: [#130][#130]
+  - PRs: [#217][#217]
+
+  </details>
+
+- Added the `arg` value as an option for defining how a command-based DSC Resource expects to
+  receive input. This enables resource authors to define resources that handle DSC passing the
+  instance JSON as an argument.
+
+  <details><summary>Related work items</summary>
+
+  - PRs: [#213][#213]
+
+  </details>
+
+- Added the new [completer][24] command enables users to add shell completions for DSC to their
+  shell. The command supports completions for Bash, Elvish, fish, PowerShell, and ZSH.
+
+  <details><summary>Related work items</summary>
+
+  - Issues: [#186][#186]
+  - PRs: [#216][#216]
+
+  </details>
+
+- DSC now emits tace logging to the stderr stream. This can make it easier to understand what DSC
+  is doing. This doesn't affect the data output. In this release, there's no way to opt out of the
+  logging.
+
+  <details><summary>Related work items</summary>
+
+  - Issues:
+    - [#107][#107]
+    - [#158][#158]
+  - PRs: [#211][#211]
+
+  </details>
+
+### Fixed
+
+- The `--format` option now works as users expect when the output is redirected or saved to a
+  variable. Before this fix, DSC always returned JSON output, even when the user wanted to save
+  the output as YAML. With this fix, the specified format is respected.
+
+  <details><summary>Related work items</summary>
+
+  - PRs: [#215][#215]
+
+  </details>
+
+- The `DSC/PowerShellGroup` resource now correctly returns the _labels_ for enumerations instead of
+  their integer value, making it easier to understand and compare results.
+
+  <details><summary>Related work items</summary>
+
+  - Issues: [#159][#159]
+  - PRs: [#208][#208]
+
+  </details>
 
 ## [v3.0.0-alpha.3][release-v3.0.0-alpha.3] - 2023-09-26
 
@@ -291,11 +393,22 @@ For the full list of changes in this release, see the [diff on GitHub][compare-v
 [19]: docs/reference/schemas/resource/manifest/set.md#input
 [20]: docs/reference/schemas/resource/manifest/test.md#input
 
+<!-- alpha.4 links -->
+[21]: docs/reference/schemas/resource/properties/exist.md
+[22]: docs/reference/cli/dsc.md#-i---input
+[23]: docs/reference/cli/dsc.md#-p---input-file
+[24]: docs/reference/cli/completer/command.md
+
 <!-- Issue and PR links -->
+[#107]: https://github.com/PowerShell/DSC/issues/107
 [#127]: https://github.com/PowerShell/DSC/issues/127
+[#130]: https://github.com/PowerShell/DSC/issues/130
 [#133]: https://github.com/PowerShell/DSC/issues/133
 [#150]: https://github.com/PowerShell/DSC/issues/150
 [#156]: https://github.com/PowerShell/DSC/issues/156
+[#158]: https://github.com/PowerShell/DSC/issues/158
+[#159]: https://github.com/PowerShell/DSC/issues/159
+[#162]: https://github.com/PowerShell/DSC/issues/162
 [#163]: https://github.com/PowerShell/DSC/issues/163
 [#168]: https://github.com/PowerShell/DSC/issues/168
 [#171]: https://github.com/PowerShell/DSC/issues/171
@@ -306,9 +419,18 @@ For the full list of changes in this release, see the [diff on GitHub][compare-v
 [#177]: https://github.com/PowerShell/DSC/issues/177
 [#181]: https://github.com/PowerShell/DSC/issues/181
 [#182]: https://github.com/PowerShell/DSC/issues/182
+[#186]: https://github.com/PowerShell/DSC/issues/186
 [#197]: https://github.com/PowerShell/DSC/issues/197
 [#198]: https://github.com/PowerShell/DSC/issues/198
 [#199]: https://github.com/PowerShell/DSC/issues/199
+[#202]: https://github.com/PowerShell/DSC/issues/202
+[#206]: https://github.com/PowerShell/DSC/issues/206
+[#208]: https://github.com/PowerShell/DSC/issues/208
+[#211]: https://github.com/PowerShell/DSC/issues/211
+[#213]: https://github.com/PowerShell/DSC/issues/213
+[#215]: https://github.com/PowerShell/DSC/issues/215
+[#216]: https://github.com/PowerShell/DSC/issues/216
+[#217]: https://github.com/PowerShell/DSC/issues/217
 [#45]:  https://github.com/PowerShell/DSC/issues/45
 [#73]:  https://github.com/PowerShell/DSC/issues/73
 [#98]:  https://github.com/PowerShell/DSC/issues/98

--- a/docs/reference/cli/completer/command.md
+++ b/docs/reference/cli/completer/command.md
@@ -1,0 +1,108 @@
+---
+description: Command line reference for the 'dsc completer' command
+ms.date:     10/05/2023
+ms.topic:    reference
+title:       dsc schema
+---
+
+# dsc schema
+
+## Synopsis
+
+Generates a shell completion script.
+
+## Syntax
+
+```sh
+dsc completer [Options] <SHELL>
+```
+
+## Description
+
+The `completer` command returns a shell script that, when executed, registers completions for the
+given shell. DSC can generate completion scripts for the following shells:
+
+- [Bourne Again SHell (BASH)][01]
+- [Elvish][02]
+- [Friendly Interactive SHell (fish)][03]
+- [PowerShell][04]
+- [Z SHell (ZSH)][05]
+
+The output for this command is the script itself. To register completions for DSC, execute the
+script.
+
+> [!WARNING]
+> Always review scripts before executing them, especially in an elevated execution context.
+
+## Examples
+
+### Example 1 - Register completions for Bash
+
+```sh
+completer=~/dsc_completion.bash
+# Export the completion script
+dsc completer bash > $completer
+# Review the completion script
+cat $completer
+# Add the completion script to your profile
+echo "source $completer" >> ~/.bashrc
+# Execute the completion script to register completions for this session
+source $completer
+```
+
+### Example 2 - Register completions for PowerShell
+
+```powershell
+$Completer = '~/dsc_completion.ps1'
+# Export the completion script
+dsc completer powershell | Out-File $Completer
+# Review the completion script
+Get-Content $completer
+# Add the completion script to your profile
+Add-Content -Path $PROFILE ". $Completer"
+# Execute the completion script to register completions for this session
+. $Completer
+```
+
+## Arguments
+
+### SHELL
+
+This argument is mandatory for the `completer` command. The value for this option determines which
+shell the application returns a completion script for:
+
+- `bash` - [Bourne Again SHell (BASH)][01]
+- `elvish` - [Elvish][02]
+- `fish` - [Friendly Interactive SHell (fish)][03]
+- `powershell` - [PowerShell][04]
+- `zsh` - [Z SHell (ZSH)][05]
+
+```yaml
+Type:        String
+Mandatory:   true
+ValidValues: [
+               bash,
+               elvish,
+               fish,
+               powershell,
+               zsh,
+             ]
+```
+
+## Options
+
+### -h, --help
+
+Displays the help for the current command or subcommand. When you specify this option, the
+application ignores all options and arguments after this one.
+
+```yaml
+Type:      Boolean
+Mandatory: false
+```
+
+[01]: https://www.gnu.org/software/bash/
+[02]: https://elv.sh/
+[03]: https://fishshell.com/
+[04]: https://learn.microsoft.com/powershell/scripting/overview
+[05]: https://zsh.sourceforge.io/

--- a/docs/reference/cli/config/get.md
+++ b/docs/reference/cli/config/get.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc config get' command
-ms.date:     08/04/2023
+ms.date:     10/05/2023
 ms.topic:    reference
 title:       dsc config get
 ---
@@ -58,6 +58,24 @@ resources:
 cat ./example.dsc.config.yaml | dsc config get
 ```
 
+### Example 2 - Passing a file to read as the configuration document
+
+The command uses the [--input-file][01] global option to retrieve the resource instances defined in
+the `example.dsc.config.yaml` file.
+
+```sh
+dsc --input-file ./example.dsc.config.yaml config get
+```
+
+### Example 3 - Passing a configuration document as a variable
+
+The command uses the [--input][02] global option to retrieve the resource instances defined in a
+configuration document stored in the `$desired` variable.
+
+```sh
+dsc --input $desired config get
+```
+
 ## Options
 
 ### -h, --help
@@ -74,6 +92,8 @@ Mandatory: false
 
 This command returns JSON output that includes whether the operation or any resources raised any
 errors, the collection of messages emitted during the operation, and the get operation results for
-every instance. For more information, see [dsc config get result schema][01].
+every instance. For more information, see [dsc config get result schema][03].
 
-[01]: ../../schemas/outputs/config/get.md
+[01]: ../dsc.md#-p---input-file
+[02]: ../dsc.md#-i---input
+[03]: ../../schemas/outputs/config/get.md

--- a/docs/reference/cli/config/set.md
+++ b/docs/reference/cli/config/set.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc config set' command
-ms.date:     08/04/2023
+ms.date:     10/05/2023
 ms.topic:    reference
 title:       dsc config set
 ---
@@ -59,6 +59,24 @@ resources:
 cat ./example.dsc.config.yaml | dsc config set
 ```
 
+### Example 2 - Passing a file to read as the configuration document
+
+The command uses the [--input-file][01] global option to enforce the configuration defined in
+the `example.dsc.config.yaml` file.
+
+```sh
+dsc --input-file ./example.dsc.config.yaml config set
+```
+
+### Example 3 - Passing a configuration document as a variable
+
+The command uses the [--input][02] global option to enforce the configuration stored in the
+`$desired` variable.
+
+```sh
+dsc --input $desired config set
+```
+
 ## Options
 
 ### -h, --help
@@ -75,6 +93,8 @@ Mandatory: false
 
 This command returns JSON output that includes whether the operation or any resources raised any
 errors, the collection of messages emitted during the operation, and the set operation results for
-every instance. For more information, see [dsc config get result schema][01].
+every instance. For more information, see [dsc config get result schema][03].
 
-[01]: ../../schemas/outputs/config/set.md
+[01]: ../dsc.md#-p---input-file
+[02]: ../dsc.md#-i---input
+[03]: ../../schemas/outputs/config/set.md

--- a/docs/reference/cli/config/test.md
+++ b/docs/reference/cli/config/test.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc config test' command
-ms.date:     08/04/2023
+ms.date:     10/05/2023
 ms.topic:    reference
 title:       dsc config test
 ---
@@ -58,6 +58,24 @@ resources:
 cat ./example.dsc.config.yaml | dsc config test
 ```
 
+### Example 2 - Passing a file to read as the configuration document
+
+The command uses the [--input-file][01] global option to validate the configuration defined in
+the `example.dsc.config.yaml` file.
+
+```sh
+dsc --input-file ./example.dsc.config.yaml config test
+```
+
+### Example 3 - Passing a configuration document as a variable
+
+The command uses the [--input][02] global option to validate the configuration stored in the
+`$desired` variable.
+
+```sh
+dsc --input $desired config test
+```
+
 ## Options
 
 ### -h, --help
@@ -74,6 +92,8 @@ Mandatory: false
 
 This command returns JSON output that includes whether the operation or any resources raised any
 errors, the collection of messages emitted during the operation, and the test operation results for
-every instance. For more information, see [dsc config test result schema][01].
+every instance. For more information, see [dsc config test result schema][03].
 
-[01]: ../../schemas/outputs/config/test.md
+[01]: ../dsc.md#-p---input-file
+[02]: ../dsc.md#-i---input
+[03]: ../../schemas/outputs/config/test.md

--- a/docs/reference/cli/dsc.md
+++ b/docs/reference/cli/dsc.md
@@ -1,6 +1,6 @@
 ---
 description: Command line reference for the 'dsc' command
-ms.date:     08/04/2023
+ms.date:     10/05/2023
 ms.topic:    reference
 title:       dsc
 ---
@@ -19,6 +19,11 @@ dsc [Options] <COMMAND>
 
 ## Commands
 
+### completer
+
+The `completer` command returns a shell script that, when executed, registers completions for the
+given shell. For more information, see [completer][01].
+
 ### config
 
 The `config` command manages a DSC Configuration document. You can use it to:
@@ -27,7 +32,7 @@ The `config` command manages a DSC Configuration document. You can use it to:
 - Test whether a configuration is in the desired state.
 - Set a configuration to the desired state.
 
-For more information, see [config][01].
+For more information, see [config][02].
 
 ### resource
 
@@ -39,12 +44,12 @@ The `resource` command manages a DSC Resource. You can use it to:
 - Test whether a resource instance is in the desired state.
 - Set a resource instance to the desired state.
 
-For more information, see [resource][02]
+For more information, see [resource][03]
 
 ### schema
 
 The `schema` command returns the JSON schema for a specific DSC type. For more information, see
-[schema][03].
+[schema][04].
 
 ### help
 
@@ -89,6 +94,36 @@ Type:      Boolean
 Mandatory: false
 ```
 
+### -i, --input
+
+Defines input for the command as a string instead of piping input from stdin. This option is
+mutually exclusive with the `--input-file` option. When you use this option, DSC ignores any input
+from stdin.
+
+To pass input for a command or subcommand, specify this option before the command, like
+`dsc --input $desired resource test`.
+
+```yaml
+Type:      String
+Mandatory: false
+```
+
+### -p, --input-file
+
+Defines the path to a text file to read as input for the command instead of piping input from
+stdin. This option is mutually exclusive with the `--input` option. When you use this option, DSC
+ignores any input from stdin.
+
+To pass a file to read as input for a command or subcommand, specify this option before the
+command, like `dsc --input-file web.dsc.config.yaml config set`.
+
+If the specified file doesn't exist, DSC raises an error.
+
+```yaml
+Type:      String
+Mandatory: false
+```
+
 ### -V, --version
 
 Displays the version of the application. When you specify this option, the application ignores all
@@ -124,6 +159,7 @@ execution of the command.
 |    `5`    | The command failed because a resource definition or instance value was invalid against its JSON schema. |
 |    `6`    | The command was cancelled by a <kbd>Ctrl</kbd>+<kbd>C</kbd> interruption.                               |
 
-[01]: config/command.md
-[02]: resource/command.md
-[03]: schema/command.md
+[01]: completer/command.md
+[02]: config/command.md
+[03]: resource/command.md
+[04]: schema/command.md

--- a/docs/reference/schemas/resource/properties/ensure.md
+++ b/docs/reference/schemas/resource/properties/ensure.md
@@ -1,6 +1,6 @@
 ---
 description: JSON schema reference for the '_ensure' well-known DSC Resource property.
-ms.date:     08/04/2023
+ms.date:     10/05/2023
 ms.topic:    reference
 title:       DSC Resource _ensure property schema
 ---
@@ -21,6 +21,11 @@ ValidValues:   [Absent, Present]
 ```
 
 ## Description
+
+> [!IMPORTANT]
+> Starting with DSC v3.0.0-alpha.4 and schema version `2023/10` this well-known property is removed
+> from the schema. It's replaced by the [_exist][01] property. Microsoft recommends migrating
+> resources to use the `_exist` keyword instead.
 
 The `_ensure` property indicates that the resource can enforce whether instances exist using the
 shared present and absent semantics.
@@ -54,3 +59,5 @@ specifically a file, or exists as a symlink. In that case, the resource would de
     "default": "present"
 }
 ```
+
+[01]: exist.md

--- a/docs/reference/schemas/resource/properties/exist.md
+++ b/docs/reference/schemas/resource/properties/exist.md
@@ -1,0 +1,49 @@
+---
+description: JSON schema reference for the '_exist' well-known DSC Resource property.
+ms.date:     10/05/2023
+ms.topic:    reference
+title:       DSC Resource _exist property schema
+---
+
+# DSC Resource _exist property schema
+
+## Synopsis
+
+Indicates whether an instance should exist.
+
+## Metadata
+
+```yaml
+SchemaDialect: https://json-schema.org/draft/2020-12/schema
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json
+Type:          boolean
+DefaultValue:  true
+```
+
+## Description
+
+The `_exist` property indicates that the resource can enforce whether instances exist, handling
+whether an instance should be added, updated, or removed during a set operation. This property
+provides shared semantics for DSC Resources and integrating tools, but doesn't enable any
+additional built-in processing with DSC.
+
+Resources should only define this property when their implementation adheres to the following
+behavior contract:
+
+1. When the desired state for `_exist` is `true`, the resource expects the instance to exist. If it
+   doesn't exist, the resource creates or adds the instance during the set operation.
+1. When the desired state for `_exist` is `false`, the resource expects the instance to not exist.
+   If it does exist, the resource deletes or removes the instance during the set operation.
+1. When the get operation queries for an instance that doesn't exist, the returned JSON always
+   defines the `_exist` property as `false`.
+
+   The resource _may_ omit the `_exist` property from the result JSON when the instance exists.
+
+To add this property to a resource's instance schema, define the property with the following
+snippet:
+
+```json
+"_exist": {
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json"
+}
+```

--- a/docs/reference/schemas/resource/properties/overview.md
+++ b/docs/reference/schemas/resource/properties/overview.md
@@ -2,7 +2,7 @@
 description: >-
   Information about the list of well-known DSC Resource properties, including their purpose and how
   to add them to a resource's manifest.
-ms.date:     08/04/2023
+ms.date:     10/05/2023
 ms.topic:    reference
 title:       DSC well-known properties
 ---
@@ -13,15 +13,14 @@ DSC has support for several well-known properties. Some well-known properties en
 to use built-in processing. The well-known properties always start with an underscore (`_`) and DSC
 Resources that use these properties may not override or extend them.
 
-## _ensure
+## _exist
 
-The `_ensure` property indicates that the resource can enforce whether instances exist using the
-shared present and absent semantics. If a resource must distinguish between states beyond whether
-an instance is present or absent, the resource should define its own `ensure` property without the
-leading underscore. This property provides shared semantics for DSC Resources and integrating
-tools, but doesn't enable any additional built-in processing with DSC.
+The `_exist` property indicates that the resource can enforce whether instances exist, handling
+whether an instance should be added, updated, or removed during a set operation. This property
+provides shared semantics for DSC Resources and integrating tools, but doesn't enable any
+additional built-in processing with DSC.
 
-For more information, see [DSC Resource _ensure property schema][01].
+For more information, see [DSC Resource _exist property schema][01].
 
 ## _inDesiredState
 
@@ -48,7 +47,7 @@ this property in their manifest.
 
 For more information, see [DSC Resource _rebootRequested property schema][06].
 
-[01]: ensure.md
+[01]: exist.md
 [02]: ../manifest/test.md
 [03]: ../manifest/root.md
 [04]: inDesiredState.md

--- a/schemas/src/resource/manifest.schema.yaml
+++ b/schemas/src/resource/manifest.schema.yaml
@@ -329,27 +329,34 @@ properties:
                 const:       ^${3:"constant value"}
 
         properties:
-          _ensure:
-            title: 'Standard Property: _ensure'
+          _exist:
+            title: 'Standard Property: _exist'
             description: >-
-              Indicates that the DSC Resource uses the standard `_ensure` property to specify
-              whether an instance should exist with the `Present` and `Absent` enums.
+              Indicates that the DSC Resource uses the standard `_exist` property to specify
+              whether an instance should exist as a boolean value that defaults to `true`.
             const:
-              $ref: <HOST>/<PREFIX>/<VERSION>/resource/properties/ensure.yaml
+              $ref: <HOST>/<PREFIX>/<VERSION>/resource/properties/exist.yaml
             # VS Code only
             markdownDescription: |
               ***
               [_Online Documentation_][01]
               ***
 
-              Indicates that the resource can enforce whether instances exist using the shared
-              `present` and `absent` semantics. If a resource must distinguish between states
-              beyond whether an instance is `present` or `absent`, the resource should define its
-              own `ensure` property without the leading underscore. This property provides shared
-              semantics for DSC Resources and integrating tools, but doesn't enable any additional
-              built-in processing with DSC.
+              Indicates that the resource can enforce whether instances exist, handling whether an
+              instance should be added, updated, or removed during a set operation. The default
+              value is `true`.
 
-              [01]: <DOCS_BASE_URL>/reference/schemas/resource/properties/ensure?<DOCS_VERSION_PIN>
+              Resources that define this property declare that the implementation adheres to the
+              following behavior contract:
+
+              1. When the desired state for `_exist` is `true`, the resource expects the instance
+                 to exist. If it doesn't exist, the resource creates or adds the instance during
+                 the set operation.
+              1. When the desired state for `_exist` is `false`, the resource expects the instance
+                 to not exist. If it does exist, the resource deletes or removes the instance
+                 during the set operation.
+
+              [01]: <DOCS_BASE_URL>/reference/schemas/resource/properties/exist?<DOCS_VERSION_PIN>
           _inDesiredState:
             title: 'Standard Property: _inDesiredState'
             description: >-

--- a/schemas/src/resource/properties/exist.yaml
+++ b/schemas/src/resource/properties/exist.yaml
@@ -1,15 +1,14 @@
 # yaml-language-server: $schema=https://json-schema.org/draft/2020-12/schema
 $schema: https://json-schema.org/draft/2020-12/schema
-$id:     <HOST>/<PREFIX>/<VERSION>/resource/properties/ensure.yaml
+$id:     <HOST>/<PREFIX>/<VERSION>/resource/properties/exist.yaml
 
-title: Ensure Existence
+title: Instance should exist
 description: >-
   Indicates whether the DSC Resource instance should exist.
 
-type: string
-enum:
-  - Absent
-  - Present
+type:    boolean
+default: true
+enum:    [false, true]
 
 # VS Code Only
 markdownDescription: |
@@ -19,15 +18,15 @@ markdownDescription: |
 
   Indicates whether the DSC Resource instance should exist.
 
-  [01]: <DOCS_BASE_URL>/reference/schemas/resource/properties/ensure?<DOCS_VERSION_PIN>
+  [01]: <DOCS_BASE_URL>/reference/schemas/resource/properties/exist?<DOCS_VERSION_PIN>
 markdownEnumDescriptions:
-  - | # Absent
+  - | # false
     _Instance shouldn't exist._
 
-    > If the desired state for `_ensure` is `absent` and the instance exists, the resource removes
+    > If the desired state for `_exist` is `false` and the instance exists, the resource removes
     > the instance during the `set` operation.
-  - | # Present
+  - | # true
     _Instance should exist._
 
-    > If the desired state for `_ensure` is `present` and the instance doesn't exist, the resource
+    > If the desired state for `_exist` is `true` and the instance doesn't exist, the resource
     > adds or creates the instance during the `set` operation.


### PR DESCRIPTION
# PR Summary

The updates include:

- Documenting the new `_exist` property, replacing `_ensure` for resources. This documentation update includes the schema definition, but doesn't regenerate the schema, which will be handled separately.
- Documenting the new `completer` command.
- Documenting the new `--input` and `--input-file` global options.
- Adding a deprecation notice to the `_ensure` documentation.
- Adding entries for all user-impacting changes to the changelog.

## PR Context

This change updates the project changelog, reference documentation, and schemas for the recent PRs merged for the project:

- #206
- #208
- #211
- #213
- #215
- #216
- #217
