### PR TITLE
Tree-sitter grammar for expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ Cargo.lock
 target
 bin/
 .DS_Store
+
+# Node.js generated files for tree-sitter
+build/
+node_modules/

--- a/build.ps1
+++ b/build.ps1
@@ -93,7 +93,7 @@ New-Item -ItemType Directory $target > $null
 # make sure dependencies are built first so clippy runs correctly
 $windows_projects = @("pal", "ntreg", "ntstatuserror", "ntuserinfo", "registry")
 $projects = @("dsc_lib", "dsc", "osinfo", "process", "tools/test_group_resource", "y2j", "powershellgroup", "tools/dsctest")
-$pedantic_unclean_projects = @("ntreg")
+$pedantic_unclean_projects = @("tree-sitter-dscexpression", "ntreg")
 
 if ($IsWindows) {
     $projects += $windows_projects

--- a/tree-sitter-dscexpression/Cargo.toml
+++ b/tree-sitter-dscexpression/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "tree-sitter-dscexpression"
+description = "DSCExpression grammar for the tree-sitter parsing library"
+version = "0.0.1"
+keywords = ["incremental", "parsing", "DSCExpression"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/powershell/dsc"
+edition = "2018"
+license = "MIT"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "queries/*",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "~0.20.10"
+
+[build-dependencies]
+cc = "1.0"

--- a/tree-sitter-dscexpression/binding.gyp
+++ b/tree-sitter-dscexpression/binding.gyp
@@ -1,0 +1,19 @@
+{
+  "targets": [
+    {
+      "target_name": "tree_sitter_DSCExpression_binding",
+      "include_dirs": [
+        "<!(node -e \"require('nan')\")",
+        "src"
+      ],
+      "sources": [
+        "bindings/node/binding.cc",
+        "src/parser.c",
+        # If your language uses an external scanner, add it here.
+      ],
+      "cflags_c": [
+        "-std=c99",
+      ]
+    }
+  ]
+}

--- a/tree-sitter-dscexpression/bindings/node/binding.cc
+++ b/tree-sitter-dscexpression/bindings/node/binding.cc
@@ -1,0 +1,28 @@
+#include "tree_sitter/parser.h"
+#include <node.h>
+#include "nan.h"
+
+using namespace v8;
+
+extern "C" TSLanguage * tree_sitter_DSCExpression();
+
+namespace {
+
+NAN_METHOD(New) {}
+
+void Init(Local<Object> exports, Local<Object> module) {
+  Local<FunctionTemplate> tpl = Nan::New<FunctionTemplate>(New);
+  tpl->SetClassName(Nan::New("Language").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+  Local<Function> constructor = Nan::GetFunction(tpl).ToLocalChecked();
+  Local<Object> instance = constructor->NewInstance(Nan::GetCurrentContext()).ToLocalChecked();
+  Nan::SetInternalFieldPointer(instance, 0, tree_sitter_DSCExpression());
+
+  Nan::Set(instance, Nan::New("name").ToLocalChecked(), Nan::New("DSCExpression").ToLocalChecked());
+  Nan::Set(module, Nan::New("exports").ToLocalChecked(), instance);
+}
+
+NODE_MODULE(tree_sitter_DSCExpression_binding, Init)
+
+}  // namespace

--- a/tree-sitter-dscexpression/bindings/node/index.js
+++ b/tree-sitter-dscexpression/bindings/node/index.js
@@ -1,0 +1,19 @@
+try {
+  module.exports = require("../../build/Release/tree_sitter_DSCExpression_binding");
+} catch (error1) {
+  if (error1.code !== 'MODULE_NOT_FOUND') {
+    throw error1;
+  }
+  try {
+    module.exports = require("../../build/Debug/tree_sitter_DSCExpression_binding");
+  } catch (error2) {
+    if (error2.code !== 'MODULE_NOT_FOUND') {
+      throw error2;
+    }
+    throw error1
+  }
+}
+
+try {
+  module.exports.nodeTypeInfo = require("../../src/node-types.json");
+} catch (_) {}

--- a/tree-sitter-dscexpression/bindings/rust/build.rs
+++ b/tree-sitter-dscexpression/bindings/rust/build.rs
@@ -1,0 +1,40 @@
+fn main() {
+    let src_dir = std::path::Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+
+    // If your language uses an external scanner written in C,
+    // then include this block of code:
+
+    /*
+    let scanner_path = src_dir.join("scanner.c");
+    c_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+
+    c_config.compile("parser");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+
+    // If your language uses an external scanner written in C++,
+    // then include this block of code:
+
+    /*
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    cpp_config.compile("scanner");
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    */
+}

--- a/tree-sitter-dscexpression/bindings/rust/lib.rs
+++ b/tree-sitter-dscexpression/bindings/rust/lib.rs
@@ -1,0 +1,52 @@
+//! This crate provides DSCExpression language support for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [language][language func] function to add this language to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
+//!
+//! ```
+//! let code = "";
+//! let mut parser = tree_sitter::Parser::new();
+//! parser.set_language(tree_sitter_DSCExpression::language()).expect("Error loading DSCExpression grammar");
+//! let tree = parser.parse(code, None).unwrap();
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+
+extern "C" {
+    fn tree_sitter_DSCExpression() -> Language;
+}
+
+/// Get the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_DSCExpression() }
+}
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+// Uncomment these to include any queries that this grammar contains
+
+// pub const HIGHLIGHTS_QUERY: &'static str = include_str!("../../queries/highlights.scm");
+// pub const INJECTIONS_QUERY: &'static str = include_str!("../../queries/injections.scm");
+// pub const LOCALS_QUERY: &'static str = include_str!("../../queries/locals.scm");
+// pub const TAGS_QUERY: &'static str = include_str!("../../queries/tags.scm");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_can_load_grammar() {
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading DSCExpression language");
+    }
+}

--- a/tree-sitter-dscexpression/build.ps1
+++ b/tree-sitter-dscexpression/build.ps1
@@ -1,0 +1,14 @@
+#requires -version 7.4
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+# check if tools are installed
+
+$PSNativeCommandUseErrorActionPreference = $true
+$ErrorActionPreference = 'Stop'
+
+npx tree-sitter generate
+node-gyp configure
+node-gyp build
+npx tree-sitter test

--- a/tree-sitter-dscexpression/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/invalid_expressions.txt
@@ -1,0 +1,75 @@
+=====
+String literal looking like function
+=====
+
+functionOne(1,2)
+
+---
+
+    (statement
+      (stringLiteral))
+
+=====
+String parameter not in quotes
+=====
+
+[functionOne(alpha, beta)]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (ERROR
+            (functionName)
+            (functionName)))))
+
+=====
+Missing parenthesis
+=====
+
+[functionOne]
+
+---
+
+    (ERROR
+      (functionName))
+
+=====
+Missing parameter
+=====
+
+[functionOne(1, ,2)]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (number)
+          (ERROR)
+          (number))))
+
+=====
+Escaped bracket
+=====
+
+[[notFunction()]
+
+---
+
+    (statement
+      (escapedStringLiteral))
+
+=====
+String literal
+=====
+
+This is a string
+
+---
+
+    (statement
+      (stringLiteral))

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -1,0 +1,96 @@
+=====
+Function no args
+=====
+
+[functionOne()]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName))))
+
+=====
+Simple expression
+=====
+
+[myFunction('argString')]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (string))))
+
+=====
+Whitespace
+=====
+
+  [  functionOne   ( 'arg'  , 2 )  ]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (string)
+          (number))))
+
+=====
+Multiple arguments
+=====
+
+[myFunction('argString', 1, true)]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (string)
+          (number)
+          (boolean))))
+
+=====
+Nested functions
+=====
+
+[functionOne('argString', functionTwo(1, functionThree('threeString', 3), 2), 'oneString')]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (string)
+          (function
+            (functionName)
+            (number)
+            (function
+              (functionName)
+              (string)
+              (number))
+            (number))
+          (string))))
+
+=====
+Function with dot-notation
+=====
+
+[functionOne('argString').prop1.prop2]
+
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (string))
+        (memberName)
+        (memberName)))

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -1,0 +1,25 @@
+module.exports = grammar({
+  name: 'dscexpression',
+
+  rules: {
+    statement: $ => choice(
+      $.escapedStringLiteral,
+      $.expression,
+      $.stringLiteral,
+    ),
+    escapedStringLiteral: $ => token(seq('[[', /.*/)),
+    expression: $ => seq('[', $.function, optional($._members), ']'),
+    stringLiteral: $ => token(prec(-11, /.*/)),
+    function: $ => seq($.functionName, '(', optional($._arguments), ')'),
+    functionName: $ => /[a-zA-Z]+/,
+    _arguments: $ => seq($._argument, repeat(seq(',', $._argument))),
+    _argument: $ => choice($.function, $.string, $.number, $.boolean),
+    string: $ => seq("'", /[^']*/, "'"),
+    number: $ => /\d+/,
+    boolean: $ => choice('true', 'false'),
+    _members: $ => repeat1($._member),
+    _member: $ => seq('.', $.memberName),
+    memberName: $ => /[a-zA-Z0-9_-]+/,
+  }
+
+});

--- a/tree-sitter-dscexpression/package.json
+++ b/tree-sitter-dscexpression/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "tree-sitter-dscexpression",
+  "version": "0.0.1",
+  "description": "DSCExpression grammar for tree-sitter",
+  "main": "bindings/node",
+  "keywords": [
+    "parsing",
+    "incremental"
+  ],
+  "dependencies": {
+    "nan": "^2.12.1"
+  },
+  "devDependencies": {
+    "tree-sitter-cli": "^0.20.8"
+  },
+  "scripts": {
+    "test": "tree-sitter test"
+  }
+}

--- a/tree-sitter-dscexpression/src/grammar.json
+++ b/tree-sitter-dscexpression/src/grammar.json
@@ -1,0 +1,227 @@
+{
+  "name": "dscexpression",
+  "rules": {
+    "statement": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "escapedStringLiteral"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "expression"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "stringLiteral"
+        }
+      ]
+    },
+    "escapedStringLiteral": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "[["
+          },
+          {
+            "type": "PATTERN",
+            "value": ".*"
+          }
+        ]
+      }
+    },
+    "expression": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "["
+        },
+        {
+          "type": "SYMBOL",
+          "name": "function"
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_members"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": "]"
+        }
+      ]
+    },
+    "stringLiteral": {
+      "type": "TOKEN",
+      "content": {
+        "type": "PREC",
+        "value": -11,
+        "content": {
+          "type": "PATTERN",
+          "value": ".*"
+        }
+      }
+    },
+    "function": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "functionName"
+        },
+        {
+          "type": "STRING",
+          "value": "("
+        },
+        {
+          "type": "CHOICE",
+          "members": [
+            {
+              "type": "SYMBOL",
+              "name": "_arguments"
+            },
+            {
+              "type": "BLANK"
+            }
+          ]
+        },
+        {
+          "type": "STRING",
+          "value": ")"
+        }
+      ]
+    },
+    "functionName": {
+      "type": "PATTERN",
+      "value": "[a-zA-Z]+"
+    },
+    "_arguments": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "_argument"
+        },
+        {
+          "type": "REPEAT",
+          "content": {
+            "type": "SEQ",
+            "members": [
+              {
+                "type": "STRING",
+                "value": ","
+              },
+              {
+                "type": "SYMBOL",
+                "name": "_argument"
+              }
+            ]
+          }
+        }
+      ]
+    },
+    "_argument": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "SYMBOL",
+          "name": "function"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "string"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "number"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "boolean"
+        }
+      ]
+    },
+    "string": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "'"
+        },
+        {
+          "type": "PATTERN",
+          "value": "[^']*"
+        },
+        {
+          "type": "STRING",
+          "value": "'"
+        }
+      ]
+    },
+    "number": {
+      "type": "PATTERN",
+      "value": "\\d+"
+    },
+    "boolean": {
+      "type": "CHOICE",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "true"
+        },
+        {
+          "type": "STRING",
+          "value": "false"
+        }
+      ]
+    },
+    "_members": {
+      "type": "REPEAT1",
+      "content": {
+        "type": "SYMBOL",
+        "name": "_member"
+      }
+    },
+    "_member": {
+      "type": "SEQ",
+      "members": [
+        {
+          "type": "STRING",
+          "value": "."
+        },
+        {
+          "type": "SYMBOL",
+          "name": "memberName"
+        }
+      ]
+    },
+    "memberName": {
+      "type": "PATTERN",
+      "value": "[a-zA-Z0-9_-]+"
+    }
+  },
+  "extras": [
+    {
+      "type": "PATTERN",
+      "value": "\\s"
+    }
+  ],
+  "conflicts": [],
+  "precedences": [],
+  "externals": [],
+  "inline": [],
+  "supertypes": []
+}
+

--- a/tree-sitter-dscexpression/src/node-types.json
+++ b/tree-sitter-dscexpression/src/node-types.json
@@ -1,0 +1,141 @@
+[
+  {
+    "type": "boolean",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "expression",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "function",
+          "named": true
+        },
+        {
+          "type": "memberName",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "function",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": true,
+      "required": true,
+      "types": [
+        {
+          "type": "boolean",
+          "named": true
+        },
+        {
+          "type": "function",
+          "named": true
+        },
+        {
+          "type": "functionName",
+          "named": true
+        },
+        {
+          "type": "number",
+          "named": true
+        },
+        {
+          "type": "string",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "statement",
+    "named": true,
+    "fields": {},
+    "children": {
+      "multiple": false,
+      "required": true,
+      "types": [
+        {
+          "type": "escapedStringLiteral",
+          "named": true
+        },
+        {
+          "type": "expression",
+          "named": true
+        },
+        {
+          "type": "stringLiteral",
+          "named": true
+        }
+      ]
+    }
+  },
+  {
+    "type": "string",
+    "named": true,
+    "fields": {}
+  },
+  {
+    "type": "'",
+    "named": false
+  },
+  {
+    "type": "(",
+    "named": false
+  },
+  {
+    "type": ")",
+    "named": false
+  },
+  {
+    "type": ",",
+    "named": false
+  },
+  {
+    "type": ".",
+    "named": false
+  },
+  {
+    "type": "[",
+    "named": false
+  },
+  {
+    "type": "]",
+    "named": false
+  },
+  {
+    "type": "escapedStringLiteral",
+    "named": true
+  },
+  {
+    "type": "false",
+    "named": false
+  },
+  {
+    "type": "functionName",
+    "named": true
+  },
+  {
+    "type": "memberName",
+    "named": true
+  },
+  {
+    "type": "number",
+    "named": true
+  },
+  {
+    "type": "stringLiteral",
+    "named": true
+  },
+  {
+    "type": "true",
+    "named": false
+  }
+]

--- a/tree-sitter-dscexpression/src/parser.c
+++ b/tree-sitter-dscexpression/src/parser.c
@@ -1,0 +1,831 @@
+#include <tree_sitter/parser.h>
+
+#if defined(__GNUC__) || defined(__clang__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmissing-field-initializers"
+#endif
+
+#define LANGUAGE_VERSION 14
+#define STATE_COUNT 26
+#define LARGE_STATE_COUNT 2
+#define SYMBOL_COUNT 26
+#define ALIAS_COUNT 0
+#define TOKEN_COUNT 16
+#define EXTERNAL_TOKEN_COUNT 0
+#define FIELD_COUNT 0
+#define MAX_ALIAS_SEQUENCE_LENGTH 4
+#define PRODUCTION_ID_COUNT 1
+
+enum {
+  sym_escapedStringLiteral = 1,
+  anon_sym_LBRACK = 2,
+  anon_sym_RBRACK = 3,
+  sym_stringLiteral = 4,
+  anon_sym_LPAREN = 5,
+  anon_sym_RPAREN = 6,
+  sym_functionName = 7,
+  anon_sym_COMMA = 8,
+  anon_sym_SQUOTE = 9,
+  aux_sym_string_token1 = 10,
+  sym_number = 11,
+  anon_sym_true = 12,
+  anon_sym_false = 13,
+  anon_sym_DOT = 14,
+  sym_memberName = 15,
+  sym_statement = 16,
+  sym_expression = 17,
+  sym_function = 18,
+  sym__arguments = 19,
+  sym__argument = 20,
+  sym_string = 21,
+  sym_boolean = 22,
+  aux_sym__members = 23,
+  sym__member = 24,
+  aux_sym__arguments_repeat1 = 25,
+};
+
+static const char * const ts_symbol_names[] = {
+  [ts_builtin_sym_end] = "end",
+  [sym_escapedStringLiteral] = "escapedStringLiteral",
+  [anon_sym_LBRACK] = "[",
+  [anon_sym_RBRACK] = "]",
+  [sym_stringLiteral] = "stringLiteral",
+  [anon_sym_LPAREN] = "(",
+  [anon_sym_RPAREN] = ")",
+  [sym_functionName] = "functionName",
+  [anon_sym_COMMA] = ",",
+  [anon_sym_SQUOTE] = "'",
+  [aux_sym_string_token1] = "string_token1",
+  [sym_number] = "number",
+  [anon_sym_true] = "true",
+  [anon_sym_false] = "false",
+  [anon_sym_DOT] = ".",
+  [sym_memberName] = "memberName",
+  [sym_statement] = "statement",
+  [sym_expression] = "expression",
+  [sym_function] = "function",
+  [sym__arguments] = "_arguments",
+  [sym__argument] = "_argument",
+  [sym_string] = "string",
+  [sym_boolean] = "boolean",
+  [aux_sym__members] = "_members",
+  [sym__member] = "_member",
+  [aux_sym__arguments_repeat1] = "_arguments_repeat1",
+};
+
+static const TSSymbol ts_symbol_map[] = {
+  [ts_builtin_sym_end] = ts_builtin_sym_end,
+  [sym_escapedStringLiteral] = sym_escapedStringLiteral,
+  [anon_sym_LBRACK] = anon_sym_LBRACK,
+  [anon_sym_RBRACK] = anon_sym_RBRACK,
+  [sym_stringLiteral] = sym_stringLiteral,
+  [anon_sym_LPAREN] = anon_sym_LPAREN,
+  [anon_sym_RPAREN] = anon_sym_RPAREN,
+  [sym_functionName] = sym_functionName,
+  [anon_sym_COMMA] = anon_sym_COMMA,
+  [anon_sym_SQUOTE] = anon_sym_SQUOTE,
+  [aux_sym_string_token1] = aux_sym_string_token1,
+  [sym_number] = sym_number,
+  [anon_sym_true] = anon_sym_true,
+  [anon_sym_false] = anon_sym_false,
+  [anon_sym_DOT] = anon_sym_DOT,
+  [sym_memberName] = sym_memberName,
+  [sym_statement] = sym_statement,
+  [sym_expression] = sym_expression,
+  [sym_function] = sym_function,
+  [sym__arguments] = sym__arguments,
+  [sym__argument] = sym__argument,
+  [sym_string] = sym_string,
+  [sym_boolean] = sym_boolean,
+  [aux_sym__members] = aux_sym__members,
+  [sym__member] = sym__member,
+  [aux_sym__arguments_repeat1] = aux_sym__arguments_repeat1,
+};
+
+static const TSSymbolMetadata ts_symbol_metadata[] = {
+  [ts_builtin_sym_end] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_escapedStringLiteral] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_LBRACK] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RBRACK] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_stringLiteral] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_LPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_RPAREN] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_functionName] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_COMMA] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_SQUOTE] = {
+    .visible = true,
+    .named = false,
+  },
+  [aux_sym_string_token1] = {
+    .visible = false,
+    .named = false,
+  },
+  [sym_number] = {
+    .visible = true,
+    .named = true,
+  },
+  [anon_sym_true] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_false] = {
+    .visible = true,
+    .named = false,
+  },
+  [anon_sym_DOT] = {
+    .visible = true,
+    .named = false,
+  },
+  [sym_memberName] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_statement] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_expression] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_function] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym__arguments] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym__argument] = {
+    .visible = false,
+    .named = true,
+  },
+  [sym_string] = {
+    .visible = true,
+    .named = true,
+  },
+  [sym_boolean] = {
+    .visible = true,
+    .named = true,
+  },
+  [aux_sym__members] = {
+    .visible = false,
+    .named = false,
+  },
+  [sym__member] = {
+    .visible = false,
+    .named = true,
+  },
+  [aux_sym__arguments_repeat1] = {
+    .visible = false,
+    .named = false,
+  },
+};
+
+static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE_LENGTH] = {
+  [0] = {0},
+};
+
+static const uint16_t ts_non_terminal_alias_map[] = {
+  0,
+};
+
+static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
+  [0] = 0,
+  [1] = 1,
+  [2] = 2,
+  [3] = 3,
+  [4] = 4,
+  [5] = 5,
+  [6] = 6,
+  [7] = 7,
+  [8] = 8,
+  [9] = 9,
+  [10] = 10,
+  [11] = 11,
+  [12] = 12,
+  [13] = 13,
+  [14] = 14,
+  [15] = 15,
+  [16] = 16,
+  [17] = 17,
+  [18] = 18,
+  [19] = 19,
+  [20] = 20,
+  [21] = 21,
+  [22] = 22,
+  [23] = 23,
+  [24] = 24,
+  [25] = 25,
+};
+
+static bool ts_lex(TSLexer *lexer, TSStateId state) {
+  START_LEXER();
+  eof = lexer->eof(lexer);
+  switch (state) {
+    case 0:
+      if (eof) ADVANCE(4);
+      if (lookahead == '\'') ADVANCE(29);
+      if (lookahead == '(') ADVANCE(10);
+      if (lookahead == ')') ADVANCE(11);
+      if (lookahead == ',') ADVANCE(28);
+      if (lookahead == '.') ADVANCE(38);
+      if (lookahead == '[') ADVANCE(6);
+      if (lookahead == ']') ADVANCE(7);
+      if (lookahead == 'f') ADVANCE(12);
+      if (lookahead == 't') ADVANCE(20);
+      if (lookahead == '-' ||
+          lookahead == '_') ADVANCE(39);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(0)
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 1:
+      if (lookahead == '\'') ADVANCE(29);
+      if (lookahead == ')') ADVANCE(11);
+      if (lookahead == 'f') ADVANCE(13);
+      if (lookahead == 't') ADVANCE(21);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(1)
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(33);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 2:
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(2)
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 3:
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') SKIP(3)
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+      END_STATE();
+    case 4:
+      ACCEPT_TOKEN(ts_builtin_sym_end);
+      END_STATE();
+    case 5:
+      ACCEPT_TOKEN(sym_escapedStringLiteral);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(5);
+      END_STATE();
+    case 6:
+      ACCEPT_TOKEN(anon_sym_LBRACK);
+      if (lookahead == '[') ADVANCE(5);
+      END_STATE();
+    case 7:
+      ACCEPT_TOKEN(anon_sym_RBRACK);
+      END_STATE();
+    case 8:
+      ACCEPT_TOKEN(sym_stringLiteral);
+      if (lookahead == '\n') SKIP(8)
+      if (lookahead == '[') ADVANCE(6);
+      if (lookahead == '\t' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(8);
+      if (lookahead != 0) ADVANCE(9);
+      END_STATE();
+    case 9:
+      ACCEPT_TOKEN(sym_stringLiteral);
+      if (lookahead != 0 &&
+          lookahead != '\n') ADVANCE(9);
+      END_STATE();
+    case 10:
+      ACCEPT_TOKEN(anon_sym_LPAREN);
+      END_STATE();
+    case 11:
+      ACCEPT_TOKEN(anon_sym_RPAREN);
+      END_STATE();
+    case 12:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'a') ADVANCE(18);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 13:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'a') ADVANCE(19);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('b' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 14:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'e') ADVANCE(34);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 15:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'e') ADVANCE(36);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 16:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'e') ADVANCE(35);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 17:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'e') ADVANCE(37);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 18:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'l') ADVANCE(22);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 19:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'l') ADVANCE(23);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 20:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'r') ADVANCE(24);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 21:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'r') ADVANCE(25);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 22:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 's') ADVANCE(15);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 23:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 's') ADVANCE(17);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 24:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'u') ADVANCE(14);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 25:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == 'u') ADVANCE(16);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 26:
+      ACCEPT_TOKEN(sym_functionName);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 27:
+      ACCEPT_TOKEN(sym_functionName);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 28:
+      ACCEPT_TOKEN(anon_sym_COMMA);
+      END_STATE();
+    case 29:
+      ACCEPT_TOKEN(anon_sym_SQUOTE);
+      END_STATE();
+    case 30:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead == '\t' ||
+          lookahead == '\n' ||
+          lookahead == '\r' ||
+          lookahead == ' ') ADVANCE(30);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(31);
+      END_STATE();
+    case 31:
+      ACCEPT_TOKEN(aux_sym_string_token1);
+      if (lookahead != 0 &&
+          lookahead != '\'') ADVANCE(31);
+      END_STATE();
+    case 32:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(32);
+      if (lookahead == '-' ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+      END_STATE();
+    case 33:
+      ACCEPT_TOKEN(sym_number);
+      if (('0' <= lookahead && lookahead <= '9')) ADVANCE(33);
+      END_STATE();
+    case 34:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 35:
+      ACCEPT_TOKEN(anon_sym_true);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 36:
+      ACCEPT_TOKEN(anon_sym_false);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          lookahead == '_') ADVANCE(39);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(26);
+      END_STATE();
+    case 37:
+      ACCEPT_TOKEN(anon_sym_false);
+      if (('A' <= lookahead && lookahead <= 'Z') ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(27);
+      END_STATE();
+    case 38:
+      ACCEPT_TOKEN(anon_sym_DOT);
+      END_STATE();
+    case 39:
+      ACCEPT_TOKEN(sym_memberName);
+      if (lookahead == '-' ||
+          ('0' <= lookahead && lookahead <= '9') ||
+          ('A' <= lookahead && lookahead <= 'Z') ||
+          lookahead == '_' ||
+          ('a' <= lookahead && lookahead <= 'z')) ADVANCE(39);
+      END_STATE();
+    default:
+      return false;
+  }
+}
+
+static const TSLexMode ts_lex_modes[STATE_COUNT] = {
+  [0] = {.lex_state = 0},
+  [1] = {.lex_state = 8},
+  [2] = {.lex_state = 1},
+  [3] = {.lex_state = 1},
+  [4] = {.lex_state = 0},
+  [5] = {.lex_state = 0},
+  [6] = {.lex_state = 0},
+  [7] = {.lex_state = 0},
+  [8] = {.lex_state = 0},
+  [9] = {.lex_state = 0},
+  [10] = {.lex_state = 0},
+  [11] = {.lex_state = 0},
+  [12] = {.lex_state = 0},
+  [13] = {.lex_state = 0},
+  [14] = {.lex_state = 2},
+  [15] = {.lex_state = 0},
+  [16] = {.lex_state = 0},
+  [17] = {.lex_state = 3},
+  [18] = {.lex_state = 0},
+  [19] = {.lex_state = 0},
+  [20] = {.lex_state = 30},
+  [21] = {.lex_state = 0},
+  [22] = {.lex_state = 0},
+  [23] = {.lex_state = 0},
+  [24] = {.lex_state = 0},
+  [25] = {.lex_state = 0},
+};
+
+static const uint16_t ts_parse_table[LARGE_STATE_COUNT][SYMBOL_COUNT] = {
+  [0] = {
+    [ts_builtin_sym_end] = ACTIONS(1),
+    [sym_escapedStringLiteral] = ACTIONS(1),
+    [anon_sym_LBRACK] = ACTIONS(1),
+    [anon_sym_RBRACK] = ACTIONS(1),
+    [anon_sym_LPAREN] = ACTIONS(1),
+    [anon_sym_RPAREN] = ACTIONS(1),
+    [sym_functionName] = ACTIONS(1),
+    [anon_sym_COMMA] = ACTIONS(1),
+    [anon_sym_SQUOTE] = ACTIONS(1),
+    [sym_number] = ACTIONS(1),
+    [anon_sym_true] = ACTIONS(1),
+    [anon_sym_false] = ACTIONS(1),
+    [anon_sym_DOT] = ACTIONS(1),
+    [sym_memberName] = ACTIONS(1),
+  },
+  [1] = {
+    [sym_statement] = STATE(25),
+    [sym_expression] = STATE(23),
+    [sym_escapedStringLiteral] = ACTIONS(3),
+    [anon_sym_LBRACK] = ACTIONS(5),
+    [sym_stringLiteral] = ACTIONS(3),
+  },
+};
+
+static const uint16_t ts_small_parse_table[] = {
+  [0] = 7,
+    ACTIONS(7), 1,
+      anon_sym_RPAREN,
+    ACTIONS(9), 1,
+      sym_functionName,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(13), 1,
+      sym_number,
+    STATE(21), 1,
+      sym__arguments,
+    ACTIONS(15), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(9), 4,
+      sym_function,
+      sym__argument,
+      sym_string,
+      sym_boolean,
+  [26] = 5,
+    ACTIONS(9), 1,
+      sym_functionName,
+    ACTIONS(11), 1,
+      anon_sym_SQUOTE,
+    ACTIONS(17), 1,
+      sym_number,
+    ACTIONS(15), 2,
+      anon_sym_true,
+      anon_sym_false,
+    STATE(16), 4,
+      sym_function,
+      sym__argument,
+      sym_string,
+      sym_boolean,
+  [46] = 3,
+    ACTIONS(19), 1,
+      anon_sym_RBRACK,
+    ACTIONS(21), 1,
+      anon_sym_DOT,
+    STATE(4), 2,
+      aux_sym__members,
+      sym__member,
+  [57] = 1,
+    ACTIONS(24), 4,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_DOT,
+  [64] = 1,
+    ACTIONS(26), 4,
+      anon_sym_RBRACK,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+      anon_sym_DOT,
+  [71] = 3,
+    ACTIONS(28), 1,
+      anon_sym_RBRACK,
+    ACTIONS(30), 1,
+      anon_sym_DOT,
+    STATE(8), 2,
+      aux_sym__members,
+      sym__member,
+  [82] = 3,
+    ACTIONS(30), 1,
+      anon_sym_DOT,
+    ACTIONS(32), 1,
+      anon_sym_RBRACK,
+    STATE(4), 2,
+      aux_sym__members,
+      sym__member,
+  [93] = 3,
+    ACTIONS(34), 1,
+      anon_sym_RPAREN,
+    ACTIONS(36), 1,
+      anon_sym_COMMA,
+    STATE(10), 1,
+      aux_sym__arguments_repeat1,
+  [103] = 3,
+    ACTIONS(36), 1,
+      anon_sym_COMMA,
+    ACTIONS(38), 1,
+      anon_sym_RPAREN,
+    STATE(11), 1,
+      aux_sym__arguments_repeat1,
+  [113] = 3,
+    ACTIONS(40), 1,
+      anon_sym_RPAREN,
+    ACTIONS(42), 1,
+      anon_sym_COMMA,
+    STATE(11), 1,
+      aux_sym__arguments_repeat1,
+  [123] = 1,
+    ACTIONS(45), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [128] = 1,
+    ACTIONS(47), 2,
+      anon_sym_RBRACK,
+      anon_sym_DOT,
+  [133] = 2,
+    ACTIONS(49), 1,
+      sym_functionName,
+    STATE(7), 1,
+      sym_function,
+  [140] = 1,
+    ACTIONS(51), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [145] = 1,
+    ACTIONS(40), 2,
+      anon_sym_RPAREN,
+      anon_sym_COMMA,
+  [150] = 1,
+    ACTIONS(53), 1,
+      sym_memberName,
+  [154] = 1,
+    ACTIONS(55), 1,
+      ts_builtin_sym_end,
+  [158] = 1,
+    ACTIONS(57), 1,
+      anon_sym_LPAREN,
+  [162] = 1,
+    ACTIONS(59), 1,
+      aux_sym_string_token1,
+  [166] = 1,
+    ACTIONS(61), 1,
+      anon_sym_RPAREN,
+  [170] = 1,
+    ACTIONS(63), 1,
+      ts_builtin_sym_end,
+  [174] = 1,
+    ACTIONS(65), 1,
+      ts_builtin_sym_end,
+  [178] = 1,
+    ACTIONS(67), 1,
+      anon_sym_SQUOTE,
+  [182] = 1,
+    ACTIONS(69), 1,
+      ts_builtin_sym_end,
+};
+
+static const uint32_t ts_small_parse_table_map[] = {
+  [SMALL_STATE(2)] = 0,
+  [SMALL_STATE(3)] = 26,
+  [SMALL_STATE(4)] = 46,
+  [SMALL_STATE(5)] = 57,
+  [SMALL_STATE(6)] = 64,
+  [SMALL_STATE(7)] = 71,
+  [SMALL_STATE(8)] = 82,
+  [SMALL_STATE(9)] = 93,
+  [SMALL_STATE(10)] = 103,
+  [SMALL_STATE(11)] = 113,
+  [SMALL_STATE(12)] = 123,
+  [SMALL_STATE(13)] = 128,
+  [SMALL_STATE(14)] = 133,
+  [SMALL_STATE(15)] = 140,
+  [SMALL_STATE(16)] = 145,
+  [SMALL_STATE(17)] = 150,
+  [SMALL_STATE(18)] = 154,
+  [SMALL_STATE(19)] = 158,
+  [SMALL_STATE(20)] = 162,
+  [SMALL_STATE(21)] = 166,
+  [SMALL_STATE(22)] = 170,
+  [SMALL_STATE(23)] = 174,
+  [SMALL_STATE(24)] = 178,
+  [SMALL_STATE(25)] = 182,
+};
+
+static const TSParseActionEntry ts_parse_actions[] = {
+  [0] = {.entry = {.count = 0, .reusable = false}},
+  [1] = {.entry = {.count = 1, .reusable = false}}, RECOVER(),
+  [3] = {.entry = {.count = 1, .reusable = false}}, SHIFT(23),
+  [5] = {.entry = {.count = 1, .reusable = false}}, SHIFT(14),
+  [7] = {.entry = {.count = 1, .reusable = true}}, SHIFT(6),
+  [9] = {.entry = {.count = 1, .reusable = false}}, SHIFT(19),
+  [11] = {.entry = {.count = 1, .reusable = true}}, SHIFT(20),
+  [13] = {.entry = {.count = 1, .reusable = true}}, SHIFT(9),
+  [15] = {.entry = {.count = 1, .reusable = false}}, SHIFT(12),
+  [17] = {.entry = {.count = 1, .reusable = true}}, SHIFT(16),
+  [19] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__members, 2),
+  [21] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__members, 2), SHIFT_REPEAT(17),
+  [24] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 4),
+  [26] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function, 3),
+  [28] = {.entry = {.count = 1, .reusable = true}}, SHIFT(18),
+  [30] = {.entry = {.count = 1, .reusable = true}}, SHIFT(17),
+  [32] = {.entry = {.count = 1, .reusable = true}}, SHIFT(22),
+  [34] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__arguments, 1),
+  [36] = {.entry = {.count = 1, .reusable = true}}, SHIFT(3),
+  [38] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__arguments, 2),
+  [40] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__arguments_repeat1, 2),
+  [42] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__arguments_repeat1, 2), SHIFT_REPEAT(3),
+  [45] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean, 1),
+  [47] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__member, 2),
+  [49] = {.entry = {.count = 1, .reusable = true}}, SHIFT(19),
+  [51] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3),
+  [53] = {.entry = {.count = 1, .reusable = true}}, SHIFT(13),
+  [55] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 3),
+  [57] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2),
+  [59] = {.entry = {.count = 1, .reusable = true}}, SHIFT(24),
+  [61] = {.entry = {.count = 1, .reusable = true}}, SHIFT(5),
+  [63] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression, 4),
+  [65] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_statement, 1),
+  [67] = {.entry = {.count = 1, .reusable = true}}, SHIFT(15),
+  [69] = {.entry = {.count = 1, .reusable = true}},  ACCEPT_INPUT(),
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#ifdef _WIN32
+#define extern __declspec(dllexport)
+#endif
+
+extern const TSLanguage *tree_sitter_dscexpression(void) {
+  static const TSLanguage language = {
+    .version = LANGUAGE_VERSION,
+    .symbol_count = SYMBOL_COUNT,
+    .alias_count = ALIAS_COUNT,
+    .token_count = TOKEN_COUNT,
+    .external_token_count = EXTERNAL_TOKEN_COUNT,
+    .state_count = STATE_COUNT,
+    .large_state_count = LARGE_STATE_COUNT,
+    .production_id_count = PRODUCTION_ID_COUNT,
+    .field_count = FIELD_COUNT,
+    .max_alias_sequence_length = MAX_ALIAS_SEQUENCE_LENGTH,
+    .parse_table = &ts_parse_table[0][0],
+    .small_parse_table = ts_small_parse_table,
+    .small_parse_table_map = ts_small_parse_table_map,
+    .parse_actions = ts_parse_actions,
+    .symbol_names = ts_symbol_names,
+    .symbol_metadata = ts_symbol_metadata,
+    .public_symbol_map = ts_symbol_map,
+    .alias_map = ts_non_terminal_alias_map,
+    .alias_sequences = &ts_alias_sequences[0][0],
+    .lex_modes = ts_lex_modes,
+    .lex_fn = ts_lex,
+    .primary_state_ids = ts_primary_state_ids,
+  };
+  return &language;
+}
+#ifdef __cplusplus
+}
+#endif

--- a/tree-sitter-dscexpression/src/tree_sitter/parser.h
+++ b/tree-sitter-dscexpression/src/tree_sitter/parser.h
@@ -1,0 +1,224 @@
+#ifndef TREE_SITTER_PARSER_H_
+#define TREE_SITTER_PARSER_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#define ts_builtin_sym_error ((TSSymbol)-1)
+#define ts_builtin_sym_end 0
+#define TREE_SITTER_SERIALIZATION_BUFFER_SIZE 1024
+
+typedef uint16_t TSStateId;
+
+#ifndef TREE_SITTER_API_H_
+typedef uint16_t TSSymbol;
+typedef uint16_t TSFieldId;
+typedef struct TSLanguage TSLanguage;
+#endif
+
+typedef struct {
+  TSFieldId field_id;
+  uint8_t child_index;
+  bool inherited;
+} TSFieldMapEntry;
+
+typedef struct {
+  uint16_t index;
+  uint16_t length;
+} TSFieldMapSlice;
+
+typedef struct {
+  bool visible;
+  bool named;
+  bool supertype;
+} TSSymbolMetadata;
+
+typedef struct TSLexer TSLexer;
+
+struct TSLexer {
+  int32_t lookahead;
+  TSSymbol result_symbol;
+  void (*advance)(TSLexer *, bool);
+  void (*mark_end)(TSLexer *);
+  uint32_t (*get_column)(TSLexer *);
+  bool (*is_at_included_range_start)(const TSLexer *);
+  bool (*eof)(const TSLexer *);
+};
+
+typedef enum {
+  TSParseActionTypeShift,
+  TSParseActionTypeReduce,
+  TSParseActionTypeAccept,
+  TSParseActionTypeRecover,
+} TSParseActionType;
+
+typedef union {
+  struct {
+    uint8_t type;
+    TSStateId state;
+    bool extra;
+    bool repetition;
+  } shift;
+  struct {
+    uint8_t type;
+    uint8_t child_count;
+    TSSymbol symbol;
+    int16_t dynamic_precedence;
+    uint16_t production_id;
+  } reduce;
+  uint8_t type;
+} TSParseAction;
+
+typedef struct {
+  uint16_t lex_state;
+  uint16_t external_lex_state;
+} TSLexMode;
+
+typedef union {
+  TSParseAction action;
+  struct {
+    uint8_t count;
+    bool reusable;
+  } entry;
+} TSParseActionEntry;
+
+struct TSLanguage {
+  uint32_t version;
+  uint32_t symbol_count;
+  uint32_t alias_count;
+  uint32_t token_count;
+  uint32_t external_token_count;
+  uint32_t state_count;
+  uint32_t large_state_count;
+  uint32_t production_id_count;
+  uint32_t field_count;
+  uint16_t max_alias_sequence_length;
+  const uint16_t *parse_table;
+  const uint16_t *small_parse_table;
+  const uint32_t *small_parse_table_map;
+  const TSParseActionEntry *parse_actions;
+  const char * const *symbol_names;
+  const char * const *field_names;
+  const TSFieldMapSlice *field_map_slices;
+  const TSFieldMapEntry *field_map_entries;
+  const TSSymbolMetadata *symbol_metadata;
+  const TSSymbol *public_symbol_map;
+  const uint16_t *alias_map;
+  const TSSymbol *alias_sequences;
+  const TSLexMode *lex_modes;
+  bool (*lex_fn)(TSLexer *, TSStateId);
+  bool (*keyword_lex_fn)(TSLexer *, TSStateId);
+  TSSymbol keyword_capture_token;
+  struct {
+    const bool *states;
+    const TSSymbol *symbol_map;
+    void *(*create)(void);
+    void (*destroy)(void *);
+    bool (*scan)(void *, TSLexer *, const bool *symbol_whitelist);
+    unsigned (*serialize)(void *, char *);
+    void (*deserialize)(void *, const char *, unsigned);
+  } external_scanner;
+  const TSStateId *primary_state_ids;
+};
+
+/*
+ *  Lexer Macros
+ */
+
+#define START_LEXER()           \
+  bool result = false;          \
+  bool skip = false;            \
+  bool eof = false;             \
+  int32_t lookahead;            \
+  goto start;                   \
+  next_state:                   \
+  lexer->advance(lexer, skip);  \
+  start:                        \
+  skip = false;                 \
+  lookahead = lexer->lookahead;
+
+#define ADVANCE(state_value) \
+  {                          \
+    state = state_value;     \
+    goto next_state;         \
+  }
+
+#define SKIP(state_value) \
+  {                       \
+    skip = true;          \
+    state = state_value;  \
+    goto next_state;      \
+  }
+
+#define ACCEPT_TOKEN(symbol_value)     \
+  result = true;                       \
+  lexer->result_symbol = symbol_value; \
+  lexer->mark_end(lexer);
+
+#define END_STATE() return result;
+
+/*
+ *  Parse Table Macros
+ */
+
+#define SMALL_STATE(id) id - LARGE_STATE_COUNT
+
+#define STATE(id) id
+
+#define ACTIONS(id) id
+
+#define SHIFT(state_value)            \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value            \
+    }                                 \
+  }}
+
+#define SHIFT_REPEAT(state_value)     \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .state = state_value,           \
+      .repetition = true              \
+    }                                 \
+  }}
+
+#define SHIFT_EXTRA()                 \
+  {{                                  \
+    .shift = {                        \
+      .type = TSParseActionTypeShift, \
+      .extra = true                   \
+    }                                 \
+  }}
+
+#define REDUCE(symbol_val, child_count_val, ...) \
+  {{                                             \
+    .reduce = {                                  \
+      .type = TSParseActionTypeReduce,           \
+      .symbol = symbol_val,                      \
+      .child_count = child_count_val,            \
+      __VA_ARGS__                                \
+    },                                           \
+  }}
+
+#define RECOVER()                    \
+  {{                                 \
+    .type = TSParseActionTypeRecover \
+  }}
+
+#define ACCEPT_INPUT()              \
+  {{                                \
+    .type = TSParseActionTypeAccept \
+  }}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // TREE_SITTER_PARSER_H_


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

ARM expressions are used as values of JSON properties:

```json
{
  "foo": "[function(arg1, arg2)]"
}
```

They are identified by the square brackets.  To have a literal square bracket as a string instead of an expression, you need to double it: `[[this is just a string]` which would be used as `[this is just a string]`.  Anything else would be treated as a string literal.

Function args can take other functions.  Strings passed to functions need to be surrounded by single-quotes.

Functions can return JSON objects which can be accessed by dot-notation: `[functionReturnObject().prop1.prop2]`.

Tree-sitter grammar for expressions in DSC (as defined by ARM)
Includes the generated source code as it only needs to be generated if the grammar changes.  Since this is generated code, having it as `unclean` as clippy complains.

The only files worth reviewing (as they aren't generated) is `grammar.js` and the two test `.txt` files