### PR TITLE
(GH-224) Convert schema constants to enums

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,11 +16,11 @@
     "json.schemas": [
         {
             "fileMatch": ["**/*.dsc.resource.json"],
-            "url": "/schemas/2023/08/bundled/resource/manifest.vscode.json"
+            "url": "/schemas/2023/10/bundled/resource/manifest.vscode.json"
         }
     ],
     "yaml.schemas": {
-        "schemas/2023/08/bundled/config/document.vscode.json": "**.dsc.{yaml,yml,config.yaml,config.yml}",
-        "schemas/2023/08/bundled/resource/manifest.vscode.json": "**.dsc.resource.{yaml,yml}"
+        "schemas/2023/10/bundled/config/document.vscode.json": "**.dsc.{yaml,yml,config.yaml,config.yml}",
+        "schemas/2023/10/bundled/resource/manifest.vscode.json": "**.dsc.resource.{yaml,yml}"
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,15 @@ changes since the last release, see the [diff on GitHub][unreleased].
 
 ### Changed
 
-- Replaced the `_ensure` well-known property with the boolean [_exist][21] property. This improves
+- Updated the canonical version of the schema URIs from `2023/08` to `2023/10`, as this release
+  includes breaking changes for the schemas.
+
+  As part of this change, the `$schema` keyword for both [configuration documents][21] and
+  [resource manifests][22] accepts any valid URI for the schemas, instead of only one. Now, you
+  can set the value for the keyword to the unbundled schema, the bundled schema, or the enhanced
+  authoring schema for any supported version.
+
+- Replaced the `_ensure` well-known property with the boolean [_exist][23] property. This improves
   the semantics for users and simplifies implementation for resources, replacing the string enum
   values `Present` and `Absent` with `true` and `false` respectively.
 
@@ -61,7 +69,7 @@ changes since the last release, see the [diff on GitHub][unreleased].
 
 ### Added
 
-- Added the [--input][22] and [--input-file][23] global options to the root `dsc` command. Now, you
+- Added the [--input][24] and [--input-file][25] global options to the root `dsc` command. Now, you
   can pass input to DSC from a variable or file instead of piping from stdin.
 
   <details><summary>Related work items</summary>
@@ -81,7 +89,7 @@ changes since the last release, see the [diff on GitHub][unreleased].
 
   </details>
 
-- Added the new [completer][24] command enables users to add shell completions for DSC to their
+- Added the new [completer][26] command enables users to add shell completions for DSC to their
   shell. The command supports completions for Bash, Elvish, fish, PowerShell, and ZSH.
 
   <details><summary>Related work items</summary>
@@ -394,10 +402,12 @@ For the full list of changes in this release, see the [diff on GitHub][compare-v
 [20]: docs/reference/schemas/resource/manifest/test.md#input
 
 <!-- alpha.4 links -->
-[21]: docs/reference/schemas/resource/properties/exist.md
-[22]: docs/reference/cli/dsc.md#-i---input
-[23]: docs/reference/cli/dsc.md#-p---input-file
-[24]: docs/reference/cli/completer/command.md
+[21]: docs/reference/schemas/config/document.md#schema
+[22]: docs/reference/schemas/resource/manifest/root.md#schema
+[23]: docs/reference/schemas/resource/properties/exist.md
+[24]: docs/reference/cli/dsc.md#-i---input
+[25]: docs/reference/cli/dsc.md#-p---input-file
+[26]: docs/reference/cli/completer/command.md
 
 <!-- Issue and PR links -->
 [#107]: https://github.com/PowerShell/DSC/issues/107

--- a/docs/reference/cli/config/get.md
+++ b/docs/reference/cli/config/get.md
@@ -34,12 +34,12 @@ document saved as `example.dsc.config.yaml`.
 
 ```yaml
 # example.dsc.config.yaml
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Windows only
   type: DSC/AssertionGroup
   properties:
-    $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
     resources:
     - name: os
       type: Microsoft/OSInfo

--- a/docs/reference/cli/config/set.md
+++ b/docs/reference/cli/config/set.md
@@ -35,12 +35,12 @@ The command inspects the resource instances defined in the configuration documen
 
 ```yaml
 # example.dsc.config.yaml
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Windows only
   type: DSC/AssertionGroup
   properties:
-    $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
     resources:
     - name: os
       type: Microsoft/OSInfo

--- a/docs/reference/cli/config/test.md
+++ b/docs/reference/cli/config/test.md
@@ -34,12 +34,12 @@ resource instances defined in the configuration document saved as `example.dsc.c
 
 ```yaml
 # example.dsc.config.yaml
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Windows only
   type: DSC/AssertionGroup
   properties:
-    $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
     resources:
     - name: os
       type: Microsoft/OSInfo

--- a/docs/reference/schemas/config/document.md
+++ b/docs/reference/schemas/config/document.md
@@ -15,7 +15,7 @@ The YAML or JSON file that defines a DSC Configuration.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 Type:          object
 ```
 
@@ -50,16 +50,46 @@ Every configuration document must include these properties:
 
 ### $schema
 
-The `$schema` property indicates the canonical URI for the version of this schema that the document
+The `$schema` property indicates the canonical URL for the version of this schema that the document
 adheres to. DSC uses this property when validating the configuration document before any
 configuration operations.
+
+For every version of the schema, there are three valid urls:
+
+- `.../config/document.json`
+
+  The URL to the canonical non-bundled schema. When it's used for validation, the validating client
+  needs to retrieve this schema and every schema it references.
+
+- `.../bundled/config/document.json`
+
+  The URL to the bundled schema. When it's used for validation, the validating client only needs to
+  retrieve this schema.
+
+  This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can still
+  validate the document when it uses this schema, other tools may error or behave in unexpected
+  ways.
+
+- `.../bundled/config/document.vscode.json`
+
+  The URL to the enhanced authoring schema. This schema is much larger than the other schemas, as
+  it includes additional definitions that provide contextual help and snippets that the others
+  don't include.
+
+  This schema uses keywords that are only recognized by VS Code. While DSC can still validate the
+  document when it uses this schema, other tools may error or behave in unexpected ways.
 
 ```yaml
 Type:        string
 Required:    true
 Format:      URI
 ValidValues: [
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.vscode.json
                https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.vscode.json
              ]
 ```
 
@@ -93,7 +123,7 @@ For more information about defining parameters in a configuration, see
 ```yaml
 Type:                object
 Required:            false
-ValidPropertySchema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
+ValidPropertySchema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json
 ```
 
 ### variables
@@ -129,7 +159,7 @@ For more information about defining a valid resource instance in a configuration
 Type:             array
 Required:         true
 MinimumItemCount: 1
-ValidItemSchema:  https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
+ValidItemSchema:  https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json
 ```
 
 <!-- [01]: ../../../configurations/overview.md -->

--- a/docs/reference/schemas/config/parameter.md
+++ b/docs/reference/schemas/config/parameter.md
@@ -15,7 +15,7 @@ Defines runtime options for a configuration.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.parameter.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/config/resource.md
+++ b/docs/reference/schemas/config/resource.md
@@ -15,7 +15,7 @@ Defines a DSC Resource instance in a configuration document.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.resource.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/definitions/message.md
+++ b/docs/reference/schemas/definitions/message.md
@@ -15,7 +15,7 @@ A message emitted by a DSC Resource with associated metadata.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/message.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/definitions/parameters/dataTypes.md
+++ b/docs/reference/schemas/definitions/parameters/dataTypes.md
@@ -15,7 +15,7 @@ Defines valid data types for a DSC configuration parameter
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/parameters/dataTypes.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json
 Type:          string
 ValidValues:   [array, bool, int, object, string, secureobject, securestring]
 ```

--- a/docs/reference/schemas/definitions/resourceType.md
+++ b/docs/reference/schemas/definitions/resourceType.md
@@ -15,7 +15,7 @@ Identifies a DSC Resource.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/definitions/resourceType.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json
 Type:          string
 Pattern:       ^\w+(\.\w+){0,2}\/\w+$
 ```

--- a/docs/reference/schemas/outputs/config/get.md
+++ b/docs/reference/schemas/outputs/config/get.md
@@ -15,7 +15,7 @@ The result output from the `dsc config get` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/get.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/get.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/outputs/config/set.md
+++ b/docs/reference/schemas/outputs/config/set.md
@@ -15,7 +15,7 @@ The result output from the `dsc config set` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/set.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/set.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/outputs/config/test.md
+++ b/docs/reference/schemas/outputs/config/test.md
@@ -15,7 +15,7 @@ The result output from the `dsc config test` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/config/test.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/test.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/outputs/resource/get.md
+++ b/docs/reference/schemas/outputs/resource/get.md
@@ -15,7 +15,7 @@ The result output from the `dsc resource get` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/get.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/outputs/resource/list.md
+++ b/docs/reference/schemas/outputs/resource/list.md
@@ -15,7 +15,7 @@ The result output from the `dsc resource list` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/list.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/list.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/outputs/resource/set.md
+++ b/docs/reference/schemas/outputs/resource/set.md
@@ -15,7 +15,7 @@ The result output from the `dsc resource set` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/set.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/outputs/resource/test.md
+++ b/docs/reference/schemas/outputs/resource/test.md
@@ -15,7 +15,7 @@ The result output from the `dsc resource test` command.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/outputs/resource/test.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/export.md
+++ b/docs/reference/schemas/resource/manifest/export.md
@@ -15,7 +15,7 @@ Defines how to retrieve the current state of every instance for a DSC Resource.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.export.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/get.md
+++ b/docs/reference/schemas/resource/manifest/get.md
@@ -15,7 +15,7 @@ Defines how to retrieve a DSC Resource instance.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.get.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/provider.md
+++ b/docs/reference/schemas/resource/manifest/provider.md
@@ -15,7 +15,7 @@ Defines a DSC Resource as a DSC Resource Provider.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.provider.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/root.md
+++ b/docs/reference/schemas/resource/manifest/root.md
@@ -15,7 +15,7 @@ The JSON file that defines a command-based DSC Resource.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json
 Type:          object
 ```
 
@@ -46,12 +46,42 @@ The `$schema` property indicates the canonical URI of this schema that the manif
 against. This property is mandatory. DSC uses this value to validate the manifest against the
 correct JSON schema.
 
+For every version of the schema, there are three valid urls:
+
+- `.../resource/manifest.json`
+
+  The URL to the canonical non-bundled schema. When it's used for validation, the validating client
+  needs to retrieve this schema and every schema it references.
+
+- `.../bundled/resource/manifest.json`
+
+  The URL to the bundled schema. When it's used for validation, the validating client only needs to
+  retrieve this schema.
+
+  This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can still
+  validate the document when it uses this schema, other tools may error or behave in unexpected
+  ways.
+
+- `.../bundled/resource/manifest.vscode.json`
+
+  The URL to the enhanced authoring schema. This schema is much larger than the other schemas, as
+  it includes additional definitions that provide contextual help and snippets that the others
+  don't include.
+
+  This schema uses keywords that are only recognized by VS Code. While DSC can still validate the
+  document when it uses this schema, other tools may error or behave in unexpected ways.
+
 ```yaml
 Type:        string
 Required:    true
 Format:      URI
 ValidValues: [
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json
                https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json
+               https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.vscode.json
              ]
 ```
 

--- a/docs/reference/schemas/resource/manifest/schema/embedded.md
+++ b/docs/reference/schemas/resource/manifest/schema/embedded.md
@@ -15,7 +15,7 @@ Defines a JSON Schema that validates a DSC Resource instance.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json#/properties/embedded
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json#/properties/embedded
 Type:          object
 ```
 
@@ -91,24 +91,23 @@ processing. The well-known properties always start with an underscore (`_`) and 
 use these properties may not override or extend them. If a resource specifies a well-known property
 in the embedded schema, the schema _must_ define the property as a reference.
 
-- [_ensure](#_ensure)
+- [_exist](#_exist)
 - [_inDesiredState](#_indesiredstate)
 - [_purge](#_purge)
 - [_rebootRequested](#_rebootrequested)
 
-#### _ensure
+#### _exist
 
-The `_ensure` property indicates that the resource can enforce whether instances exist using the
-shared present and absent semantics. If a resource must distinguish between states beyond whether
-an instance is present or absent, the resource should define its own `ensure` property without the
-leading underscore. This property provides shared semantics for DSC Resources and integrating
-tools, but doesn't enable any additional built-in processing with DSC.
+The `_exist` property indicates that the resource can enforce whether instances exist, handling
+whether an instance should be added, updated, or removed during a set operation. This property
+provides shared semantics for DSC Resources and integrating tools, but doesn't enable any
+additional built-in processing with DSC.
 
 If defined, this property must be a reference to the schema for the well-known property:
 
 ```json
-"_ensure": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/ensure.json"
+"_exist": {
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json"
 }
 ```
 
@@ -124,7 +123,7 @@ If defined, this property must be a reference to the schema for the well-known p
 
 ```json
 "_inDesiredState": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json"
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json"
 }
 ```
 
@@ -140,7 +139,7 @@ If defined, this property must be a reference to the schema for the well-known p
 
 ```json
 "_inDesiredState": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json"
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json"
 }
 ```
 
@@ -156,7 +155,7 @@ If defined, this property must be a reference to the schema for the well-known p
 
 ```json
 "_rebootRequested": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json"
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json"
 }
 ```
 

--- a/docs/reference/schemas/resource/manifest/schema/property.md
+++ b/docs/reference/schemas/resource/manifest/schema/property.md
@@ -15,7 +15,7 @@ Defines how to retrieve the JSON Schema that validates a DSC Resource instance.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.schema.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/set.md
+++ b/docs/reference/schemas/resource/manifest/set.md
@@ -15,7 +15,7 @@ Defines how to enforce state for a DSC Resource instance.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.set.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/test.md
+++ b/docs/reference/schemas/resource/manifest/test.md
@@ -15,7 +15,7 @@ Defines how to test whether a DSC Resource instance is in the desired state.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.test.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/manifest/validate.md
+++ b/docs/reference/schemas/resource/manifest/validate.md
@@ -15,7 +15,7 @@ This property
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.validate.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json
 Type:          object
 ```
 

--- a/docs/reference/schemas/resource/properties/inDesiredState.md
+++ b/docs/reference/schemas/resource/properties/inDesiredState.md
@@ -15,7 +15,7 @@ Indicates whether an instance is in the desired state.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json
 Type:          [boolean, 'null']
 ReadOnly:      true
 ```
@@ -43,7 +43,7 @@ snippet:
 
 ```json
 "_inDesiredState": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/inDesiredState.json"
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json"
 }
 ```
 

--- a/docs/reference/schemas/resource/properties/purge.md
+++ b/docs/reference/schemas/resource/properties/purge.md
@@ -15,7 +15,7 @@ Indicates that the resource should treat non-defined entries in a list as invali
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json
 Type:          [boolean, 'null']
 WriteOnly:     true
 ```
@@ -44,6 +44,6 @@ snippet:
 
 ```json
 "_inDesiredState": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/purge.json"
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json"
 }
 ```

--- a/docs/reference/schemas/resource/properties/rebootRequested.md
+++ b/docs/reference/schemas/resource/properties/rebootRequested.md
@@ -15,7 +15,7 @@ Indicates whether an instance is in the desired state.
 
 ```yaml
 SchemaDialect: https://json-schema.org/draft/2020-12/schema
-SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json
+SchemaID:      https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json
 Type:          [boolean, 'null']
 ReadOnly:      true
 ```
@@ -43,6 +43,6 @@ snippet:
 
 ```json
 "_rebootRequested": {
-  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/properties/rebootRequested.json"
+  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json"
 }
 ```

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -163,7 +163,7 @@ pub fn export(dsc: &mut DscManager, resource: &str, format: &Option<OutputFormat
     let mut conf = Configuration::new();
 
     match add_resource_export_results_to_configuration(&dsc_resource, &mut conf) {
-        Ok(_) => (),
+        Ok(()) => (),
         Err(err) => {
             error!("Error: {err}");
             exit(EXIT_DSC_ERROR);
@@ -191,7 +191,7 @@ pub fn get_resource(dsc: &mut DscManager, resource: &str) -> DscResource {
             }
 
             match dsc.initialize_discovery() {
-                Ok(_) => (),
+                Ok(()) => (),
                 Err(err) => {
                     error!("Error: {err}");
                     exit(EXIT_DSC_ERROR);

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -273,7 +273,7 @@ pub fn validate_config(config: &str) {
                     };
                     let properties = resource_block["properties"].clone();
                     let _result: Result<(), ValidationError> = match compiled_schema.validate(&properties) {
-                        Ok(_) => Ok(()),
+                        Ok(()) => Ok(()),
                         Err(err) => {
                             let mut error = String::new();
                             for e in err {
@@ -304,7 +304,7 @@ pub fn resource(subcommand: &ResourceSubCommand, format: &Option<OutputFormat>, 
     match subcommand {
         ResourceSubCommand::List { resource_name, description, tags } => {
             match dsc.initialize_discovery() {
-                Ok(_) => (),
+                Ok(()) => (),
                 Err(err) => {
                     error!("Error: {err}");
                     exit(EXIT_DSC_ERROR);

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -25,7 +25,7 @@ Describe 'resource export tests' {
     It 'Export can be called on a configuration' {
 
         $yaml = @'
-            $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+            $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
             resources:
             - name: Processes
               type: Microsoft/Process
@@ -43,7 +43,7 @@ Describe 'resource export tests' {
     It 'Configuration Export can be piped to configuration Set' -Skip:(!$IsWindows) {
 
         $yaml = @'
-            $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+            $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
             resources:
             - name: Processes
               type: Microsoft/Process
@@ -59,7 +59,7 @@ Describe 'resource export tests' {
     It 'Duplicate resource types in Configuration Export should result in error' {
 
         $yaml = @'
-            $schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+            $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
             resources:
             - name: Processes
               type: Microsoft/Process

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 #[serde(deny_unknown_fields)]
 pub struct Configuration {
     #[serde(rename = "$schema")]
-    pub schema: String,
+    pub schema: DocumentSchemaUri,
     // `contentVersion` is required by ARM, but doesn't serve a purpose here
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<HashMap<String, Parameter>>,
@@ -78,12 +78,28 @@ pub struct Resource {
     pub properties: Option<HashMap<String, Value>>,
 }
 
-const SCHEMA: &str = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json";
+// Defines the valid and recognized canonical URIs for the configuration schema
+#[derive(Debug, Default, Clone, Copy, Hash, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum DocumentSchemaUri {
+    #[default]
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json")]
+    Version2023_10,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.json")]
+    Bundled2023_10,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.vscode.json")]
+    VSCode2023_10,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json")]
+    Version2023_08,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.json")]
+    Bundled2023_08,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.vscode.json")]
+    VSCode2023_08,
+}
 
 impl Default for Configuration {
     fn default() -> Self {
         Self {
-            schema: SCHEMA.to_string(),
+            schema: DocumentSchemaUri::Version2023_08,
             parameters: None,
             variables: None,
             resources: Vec::new(),
@@ -96,7 +112,7 @@ impl Configuration {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            schema: SCHEMA.to_string(),
+            schema: DocumentSchemaUri::Version2023_08,
             parameters: None,
             variables: None,
             resources: Vec::new(),

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -493,7 +493,7 @@ fn verify_json(resource: &ResourceManifest, cwd: &str, json: &str) -> Result<(),
     };
     let json: Value = serde_json::from_str(json)?;
     let result = match compiled_schema.validate(&json) {
-        Ok(_) => Ok(()),
+        Ok(()) => Ok(()),
         Err(err) => {
             let mut error = String::new();
             for e in err {

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -13,7 +13,7 @@ use crate::dscerror::DscError;
 pub struct ResourceManifest {
     /// The version of the resource manifest schema.
     #[serde(rename = "$schema")]
-    pub schema_version: String,
+    pub schema_version: ManifestSchemaUri,
     /// The namespaced name of the resource.
     #[serde(rename = "type")]
     pub resource_type: String,
@@ -46,6 +46,24 @@ pub struct ResourceManifest {
     /// Details how to get the schema of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<SchemaKind>,
+}
+
+// Defines the valid and recognized canonical URIs for the manifest schema
+#[derive(Debug, Default, Clone, Copy, Hash, Eq, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum ManifestSchemaUri {
+    #[default]
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json")]
+    Version2023_10,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json")]
+    Bundled2023_10,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json")]
+    VSCode2023_10,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json")]
+    Version2023_08,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json")]
+    Bundled2023_08,
+    #[serde(rename = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.vscode.json")]
+    VSCode2023_08,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -188,11 +206,11 @@ pub struct ListMethod {
 ///
 /// * `DscError` - The JSON value is invalid or the schema version is not supported.
 pub fn import_manifest(manifest: Value) -> Result<ResourceManifest, DscError> {
-    const MANIFEST_SCHEMA_VERSION: &str = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json";
+    // const MANIFEST_SCHEMA_VERSION: &str = "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json";
     let manifest = serde_json::from_value::<ResourceManifest>(manifest)?;
-    if !manifest.schema_version.eq(MANIFEST_SCHEMA_VERSION) {
-        return Err(DscError::InvalidManifestSchemaVersion(manifest.schema_version, MANIFEST_SCHEMA_VERSION.to_string()));
-    }
+    // if !manifest.schema_version.eq(MANIFEST_SCHEMA_VERSION) {
+    //     return Err(DscError::InvalidManifestSchemaVersion(manifest.schema_version, MANIFEST_SCHEMA_VERSION.to_string()));
+    // }
 
     Ok(manifest)
 }

--- a/powershellgroup/Tests/class_ps_resources.dsc.yaml
+++ b/powershellgroup/Tests/class_ps_resources.dsc.yaml
@@ -1,4 +1,4 @@
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Working with classic DSC resources
   type: DSC/PowerShellGroup

--- a/powershellgroup/Tests/native_and_powershell.dsc.yaml
+++ b/powershellgroup/Tests/native_and_powershell.dsc.yaml
@@ -1,5 +1,5 @@
 # Example configuration mixing native app resources with classic PS resources
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Get info from classic DSC resources
   type: DSC/PowerShellGroup

--- a/powershellgroup/Tests/winps_resource.dsc.yaml
+++ b/powershellgroup/Tests/winps_resource.dsc.yaml
@@ -1,5 +1,5 @@
 # Example configuration mixing native app resources with classic PS resources
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Get info from classic DSC resources
   type: DSC/WindowsPowerShellGroup

--- a/process/ExportTest.dsc.yaml
+++ b/process/ExportTest.dsc.yaml
@@ -1,5 +1,5 @@
 # Example configuration mixing native app resources with classic PS resources
-$schema: https://schemas.microsoft.com/dsc/2023/03/configuration.schema.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 resources:
 - name: Processes
   type: Microsoft/Process

--- a/registry/src/main.rs
+++ b/registry/src/main.rs
@@ -91,7 +91,7 @@ fn main() {
         args::SubCommand::Config { subcommand } => {
             let json: String;
             match regconfighelper::validate_config(&config) {
-                Ok(_) => {},
+                Ok(()) => {},
                 Err(err) => {
                     eprintln!("Error validating config: {err}");
                     exit(EXIT_INVALID_INPUT);

--- a/registry/src/regconfighelper.rs
+++ b/registry/src/regconfighelper.rs
@@ -114,7 +114,7 @@ pub fn config_set(config: &Registry) -> Result<String, RegistryError> {
                     reg_key = open_or_create_key(&config.key_path)?;
                     reg_result.exist = Some(false);
                     match reg_key.delete_value(value_name) {
-                        Ok(_) | Err(NtStatusError { status: NtStatusErrorKind::ObjectNameNotFound, ..}) => {},
+                        Ok(()) | Err(NtStatusError { status: NtStatusErrorKind::ObjectNameNotFound, ..}) => {},
                         Err(err) => {
                             return Err(RegistryError::NtStatus(err));
                         }

--- a/schemas/2023/10/bundled/config/document.json
+++ b/schemas/2023/10/bundled/config/document.json
@@ -1,0 +1,363 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json",
+  "title": "DSC Configuration Document schema",
+  "description": "Describes a valid DSC Configuration Document.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "resources"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "This property must be the canonical URL of the DSC Configuration Document schema that the document is implemented for.",
+      "type": "string",
+      "format": "uri",
+      "enum": [
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.vscode.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.vscode.json"
+      ]
+    },
+    "parameters": {
+      "title": "DSC Configuration document parameters",
+      "description": "Defines runtime options for the configuration. Users and integrating tools can override use the defined parameters to pass alternate values to the configuration.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json"
+      }
+    },
+    "variables": {
+      "title": "Configuration variables",
+      "description": "Defines a set of reusable values for the configuration document. The names of this value's properties are the strings used to reference a variable's value.",
+      "type": "object"
+    },
+    "resources": {
+      "title": "DSC Configuration document resources",
+      "description": "Defines a list of DSC Resource instances for the configuration to manage.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json"
+      }
+    },
+    "metadata": {
+      "title": "Configuration metadata",
+      "description": "Defines a set of key-value pairs for the configuration. This metadata isn't validated.",
+      "type": "object"
+    }
+  },
+  "$defs": {
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json",
+      "title": "Parameter",
+      "description": "Defines a runtime option for a DSC Configuration Document.",
+      "type": "object",
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json"
+        },
+        "defaultValue": {
+          "title": "Default value",
+          "description": "Defines the default value for the parameter.",
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json"
+        },
+        "allowedValues": {
+          "title": "Allowed values",
+          "description": "Defines a list of valid values for the parameter. If the parameter is defined with any other values, it's invalid.",
+          "type": "array",
+          "items": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json"
+          }
+        },
+        "description": {
+          "title": "Parameter description",
+          "description": "Defines a synopsis for the parameter explaining its purpose.",
+          "type": "string"
+        },
+        "metadata": {
+          "title": "Parameter metadata",
+          "description": "Defines a set of key-value pairs for the parameter. This metadata isn't validated.",
+          "type": "object"
+        }
+      },
+      "allOf": [
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "int"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "minValue": {
+                "title": "Minimum value",
+                "description": "The minimum valid value for an integer type. If defined with the `maxValue` property, this value must be less than the value of `maxValue`.",
+                "type": "integer"
+              },
+              "maxValue": {
+                "title": "Maximum value",
+                "description": "The maximum valid value for an integer type. If defined with the `minValue` property, this value must be greater than the value of `minValue`.",
+                "type": "integer"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "securestring"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "array"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "minLength": {
+                "title": "Minimum length",
+                "description": "The minimum valid length for a `string`, `securestring`, or `array`. If defined with the `maxLength` property, this value must be less than the value of `maxLength`.",
+                "type": "integer",
+                "minimum": 0
+              },
+              "maxLength": {
+                "title": "Maximum length",
+                "description": "The maximum valid length for a `string`, `securestring`, or `array`. If defined with the `minLength` property, this value must be less than the value of `minLength`.",
+                "type": "integer",
+                "minimum": 0
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "string"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "securestring"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "defaultValue": {
+                "type": "string"
+              },
+              "allowedValues": {
+                "items": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "oneOf": [
+              {
+                "properties": {
+                  "type": {
+                    "const": "object"
+                  }
+                }
+              },
+              {
+                "properties": {
+                  "type": {
+                    "const": "secureobject"
+                  }
+                }
+              }
+            ]
+          },
+          "then": {
+            "properties": {
+              "defaultValue": {
+                "type": "object"
+              },
+              "allowedValues": {
+                "items": {
+                  "type": "object"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "int"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "defaultValue": {
+                "type": "integer"
+              },
+              "allowedValues": {
+                "items": {
+                  "type": "integer"
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "array"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "defaultValue": {
+                "type": "array"
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "bool"
+              }
+            }
+          },
+          "then": {
+            "properties": {
+              "defaultValue": {
+                "type": "boolean"
+              },
+              "allowedValues": {
+                "items": {
+                  "type": "boolean"
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json",
+      "title": "DSC Resource instance",
+      "description": "Defines an instance of a DSC Resource in a configuration.",
+      "type": "object",
+      "required": [
+        "type",
+        "name"
+      ],
+      "properties": {
+        "type": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        "name": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+        },
+        "dependsOn": {
+          "title": "Instance depends on",
+          "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the `resourceID()` lookup for another instance in the configuration. Multiple instances can depend on the same instance, but every dependency for an instance must be unique in that instance's `dependsOn` property.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "uniqueItems": true,
+            "pattern": "^\\[resourceId\\(\\s*'\\w+(\\.\\w+){0,2}\\/\\w+'\\s*,\\s*'[a-zA-Z0-9 ]+'\\s*\\)\\]$"
+          }
+        },
+        "properties": {
+          "title": "Managed instance properties",
+          "description": "Defines the properties of the DSC Resource this instance manages. This property's value must be an object. DSC validates the property's value against the DSC Resource's schema.",
+          "type": "object"
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json",
+      "title": "Data Types",
+      "description": "Defines the data type for the parameter value.",
+      "type": "string",
+      "enum": [
+        "string",
+        "securestring",
+        "int",
+        "bool",
+        "object",
+        "secureobject",
+        "array"
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json",
+      "$comment": "This schema fragment makes it a little easier to compose the valid properties\nfor DSC Configuration document parameters. As-written, values must be one of\nthose on this list - the schema definition for dataType excludes `null` and\nnumbers with fractional parts, like `3.5`.\n",
+      "type": [
+        "string",
+        "integer",
+        "object",
+        "array",
+        "boolean"
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+      "title": "DSC Resource fully qualified type name",
+      "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+      "type": "string",
+      "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json",
+      "title": "Instance name",
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
+    }
+  }
+}

--- a/schemas/2023/10/bundled/config/document.vscode.json
+++ b/schemas/2023/10/bundled/config/document.vscode.json
@@ -1,0 +1,569 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json",
+  "title": "DSC Configuration Document schema",
+  "description": "Describes a valid DSC Configuration Document.",
+  "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDescribes a valid DSC Configuration Document.\n\nDSC Configurations enable users to define state by combining different DSC Resources. A\nconfiguration document uses parameters and variables to pass to a set of one or more resources\nthat define a desired state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/document?view=dsc-3.0&preserve-view=true\n",
+  "type": "object",
+  "required": [
+    "$schema",
+    "resources"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "This property must be the canonical URL of the DSC Configuration Document schema that the document is implemented for.",
+      "type": "string",
+      "format": "uri",
+      "enum": [
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.vscode.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.vscode.json"
+      ],
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThis property must be the canonical URL of the DSC Configuration Document schema that the\ndocument is implemented for.\n\nFor every version of the schema, there are three valid urls:\n\n```yaml\n.../config/document.json\n```\n\n> The URL to the canonical non-bundled schema. When it's used for validation, the validating\n> client needs to retrieve this schema and every schema it references.\n  \n```yaml\n.../bundled/config/document.json\n```\n\n> The URL to the bundled schema. When it's used for validation, the validating client only\n> needs to retrieve this schema.\n>\n> This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can\n> still validate the document when it uses this schema, other tools may error or behave\n> in unexpected ways.\n\n```yaml\n.../bundled/config/document.vscode.json\n```\n\n> The URL to the enhanced authoring schema. This schema is much larger than the other\n> schemas, as it includes additional definitions that provide contextual help and snippets\n> that the others don't include.\n>\n> This schema uses keywords that are only recognized by VS Code. While DSC can still\n> validate the document when it uses this schema, other tools may error or behave in\n> unexpected ways.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/document?view=dsc-3.0&preserve-view=true#schema\n",
+      "markdownEnumDescriptions": [
+        "<!-- force a line break -->\n\n> #### `2023/10` non-bundled\n>\n> Indicates that the configuration document adheres to the `2023/10` schema. This URL\n> points to the canonical non-bundled schema. When it's used for validation, the\n> validating client needs to retrieve this schema and every schema it references.\n",
+        "<!-- force a line break -->\n\n> #### `2023/10` bundled\n>\n> Indicates that the configuration document adheres to the `2023/10` schema. This URL\n> points to the bundled schema. When it's used for validation, the validating client\n> only needs to retrieve this schema.\n>\n> This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can\n> still validate the document when it uses this schema, other tools may error or behave\n> in unexpected ways.\n",
+        "<!-- force a line break -->\n\n> #### `2023/10` enhanced authoring\n>\n> Indicates that the configuration document adheres to the `2023/10` schema. This URL\n> points to the enhanced authoring schema. This schema is much larger than the other\n> schemas, as it includes additional definitions that provide contextual help and\n> snippets that the others don't include.\n>\n> This schema uses keywords that are only recognized by VS Code. While DSC can still\n> validate the document when it uses this schema, other tools may error or behave in\n> unexpected ways.\n",
+        "<!-- force a line break -->\n\n> #### `2023/08` non-bundled\n>\n> Indicates that the configuration document adheres to the `2023/08` schema. This version\n> is deprecated, and should only be used for compatibility with `alpha.3` and earlier.\n> Migrate to using the `2023/10` of the schema \n>\n> This URL points to the canonical non-bundled schema. When it's used for validation, the\n> validating client needs to retrieve this schema and every schema it references.\n",
+        "<!-- force a line break -->\n\n> #### `2023/08` bundled\n>\n> Indicates that the configuration document adheres to the `2023/08` schema. This URL\n> points to the bundled schema. When it's used for validation, the validating client\n> only needs to retrieve this schema.\n>\n> This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can\n> still validate the document when it uses this schema, other tools may error or behave\n> in unexpected ways.\n",
+        "<!-- force a line break -->\n\n> #### `2023/08` enhanced authoring\n>\n> Indicates that the configuration document adheres to the `2023/08` schema. This URL\n> points to the enhanced authoring schema. This schema is much larger than the other\n> schemas, as it includes additional definitions that provide contextual help and\n> snippets that the others don't include.\n>\n> This schema uses keywords that are only recognized by VS Code. While DSC can still\n> validate the document when it uses this schema, other tools may error or behave in\n> unexpected ways.\n"
+      ]
+    },
+    "parameters": {
+      "title": "DSC Configuration document parameters",
+      "description": "Defines runtime options for the configuration. Users and integrating tools can override use the defined parameters to pass alternate values to the configuration.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json"
+      },
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines runtime options for the configuration. Users and integrating tools can override use\nthe defined parameters to pass alternate values to the configuration.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/document?view=dsc-3.0&preserve-view=true#parameters\n",
+      "defaultSnippets": [
+        {
+          "label": " New Parameter",
+          "markdownDescription": "Defines a new runtime option for the configuration.\n\n```yaml\nparameterId:\n  type:          <type>\n  description:   <description text>\n  defaultValue:  <value>\n  allowedValues:\n    - <first>\n```",
+          "body": {
+            "${1:parameterId}": {
+              "type": "$2",
+              "description": "$3",
+              "defaultValue": "$4",
+              "allowedValues": [
+                "$5"
+              ]
+            }
+          }
+        },
+        {
+          "label": " New Integer Parameter",
+          "markdownDescription": "Defines a new runtime option for the configuration as an integer value.\n\n```yaml\nparameterId:\n  type:          int\n  description:   <description text>\n  defaultValue:  <value>\n  minValue:      <minimum>\n  minValue:      <maximum>\n```",
+          "body": {
+            "${1:parameterId}": {
+              "type": "int",
+              "description": "$2",
+              "defaultValue": "$3",
+              "minValue": "$4",
+              "maxValue": "$5"
+            }
+          }
+        }
+      ]
+    },
+    "variables": {
+      "title": "Configuration variables",
+      "description": "Defines a set of reusable values for the configuration document. The names of this value's properties are the strings used to reference a variable's value.",
+      "type": "object",
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a set of reusable values for the configuration document. The names of this value's\nproperties are the strings used to reference a variable's value.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/document?view=dsc-3.0&preserve-view=true#variables\n",
+      "defaultSnippets": [
+        {
+          "label": " New variable property",
+          "markdownDescription": "Defines a new variable as a key-value pair.\n\n```yaml\nvariableName: variableValue\n```",
+          "body": {
+            "${1:variableName}": "${2:variableValue}"
+          }
+        },
+        {
+          "label": " New variable property (object)",
+          "markdownDescription": "Defines a new key-value pair for the variables where the value is an object.\n\n```yaml\nvariableName:\n  key: value\n```",
+          "body": {
+            "${1:variableName}": {
+              "${2:key}": "${3:value}"
+            }
+          }
+        },
+        {
+          "label": " New variable property (array)",
+          "markdownDescription": "Defines a new key-value pair for the variables where the value is an array.\n\n```yaml\nvariableName:\n  - firstValue\n  - secondValue\n```",
+          "body": {
+            "${1:variableName}": [
+              "${2:firstValue}",
+              "${3:secondValue}"
+            ]
+          }
+        }
+      ]
+    },
+    "resources": {
+      "title": "DSC Configuration document resources",
+      "description": "Defines a list of DSC Resource instances for the configuration to manage.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json"
+      },
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a list of DSC Resource instances for the configuration to manage.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/document?view=dsc-3.0&preserve-view=true#resources\n"
+    },
+    "metadata": {
+      "title": "Configuration metadata",
+      "description": "Defines a set of key-value pairs for the configuration. This metadata isn't validated.",
+      "type": "object",
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a set of key-value pairs for the configuration. This metadata isn't validated.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/document?view=dsc-3.0&preserve-view=true#metadata-1\n",
+      "defaultSnippets": [
+        {
+          "label": " New metadata property",
+          "markdownDescription": "Defines a key-value pair for the metadata:\n\n```yaml\nmetadataName: value\n```",
+          "body": {
+            "${1:metadataName}": "${2:value}"
+          }
+        },
+        {
+          "label": " New metadata property (object)",
+          "markdownDescription": "Defines a new key-value pair for the metadata where the value is an object.\n\n```yaml\nmetadataName:\n  key: value\n```",
+          "body": {
+            "${1:metadataName}": {
+              "${2:key}": "${3:value}"
+            }
+          }
+        },
+        {
+          "label": " New metadata property (array)",
+          "markdownDescription": "Defines a new key-value pair for the metadata where the value is an array.\n\n```yaml\nmetadataName:\n  - firstValue\n  - secondValue\n```",
+          "body": {
+            "${1:metadataName}": [
+              "${2:firstValue}",
+              "${3:secondValue}"
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "PowerShell": {
+      "DSC": {
+        "main": {
+          "schemas": {
+            "2023": {
+              "10": {
+                "config": {
+                  "document.parameter.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json",
+                    "title": "Parameter",
+                    "description": "Defines a runtime option for a DSC Configuration Document.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a runtime option for a DSC Configuration Document.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "type"
+                    ],
+                    "properties": {
+                      "type": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json"
+                      },
+                      "defaultValue": {
+                        "title": "Default value",
+                        "description": "Defines the default value for the parameter.",
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the default value for the parameter.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#allowedvalues\n"
+                      },
+                      "allowedValues": {
+                        "title": "Allowed values",
+                        "description": "Defines a list of valid values for the parameter. If the parameter is defined with any other values, it's invalid.",
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json"
+                        },
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a list of valid values for the parameter. If the parameter is defined with any other\nvalues, it's invalid.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#allowedvalues\n"
+                      },
+                      "description": {
+                        "title": "Parameter description",
+                        "description": "Defines a synopsis for the parameter explaining its purpose.",
+                        "type": "string",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a synopsis for the parameter explaining its purpose.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#description-1\n"
+                      },
+                      "metadata": {
+                        "title": "Parameter metadata",
+                        "description": "Defines a set of key-value pairs for the parameter. This metadata isn't validated.",
+                        "type": "object",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a set of key-value pairs for the parameter. This metadata isn't validated.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#metadata-1\n",
+                        "defaultSnippets": [
+                          {
+                            "label": " New metadata property",
+                            "markdownDescription": "Defines a key-value pair for the metadata:\n\n```yaml\nmetadataName: value\n```",
+                            "body": {
+                              "${1:metadataName}": "${2:value}"
+                            }
+                          },
+                          {
+                            "label": " New metadata property (object)",
+                            "markdownDescription": "Defines a new key-value pair for the metadata where the value is an object.\n\n```yaml\nmetadataName:\n  key: value\n```",
+                            "body": {
+                              "${1:metadataName}": {
+                                "${2:key}": "${3:value}"
+                              }
+                            }
+                          },
+                          {
+                            "label": " New metadata property (array)",
+                            "markdownDescription": "Defines a new key-value pair for the metadata where the value is an array.\n\n```yaml\nmetadataName:\n  - firstValue\n  - secondValue\n```",
+                            "body": {
+                              "${1:metadataName}": [
+                                "${2:firstValue}",
+                                "${3:secondValue}"
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    },
+                    "allOf": [
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "int"
+                            }
+                          }
+                        },
+                        "then": {
+                          "properties": {
+                            "minValue": {
+                              "title": "Minimum value",
+                              "description": "The minimum valid value for an integer type. If defined with the `maxValue` property, this value must be less than the value of `maxValue`.",
+                              "type": "integer",
+                              "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe minimum valid value for an integer type. If defined with the `maxValue` property,\nthis value must be less than the value of `maxValue`.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#minvalue\n"
+                            },
+                            "maxValue": {
+                              "title": "Maximum value",
+                              "description": "The maximum valid value for an integer type. If defined with the `minValue` property, this value must be greater than the value of `minValue`.",
+                              "type": "integer",
+                              "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe maximum valid value for an integer type. If defined with the `minValue` property,\nthis value must be greater than the value of `minValue`.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#maxvalue\n"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "string"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "securestring"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "array"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "then": {
+                          "properties": {
+                            "minLength": {
+                              "title": "Minimum length",
+                              "description": "The minimum valid length for a `string`, `securestring`, or `array`. If defined with the `maxLength` property, this value must be less than the value of `maxLength`.",
+                              "type": "integer",
+                              "minimum": 0,
+                              "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe minimum valid length for a `string`, `securestring`, or `array`. If defined with\nthe `maxLength` property, this value must be less than the value of `maxLength`.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#minLength\n"
+                            },
+                            "maxLength": {
+                              "title": "Maximum length",
+                              "description": "The maximum valid length for a `string`, `securestring`, or `array`. If defined with the `minLength` property, this value must be less than the value of `minLength`.",
+                              "type": "integer",
+                              "minimum": 0,
+                              "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe maximum valid length for a `string`, `securestring`, or `array`. If defined with\nthe `minLength` property, this value must be less than the value of `minLength`.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/parameter?view=dsc-3.0&preserve-view=true#maxLength\n"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "string"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "securestring"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "then": {
+                          "properties": {
+                            "defaultValue": {
+                              "type": "string"
+                            },
+                            "allowedValues": {
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "oneOf": [
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "object"
+                                }
+                              }
+                            },
+                            {
+                              "properties": {
+                                "type": {
+                                  "const": "secureobject"
+                                }
+                              }
+                            }
+                          ]
+                        },
+                        "then": {
+                          "properties": {
+                            "defaultValue": {
+                              "type": "object"
+                            },
+                            "allowedValues": {
+                              "items": {
+                                "type": "object"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "int"
+                            }
+                          }
+                        },
+                        "then": {
+                          "properties": {
+                            "defaultValue": {
+                              "type": "integer"
+                            },
+                            "allowedValues": {
+                              "items": {
+                                "type": "integer"
+                              }
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "array"
+                            }
+                          }
+                        },
+                        "then": {
+                          "properties": {
+                            "defaultValue": {
+                              "type": "array"
+                            }
+                          }
+                        }
+                      },
+                      {
+                        "if": {
+                          "properties": {
+                            "type": {
+                              "const": "bool"
+                            }
+                          }
+                        },
+                        "then": {
+                          "properties": {
+                            "defaultValue": {
+                              "type": "boolean"
+                            },
+                            "allowedValues": {
+                              "items": {
+                                "type": "boolean"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "document.resource.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json",
+                    "title": "DSC Resource instance",
+                    "description": "Defines an instance of a DSC Resource in a configuration.",
+                    "type": "object",
+                    "required": [
+                      "type",
+                      "name"
+                    ],
+                    "properties": {
+                      "type": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+                      },
+                      "name": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+                      },
+                      "dependsOn": {
+                        "title": "Instance depends on",
+                        "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the `resourceID()` lookup for another instance in the configuration. Multiple instances can depend on the same instance, but every dependency for an instance must be unique in that instance's `dependsOn` property.",
+                        "type": "array",
+                        "items": {
+                          "type": "string",
+                          "uniqueItems": true,
+                          "pattern": "^\\[resourceId\\(\\s*'\\w+(\\.\\w+){0,2}\\/\\w+'\\s*,\\s*'[a-zA-Z0-9 ]+'\\s*\\)\\]$",
+                          "patternErrorMessage": "Invalid value, must be a value like `[resourceId('<type>', '<name>`)], such as\n`[resourceId('Microsoft/OSInfo', 'Foo')]`.\n\nThe `<type>` and `<name>` should be the fully qualified type of the resource and its\nfriendly name in the configuration.\n",
+                          "defaultSnippets": [
+                            {
+                              "label": " New dependency",
+                              "markdownDescription": "Defines a new dependency for the resource instance.\n\n```yaml\n\"[resourceId('dependencyInstance/Type', 'dependencyInstanceName')]\"\n```",
+                              "bodyText": "\"[resourceId('${3:dependencyInstance/Type}', '${4:dependencyInstanceName}')]\""
+                            }
+                          ]
+                        },
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a list of DSC Resource instances that DSC must successfully process before processing\nthis instance. Each value for this property must be the `resourceID()` lookup for another\ninstance in the configuration. Multiple instances can depend on the same instance, but every\ndependency for an instance must be unique in that instance's `dependsOn` property.\n\nThe `resourceID()` function uses this syntax:\n\n```yaml\n\"[resourceId('<resource-type-name>', '']<instance-name>\"\n```\n\nThe `<resource-type-name>` value is the `type` property of the dependent resource and\n`<instance-name>` is the dependency's `name` property. When adding a dependency in a\nYAML-format configuration document, always wrap the `resourceID()` lookup in double quotes\n(`\"`).\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserve-view=true#properties-1\n"
+                      },
+                      "properties": {
+                        "title": "Managed instance properties",
+                        "description": "Defines the properties of the DSC Resource this instance manages. This property's value must be an object. DSC validates the property's value against the DSC Resource's schema.",
+                        "type": "object",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the properties of the DSC Resource this instance manages. This property's value must\nbe an object. DSC validates the property's value against the DSC Resource's schema.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserve-view=true#properties-1\n"
+                      }
+                    },
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an instance of a DSC Resource in a configuration.\n\nThe `resources` property of a DSC Configuration document always includes at least one DSC Resource\ninstance. Together, the instances in a configuration define the desired state that DSC can get,\ntest, and set on a machine.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserve-view=true\n",
+                    "defaultSnippets": [
+                      {
+                        "label": " New resource instance",
+                        "markdownDescription": "Defines a new instance of a DSC Resource for the configuration.\n\n```yaml\ntype: owner[.group][.area]/name\nname: instance_name\nproperties:\n  propertyName: propertyValue\n```",
+                        "body": {
+                          "type": "${1:owner[.group][.area]/name}",
+                          "name": "${2:instance_name}",
+                          "properties": {
+                            "${3:propertyName}": "${4:propertyValue}"
+                          }
+                        }
+                      },
+                      {
+                        "label": " New dependent resource instance",
+                        "markdownDescription": "Defines a new instance of a DSC Resource for the configuration that depends on another\ninstance.\n\n```yaml\ntype:      owner[.group][.area]/name\nname:      instance_name\ndependsOn:\n  - \"[resourceId('dependencyInstance/Type', 'dependencyInstanceName')]\"\nproperties:\n  propertyName: propertyValue\n```",
+                        "body": {
+                          "type": "${1:owner[.group][.area]/name}",
+                          "name": "${2:instance_name}",
+                          "dependsOn": [
+                            "\"[resourceId('${3:dependencyInstance/Type}', '${4:dependencyInstanceName}')]\""
+                          ],
+                          "properties": {
+                            "${5:propertyName}": "${6:propertyValue}"
+                          }
+                        }
+                      }
+                    ]
+                  }
+                },
+                "definitions": {
+                  "parameters": {
+                    "dataTypes.json": {
+                      "$schema": "https://json-schema.org/draft/2020-12/schema",
+                      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json",
+                      "title": "Data Types",
+                      "description": "Defines the data type for the parameter value.",
+                      "type": "string",
+                      "enum": [
+                        "string",
+                        "securestring",
+                        "int",
+                        "bool",
+                        "object",
+                        "secureobject",
+                        "array"
+                      ],
+                      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the data type for the parameter value.\n\nThe valid data types for a parameter are:\n\n- `array` for arrays\n- `bool` for booleans\n- `int` for integers\n- `object` for objects\n- `string` for strings\n- `secureobject` for secure objects\n- `securestring` for secure strings\n\nAccess parameters in a configuration using this syntax:\n\n```yaml\n\"[parameter('<parameter-name>')]\"\n```\n\nIn YAML, the parameter syntax needs to be enclosed in double-quotes when used as an inline value.\nIf the syntax isn't quoted, YAML interprets the syntax as an array.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true\n",
+                      "markdownEnumDescriptions": [
+                        "_Strings are an arbitrary set of text._\n\n> To define a long strings in YAML, use the folded block syntax or literal block syntax by\n> adding a `>` or `|` and a line break after the key. Then, indent the next line. Every line\n> in the string must start at the same level of indentation. You can trim the trailing\n> whitespace by using `>-` or `|-` instead.\n>\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#strings\n",
+                        "_Secure strings are text that needs to be handled securely._\n\n> Secure strings are an arbitrary set of text that DSC and integrating tools shouldn't log or\n> record. If a secure data type parameter is used for a resource instance property that doesn't\n> expect a secure value, the resource may still log or record the value. If the resource has\n> independent logging or recording that isn't handled by DSC, the value may be stored\n> insecurely.\n>\n> Use secure strings for passwords and secrets. Never define a default value for secure string\n> parameters.\n>\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#secure-strings-and-objects\n",
+                        "_Integer values are numbers without a fractional part._\n\n> Integer values may be limited by integrating tools or the DSC Resources they're used with.\n> DSC itself supports integer values between `-9223372036854775808` and `9223372036854775807`.\n>\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#integers\n",
+                        "_Boolean values are either `true` or `false`._\n\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#booleans\n",
+                        "_Objects define a set of key-value pairs._\n\n> The value for each key can be any valid data type. The values can be the same type or\n> different types.\n>\n> Access keys in the object using dot-notation. Dot-notation uses this syntax:\n>\n> ```yaml\n> \"[parameters('<parameter-name>').<key-name>]\n> ```\n>\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#objects\n",
+                        "_Secure objects are key-value pairs that need to be handled securely._\n\n> Secure objects define a set of key-value pairs that DSC and integrating tools shouldn't log\n> or record. If a secure data type parameter is used for a resource instance property that\n> doesn't expect a secure value, the resource may still log or record the value. If the\n> resource has independent logging or recording that isn't handled by DSC, the value may be\n> stored insecurely.\n>\n> Never define a default value for secure object parameters.\n>\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#secure-strings-and-objects\n",
+                        "_Arrays are a list of one or more values._\n\n> The values in the array can be any valid data type. Values in the array can be the same type\n> or different types.\n>\n> For more information, see the [_Online Documentation_][01].\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/parameters/datatypes?view=dsc-3.0&preserve-view=true#arrays\n"
+                      ]
+                    },
+                    "validValueTypes.json": {
+                      "$schema": "https://json-schema.org/draft/2020-12/schema",
+                      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json",
+                      "$comment": "This schema fragment makes it a little easier to compose the valid properties\nfor DSC Configuration document parameters. As-written, values must be one of\nthose on this list - the schema definition for dataType excludes `null` and\nnumbers with fractional parts, like `3.5`.\n",
+                      "type": [
+                        "string",
+                        "integer",
+                        "object",
+                        "array",
+                        "boolean"
+                      ]
+                    }
+                  },
+                  "resourceType.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+                    "title": "DSC Resource fully qualified type name",
+                    "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+                    "type": "string",
+                    "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe namespaced name of the DSC Resource, using the syntax:\n\n```yaml\nowner[.group][.area]/name\n```\n\nFor example:\n\n- `Microsoft.SqlServer/Database`\n- `Microsoft.SqlServer.Database/User`\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/resourcetype?view=dsc-3.0&preserve-view=true\n",
+                    "patternErrorMessage": "Invalid type name. Valid resource type names always define an owner and a name separated by a\nslash, like `Microsoft/OSInfo`. Type names may optionally include a group and area to namespace\nthe resource under the owner, like `Microsoft.Windows/Registry`.\n"
+                  },
+                  "instanceName.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json",
+                    "title": "Instance name",
+                    "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+                    "type": "string",
+                    "pattern": "^[a-zA-Z0-9 ]+$",
+                    "minLength": 1,
+                    "patternErrorMessage": "Invalid value for instance name. An instance name must be a non-empty string containing only\nletters, numbers, and spaces.\n",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the short, human-readable name for a DSC Resource instance. This property must be unique\nwithin a DSC Configuration document. If any resource instances share the same name, DSC raises an\nerror.\n\nThe instance name must be a non-empty string containing only letters, numbers, and spaces.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/config/resource?view=dsc-3.0&preserve-view=true#name\n"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/2023/10/bundled/outputs/config/get.json
+++ b/schemas/2023/10/bundled/outputs/config/get.json
@@ -1,0 +1,137 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/get.json",
+  "title": "DSC Configuration get command result",
+  "description": "Represents the data structure returned by the `dsc config get` command.",
+  "type": "object",
+  "required": [
+    "results",
+    "messages",
+    "hadErrors"
+  ],
+  "properties": {
+    "results": {
+      "title": "Results",
+      "description": "The results of the `get` method for every DSC Resource instance in the DSC Configuration Document with the instance's name and type.",
+      "type": "array",
+      "items": {
+        "title": "Get Result",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+          },
+          "type": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+          },
+          "result": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json"
+          }
+        }
+      }
+    },
+    "messages": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json"
+    },
+    "hadErrors": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json"
+    }
+  },
+  "$defs": {
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json",
+      "title": "Instance name",
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+      "title": "DSC Resource fully qualified type name",
+      "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+      "type": "string",
+      "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json",
+      "title": "dsc resource get result",
+      "description": "Describes the return data for a DSC Resource instance from the `dsc resource get` command.",
+      "type": "object",
+      "required": [
+        "actualState"
+      ],
+      "properties": {
+        "actualState": {
+          "title": "Actual state",
+          "description": "This property always represents the current state of the DSC Resource instance as returned by its `get` method. DSC validates this return value against the DSC Resource's schema.",
+          "type": "object"
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json",
+      "title": "Messages",
+      "description": "A list of structured messages emitted by the DSC Resources during an operation.",
+      "type": "array",
+      "items": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/message.json"
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json",
+      "title": "Had Errors",
+      "description": "Indicates whether any of the DSC Resources returned a non-zero exit code.",
+      "type": "boolean"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json",
+      "title": "Message",
+      "description": "A message emitted by a DSC Resource with associated metadata.",
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "message",
+        "level"
+      ],
+      "properties": {
+        "name": {
+          "title": "Message source instance name",
+          "description": "The short, human-readable name for the instance that emitted the message, as defined in the DSC Configuration Document.",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        "message": {
+          "title": "Message content",
+          "description": "The actual content of the message as emitted by the DSC Resource.",
+          "type": "string",
+          "minLength": 1
+        },
+        "level": {
+          "title": "Message level",
+          "description": "Indicates the severity of the message.",
+          "type": "string",
+          "enum": [
+            "Error",
+            "Warning",
+            "Information"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/2023/10/bundled/outputs/config/set.json
+++ b/schemas/2023/10/bundled/outputs/config/set.json
@@ -1,0 +1,153 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/set.json",
+  "title": "DSC Configuration set command result",
+  "description": "Represents the data structure returned by the `dsc config set` command.",
+  "type": "object",
+  "required": [
+    "results",
+    "messages",
+    "hadErrors"
+  ],
+  "properties": {
+    "results": {
+      "title": "Results",
+      "description": "The results of the `set` method for every DSC Resource instance in the DSC Configuration Document with the instance's name and type.",
+      "type": "array",
+      "items": {
+        "title": "Set Result",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+          },
+          "type": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+          },
+          "result": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json"
+          }
+        }
+      }
+    },
+    "messages": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json"
+    },
+    "hadErrors": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json"
+    }
+  },
+  "$defs": {
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json",
+      "title": "Instance name",
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+      "title": "DSC Resource fully qualified type name",
+      "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+      "type": "string",
+      "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json",
+      "title": "dsc resource set result",
+      "description": "Describes the return data for a DSC Resource instance from the `dsc resource set` command.",
+      "type": "object",
+      "required": [
+        "beforeState",
+        "afterState",
+        "changedProperties"
+      ],
+      "properties": {
+        "beforeState": {
+          "title": "State before enforcing",
+          "description": "This property always represents the desired state of the DSC Resource instance before the `set` method runs. DSC validates this return value against the DSC Resource's schema.",
+          "type": "object"
+        },
+        "afterState": {
+          "title": "State after enforcing",
+          "description": "This property always represents the current state of the DSC Resource instance as returned by its `set` method after enforcing the desired state. DSC validates this return value against the DSC Resource's schema.",
+          "type": "object"
+        },
+        "changedProperties": {
+          "title": "Changed properties",
+          "description": "This property always represents the list of property names for the DSC Resource instance that the `set` method modified. When this value is an empty array, the `set` method didn't enforce any properties for the instance.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json",
+      "title": "Messages",
+      "description": "A list of structured messages emitted by the DSC Resources during an operation.",
+      "type": "array",
+      "items": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/message.json"
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json",
+      "title": "Had Errors",
+      "description": "Indicates whether any of the DSC Resources returned a non-zero exit code.",
+      "type": "boolean"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json",
+      "title": "Message",
+      "description": "A message emitted by a DSC Resource with associated metadata.",
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "message",
+        "level"
+      ],
+      "properties": {
+        "name": {
+          "title": "Message source instance name",
+          "description": "The short, human-readable name for the instance that emitted the message, as defined in the DSC Configuration Document.",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        "message": {
+          "title": "Message content",
+          "description": "The actual content of the message as emitted by the DSC Resource.",
+          "type": "string",
+          "minLength": 1
+        },
+        "level": {
+          "title": "Message level",
+          "description": "Indicates the severity of the message.",
+          "type": "string",
+          "enum": [
+            "Error",
+            "Warning",
+            "Information"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/2023/10/bundled/outputs/config/test.json
+++ b/schemas/2023/10/bundled/outputs/config/test.json
@@ -1,0 +1,159 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/test.json",
+  "title": "DSC Configuration test command result",
+  "description": "Represents the data structure returned by the `dsc config test` command.",
+  "type": "object",
+  "required": [
+    "results",
+    "messages",
+    "hadErrors"
+  ],
+  "properties": {
+    "results": {
+      "title": "Results",
+      "description": "The results of the `test` method for every DSC Resource instance in the DSC Configuration Document with the instance's name and type.",
+      "type": "array",
+      "items": {
+        "title": "Test Result",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+          },
+          "type": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+          },
+          "result": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json"
+          }
+        }
+      }
+    },
+    "messages": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json"
+    },
+    "hadErrors": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json"
+    }
+  },
+  "$defs": {
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json",
+      "title": "Instance name",
+      "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9 ]+$",
+      "minLength": 1
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+      "title": "DSC Resource fully qualified type name",
+      "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+      "type": "string",
+      "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json",
+      "title": "dsc resource test result",
+      "description": "Describes the return data for a DSC Resource instance from the `dsc resource test` command.",
+      "type": "object",
+      "required": [
+        "desiredState",
+        "actualState",
+        "inDesiredState",
+        "differingProperties"
+      ],
+      "properties": {
+        "desiredState": {
+          "title": "Desired state",
+          "description": "This property always represents the desired state of the DSC Resource instance as specified to DSC.",
+          "type": "object"
+        },
+        "actualState": {
+          "title": "Actual state",
+          "description": "This property always represents the current state of the DSC Resource instance as returned by its `test` method or, if the DSC Resource doesn't define the `test` method, by its `get` method. DSC validates this return value against the DSC Resource's schema.",
+          "type": "object"
+        },
+        "inDesiredState": {
+          "title": "Instance is in the desired state",
+          "description": "This property indicates whether the instance is in the desired state.",
+          "type": "boolean"
+        },
+        "differingProperties": {
+          "title": "Differing properties",
+          "description": "This property always represents the list of property names for the DSC Resource instance that aren't in the desired state. When this property is an empty array, the instance is in the desired state.",
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json",
+      "title": "Messages",
+      "description": "A list of structured messages emitted by the DSC Resources during an operation.",
+      "type": "array",
+      "items": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/message.json"
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json",
+      "title": "Had Errors",
+      "description": "Indicates whether any of the DSC Resources returned a non-zero exit code.",
+      "type": "boolean"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json",
+      "title": "Message",
+      "description": "A message emitted by a DSC Resource with associated metadata.",
+      "type": "object",
+      "required": [
+        "name",
+        "type",
+        "message",
+        "level"
+      ],
+      "properties": {
+        "name": {
+          "title": "Message source instance name",
+          "description": "The short, human-readable name for the instance that emitted the message, as defined in the DSC Configuration Document.",
+          "type": "string"
+        },
+        "type": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        "message": {
+          "title": "Message content",
+          "description": "The actual content of the message as emitted by the DSC Resource.",
+          "type": "string",
+          "minLength": 1
+        },
+        "level": {
+          "title": "Message level",
+          "description": "Indicates the severity of the message.",
+          "type": "string",
+          "enum": [
+            "Error",
+            "Warning",
+            "Information"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/schemas/2023/10/bundled/outputs/resource/get.json
+++ b/schemas/2023/10/bundled/outputs/resource/get.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json",
+  "title": "dsc resource get result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource get` command.",
+  "type": "object",
+  "required": [
+    "actualState"
+  ],
+  "properties": {
+    "actualState": {
+      "title": "Actual state",
+      "description": "This property always represents the current state of the DSC Resource instance as returned by its `get` method. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    }
+  },
+  "$defs": {}
+}

--- a/schemas/2023/10/bundled/outputs/resource/list.json
+++ b/schemas/2023/10/bundled/outputs/resource/list.json
@@ -1,0 +1,705 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/list.json",
+  "title": "dsc resource list result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource list` command.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "version": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json"
+    },
+    "description": {
+      "title": "Resource Description",
+      "description": "A short synopsis of the DSC Resource's purpose.",
+      "type": "string"
+    },
+    "path": {
+      "title": "Path",
+      "description": "Indicates the path to the DSC Resource on the file system.",
+      "type": "string"
+    },
+    "directory": {
+      "title": "Directory",
+      "description": "Indicates the path to the folder containing the DSC Resource on the file system.",
+      "type": "string"
+    },
+    "implementedAs": {
+      "title": "Implemented as",
+      "description": "Indicates how the DSC Resource was implemented.",
+      "oneOf": [
+        {
+          "title": "Standard implementation",
+          "description": "Indicates that the DSC Resource is implemented as one of the standard implementations built into DSC.",
+          "type": "string",
+          "enum": [
+            "Command"
+          ]
+        },
+        {
+          "title": "Custom implementation",
+          "description": "Indicates that the DSC Resource uses a custom implementation.",
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "title": "Custom implementation name",
+              "description": "The name of the custom implementation.",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "author": {
+      "title": "Author",
+      "description": "Indicates the name of the person or organization that developed and maintains the DSC Resource.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "properties": {
+      "title": "Properties",
+      "description": "Defines the DSC Resource's property names.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^\\w+$"
+      }
+    },
+    "requires": {
+      "title": "Required DSC Resource Provider",
+      "description": "Defines the fully qualified type name of the DSC Resource Provider the DSC Resource depends on.",
+      "oneOf": [
+        {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "manifest": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json"
+    }
+  },
+  "$defs": {
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+      "title": "DSC Resource fully qualified type name",
+      "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+      "type": "string",
+      "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json",
+      "type": "string",
+      "title": "Semantic Version",
+      "description": "A valid semantic version (semver) string.\n\nFor reference, see https://semver.org/\n",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "$comment": "A valid semantic version ([semver][01]) string.\n\nThis value uses the [suggested regular expression][02] to validate whether the string is valid\nsemver. This is the same pattern, made multi-line for easier readability:\n\n```regex\n^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\n(?:-(\n  (?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)\n  (?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))\n*))?\n(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$\n```\n\nThe first line matches the `major.minor.patch` components of the version. The middle lines match\nthe pre-release components. The last line matches the build metadata component.\n\n[01]: https://semver.org/\n[02]: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string\n"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+      "title": "Command-based DSC Resource Manifest",
+      "description": "Defines the information DSC and integrating require to process and call a command-based DSC Resource.",
+      "type": "object",
+      "required": [
+        "$schema",
+        "type",
+        "version",
+        "get"
+      ],
+      "properties": {
+        "$schema": {
+          "title": "Manifest Schema",
+          "description": "This property must be the canonical URL of the Command-based DSC Resource Manifest schema that the manifest is implemented for.",
+          "type": "string",
+          "format": "uri",
+          "enum": [
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json",
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json",
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.vscode.json"
+          ]
+        },
+        "type": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        "version": {
+          "title": "Resource Semantic Version",
+          "description": "The semantic version (semver) of the DSC Resource. This version identifies the DSC Resource, not the version of the application it manages.",
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json"
+        },
+        "description": {
+          "title": "Resource Description",
+          "description": "A short synopsis of the DSC Resource's purpose.",
+          "type": "string"
+        },
+        "tags": {
+          "title": "Tags",
+          "description": "Defines a list of searchable terms for the resource.",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "string",
+            "pattern": "^\\w+$"
+          }
+        },
+        "get": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json"
+        },
+        "export": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json"
+        },
+        "set": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json"
+        },
+        "test": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json"
+        },
+        "validate": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json"
+        },
+        "provider": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json"
+        },
+        "exitCodes": {
+          "title": "Exit Codes",
+          "description": "This property defines a map of valid exit codes for the DSC Resource. DSC always interprets exit code `0` as a successful operation and any other exit code as an error. Use this property to indicate human-readable semantic meanings for the DSC Resource's exit codes.",
+          "type": "object",
+          "propertyNames": {
+            "pattern": "^[0-9]+$"
+          },
+          "patternProperties": {
+            "^[0-9]+$": {
+              "type": "string"
+            }
+          },
+          "unevaluatedProperties": false,
+          "default": {
+            "0": "Success",
+            "1": "Error"
+          },
+          "examples": [
+            {
+              "0": "Success",
+              "1": "Invalid parameter",
+              "2": "Invalid input",
+              "3": "Registry error",
+              "4": "JSON serialization failed"
+            }
+          ]
+        },
+        "schema": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json"
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json",
+      "title": "Get Method",
+      "description": "Defines how DSC must call the DSC Resource to get the current state of an instance.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        },
+        "input": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "registry",
+          "args": [
+            "config",
+            "get"
+          ],
+          "input": "stdin"
+        },
+        {
+          "executable": "osinfo"
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json",
+      "title": "Get Method",
+      "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json",
+      "title": "Set Method",
+      "description": "Defines how DSC must call the DSC Resource to set the desired state of an instance and how to process the output from the DSC Resource.",
+      "type": "object",
+      "required": [
+        "executable",
+        "input"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        },
+        "input": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+        },
+        "implementsPretest": {
+          "title": "Resource Performs Pre-Test",
+          "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
+          "type": "boolean",
+          "default": false
+        },
+        "return": {
+          "description": "Defines whether the command returns a JSON blob of the DSC Resource's state after the set operation or the state and an array of the properties the DSC Resource modified.",
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "registry",
+          "args": [
+            "config",
+            "set"
+          ],
+          "input": "stdin",
+          "implementsPretest": true,
+          "return": "state"
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json",
+      "title": "Test Method",
+      "description": "Defines how DSC must call the DSC Resource to test if an instance is in the desired state and how to process the output from the DSC Resource.",
+      "type": "object",
+      "required": [
+        "executable",
+        "input"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        },
+        "input": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+        },
+        "return": {
+          "title": "Test Command Return Type",
+          "description": "Defines whether the command returns a JSON blob of the DSC Resource's current state or the state and an array of the properties that are out of the desired state.",
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "registry",
+          "args": [
+            "config",
+            "test"
+          ],
+          "input": "stdin",
+          "return": "state"
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json",
+      "title": "Validate Method",
+      "description": "Defines how DSC must call the DSC Resource to validate the state of an instance. This method is mandatory for DSC Group Resources. It's ignored for all other DSC Resources.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "dsc",
+          "args": [
+            "config",
+            "validate"
+          ]
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json",
+      "title": "Provider",
+      "description": "Defines the DSC Resource as a DSC Resource Provider. A DSC Resource Provider enables users to manage resources that don't have their own manifests with DSC.",
+      "type": "object",
+      "required": [
+        "list",
+        "config"
+      ],
+      "properties": {
+        "list": {
+          "title": "List Command",
+          "description": "Defines how DSC must call the DSC Resource Provider to list its supported DSC Resources.",
+          "type": "object",
+          "required": [
+            "executable"
+          ],
+          "properties": {
+            "executable": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+            },
+            "args": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+            }
+          }
+        },
+        "config": {
+          "title": "Expected Configuration",
+          "description": "Defines whether the provider expects to receive a full and unprocessed configuration as a single JSON blob over stdin or a sequence of JSON Lines for each child resource's configurations.",
+          "type": "string",
+          "enum": [
+            "full",
+            "sequence"
+          ]
+        }
+      },
+      "examples": [
+        {
+          "config": "full",
+          "list": {
+            "executable": "pwsh",
+            "args": [
+              "-NoLogo",
+              "-NonInteractive",
+              "-NoProfile",
+              "-Command",
+              "./powershellgroup.resource.ps1 List"
+            ]
+          }
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json",
+      "title": "Instance Schema",
+      "description": "Defines how DSC must validate a JSON blob representing an instance of the DSC Resource.",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "command"
+          ]
+        },
+        {
+          "required": [
+            "embedded"
+          ]
+        }
+      ],
+      "properties": {
+        "command": {
+          "title": "Instance Schema Command",
+          "description": "Defines how DSC must call the DSC Resource to get the JSON Schema for validating a JSON blob representing an instance of the DSC Resource.",
+          "type": "object",
+          "required": [
+            "executable"
+          ],
+          "properties": {
+            "executable": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+            },
+            "args": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+            }
+          }
+        },
+        "embedded": {
+          "title": "Embedded Instance Schema",
+          "description": "Defines the JSON Schema DSC must use to validate a JSON blob representing an instance of the DSC Resource.",
+          "type": "object",
+          "required": [
+            "$schema",
+            "type",
+            "properties"
+          ],
+          "properties": {
+            "type": {
+              "title": "Instance Type",
+              "description": "Defines the JSON type for an instance of the DSC Resource. DSC Resource instances always have the `object` type.",
+              "const": "object"
+            },
+            "$schema": {
+              "title": "DSC Resource instance schema dialect",
+              "description": "Defines which dialect of JSON Schema the DSC Resource is using to validate instances.",
+              "type": "string",
+              "format": "uri-reference",
+              "enum": [
+                "https://json-schema.org/draft/2020-12/schema",
+                "https://json-schema.org/draft/2019-09/schema",
+                "http://json-schema.org/draft-07/schema#"
+              ]
+            },
+            "$id": {
+              "title": "DSC Resource instance schema ID",
+              "description": "Defines the unique ID for the DSC Resource's instance schema. If the instance schema is published to its own public URI, set this keyword to that URI.",
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "properties": {
+              "title": "Instance Properties",
+              "description": "Defines the properties that DSC can retrieve and manage for the resource's instances. This keyword must define at least one property as a key-value pair. The key is the property's name. The value is a subschema that validates the property.",
+              "type": "object",
+              "minProperties": 1,
+              "unevaluatedProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "https://json-schema.org/draft/2020-12/schema"
+                  },
+                  {
+                    "$ref": "https://json-schema.org/draft/2019-09/schema"
+                  },
+                  {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                  }
+                ]
+              },
+              "additionalProperties": {},
+              "properties": {
+                "_exist": {
+                  "title": "Standard Property: _exist",
+                  "description": "Indicates that the DSC Resource uses the standard `_exist` property to specify whether an instance should exist as a boolean value that defaults to `true`.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json"
+                  }
+                },
+                "_inDesiredState": {
+                  "title": "Standard Property: _inDesiredState",
+                  "description": "Indicates that the DSC Resource returns this value for it's own `test` method. This read-only property is mandatory when the manifest defines the `test` property. It shouldn't be included if the DSC Resource relies on DSC's synthetic testing.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json"
+                  }
+                },
+                "_purge": {
+                  "title": "Standard Property: _purge",
+                  "description": "Indicates that the DSC Resource uses the standard `_purge` property to specify whether the DSC Resource should remove all non-specified members when it manages an array of members or values.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json"
+                  }
+                },
+                "_rebootRequested": {
+                  "title": "Standard property: _rebootRequested",
+                  "description": "Indicates whether a resource instance requires a reboot after a set operation. To use DSC's built-in reboot notification processing, resources must define this property in their manifest.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "url": {
+          "title": "Instance Schema URL",
+          "description": "Defines the URL to the DSC Resource's JSON schema for integrating tools.",
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "examples": [
+        {
+          "command": {
+            "executable": "registry",
+            "args": [
+              "schema"
+            ]
+          }
+        },
+        {
+          "embedded": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "OSInfo",
+            "type": "object",
+            "required": [],
+            "properties": {
+              "$id": {
+                "type": "string"
+              },
+              "architecture": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "bitness": {
+                "$ref": "#/definitions/Bitness"
+              },
+              "codename": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "edition": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "family": {
+                "$ref": "#/definitions/Family"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "definitions": {
+              "Bitness": {
+                "type": "string",
+                "enum": [
+                  "32",
+                  "64",
+                  "unknown"
+                ]
+              },
+              "Family": {
+                "type": "string",
+                "enum": [
+                  "Linux",
+                  "macOS",
+                  "Windows"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+      "title": "Executable Command Name",
+      "description": "The name of the command to run.",
+      "type": "string"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+      "title": "Executable Command Arguments",
+      "description": "The list of arguments to pass to the command.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+      "title": "Executable Command Input Type",
+      "description": "Defines how DSC should pass input to the command, either as environment variables or JSON over stdin. When this value isn't defined, DSC doesn't send the resource any input.",
+      "type": "string",
+      "enum": [
+        "env",
+        "stdin"
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json",
+      "title": "Return Kind",
+      "type": "string",
+      "enum": [
+        "state",
+        "stateAndDiff"
+      ],
+      "default": "state",
+      "$comment": "While the enumeration for return kind is the same for the `set` and `test`\nmethod, the way it changes the behavior of the command isn't. The description\nkeyword isn't included here because the respective schemas for those methods\ndocument the behavior themselves."
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json",
+      "title": "Instance should exist",
+      "description": "Indicates whether the DSC Resource instance should exist.",
+      "type": "boolean",
+      "default": true,
+      "enum": [
+        false,
+        true
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json",
+      "title": "Instance is in the Desired State",
+      "description": "Indicates whether the instance is in the desired state. This property is only returned by the `test` method.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "readOnly": true
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json",
+      "title": "Purge",
+      "description": "Indicates that only the components described in the DSC Resource should exist. If other components exist, the DSC Resource is out of the desired state. When enforcing desired state, the DSC Resource removes unmanaged components.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "writeOnly": true
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json",
+      "title": "Reboot Requested",
+      "description": "Indicates that the set operation requires a reboot before it's fully complete.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/2023/10/bundled/outputs/resource/schema.json
+++ b/schemas/2023/10/bundled/outputs/resource/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/schema.json",
+  "title": "DSC Resource schema result",
+  "description": "Describes the return data for a DSC Resource from the `dsc resource schema` command. This command always returns the DSC Resource's JSON schema document.",
+  "type": "object",
+  "$defs": {}
+}

--- a/schemas/2023/10/bundled/outputs/resource/set.json
+++ b/schemas/2023/10/bundled/outputs/resource/set.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json",
+  "title": "dsc resource set result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource set` command.",
+  "type": "object",
+  "required": [
+    "beforeState",
+    "afterState",
+    "changedProperties"
+  ],
+  "properties": {
+    "beforeState": {
+      "title": "State before enforcing",
+      "description": "This property always represents the desired state of the DSC Resource instance before the `set` method runs. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    },
+    "afterState": {
+      "title": "State after enforcing",
+      "description": "This property always represents the current state of the DSC Resource instance as returned by its `set` method after enforcing the desired state. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    },
+    "changedProperties": {
+      "title": "Changed properties",
+      "description": "This property always represents the list of property names for the DSC Resource instance that the `set` method modified. When this value is an empty array, the `set` method didn't enforce any properties for the instance.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {}
+}

--- a/schemas/2023/10/bundled/outputs/resource/test.json
+++ b/schemas/2023/10/bundled/outputs/resource/test.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json",
+  "title": "dsc resource test result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource test` command.",
+  "type": "object",
+  "required": [
+    "desiredState",
+    "actualState",
+    "inDesiredState",
+    "differingProperties"
+  ],
+  "properties": {
+    "desiredState": {
+      "title": "Desired state",
+      "description": "This property always represents the desired state of the DSC Resource instance as specified to DSC.",
+      "type": "object"
+    },
+    "actualState": {
+      "title": "Actual state",
+      "description": "This property always represents the current state of the DSC Resource instance as returned by its `test` method or, if the DSC Resource doesn't define the `test` method, by its `get` method. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    },
+    "inDesiredState": {
+      "title": "Instance is in the desired state",
+      "description": "This property indicates whether the instance is in the desired state.",
+      "type": "boolean"
+    },
+    "differingProperties": {
+      "title": "Differing properties",
+      "description": "This property always represents the list of property names for the DSC Resource instance that aren't in the desired state. When this property is an empty array, the instance is in the desired state.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "$defs": {}
+}

--- a/schemas/2023/10/bundled/outputs/schema.json
+++ b/schemas/2023/10/bundled/outputs/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/schema.json",
+  "title": "DSC Resource schema result",
+  "description": "Describes the return data for a DSC Resource from the `dsc schema` command. This command always returns a JSON schema document.",
+  "type": "object",
+  "$defs": {}
+}

--- a/schemas/2023/10/bundled/resource/manifest.json
+++ b/schemas/2023/10/bundled/resource/manifest.json
@@ -1,0 +1,614 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+  "title": "Command-based DSC Resource Manifest",
+  "description": "Defines the information DSC and integrating require to process and call a command-based DSC Resource.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "type",
+    "version",
+    "get"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Manifest Schema",
+      "description": "This property must be the canonical URL of the Command-based DSC Resource Manifest schema that the manifest is implemented for.",
+      "type": "string",
+      "format": "uri",
+      "enum": [
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.vscode.json"
+      ]
+    },
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "version": {
+      "title": "Resource Semantic Version",
+      "description": "The semantic version (semver) of the DSC Resource. This version identifies the DSC Resource, not the version of the application it manages.",
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json"
+    },
+    "description": {
+      "title": "Resource Description",
+      "description": "A short synopsis of the DSC Resource's purpose.",
+      "type": "string"
+    },
+    "tags": {
+      "title": "Tags",
+      "description": "Defines a list of searchable terms for the resource.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\w+$"
+      }
+    },
+    "get": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json"
+    },
+    "export": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json"
+    },
+    "set": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json"
+    },
+    "test": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json"
+    },
+    "validate": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json"
+    },
+    "provider": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json"
+    },
+    "exitCodes": {
+      "title": "Exit Codes",
+      "description": "This property defines a map of valid exit codes for the DSC Resource. DSC always interprets exit code `0` as a successful operation and any other exit code as an error. Use this property to indicate human-readable semantic meanings for the DSC Resource's exit codes.",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[0-9]+$"
+      },
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false,
+      "default": {
+        "0": "Success",
+        "1": "Error"
+      },
+      "examples": [
+        {
+          "0": "Success",
+          "1": "Invalid parameter",
+          "2": "Invalid input",
+          "3": "Registry error",
+          "4": "JSON serialization failed"
+        }
+      ]
+    },
+    "schema": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json"
+    }
+  },
+  "$defs": {
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+      "title": "DSC Resource fully qualified type name",
+      "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+      "type": "string",
+      "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json",
+      "type": "string",
+      "title": "Semantic Version",
+      "description": "A valid semantic version (semver) string.\n\nFor reference, see https://semver.org/\n",
+      "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "$comment": "A valid semantic version ([semver][01]) string.\n\nThis value uses the [suggested regular expression][02] to validate whether the string is valid\nsemver. This is the same pattern, made multi-line for easier readability:\n\n```regex\n^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\n(?:-(\n  (?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)\n  (?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))\n*))?\n(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$\n```\n\nThe first line matches the `major.minor.patch` components of the version. The middle lines match\nthe pre-release components. The last line matches the build metadata component.\n\n[01]: https://semver.org/\n[02]: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string\n"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json",
+      "title": "Get Method",
+      "description": "Defines how DSC must call the DSC Resource to get the current state of an instance.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        },
+        "input": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "registry",
+          "args": [
+            "config",
+            "get"
+          ],
+          "input": "stdin"
+        },
+        {
+          "executable": "osinfo"
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json",
+      "title": "Get Method",
+      "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        }
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json",
+      "title": "Set Method",
+      "description": "Defines how DSC must call the DSC Resource to set the desired state of an instance and how to process the output from the DSC Resource.",
+      "type": "object",
+      "required": [
+        "executable",
+        "input"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        },
+        "input": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+        },
+        "implementsPretest": {
+          "title": "Resource Performs Pre-Test",
+          "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
+          "type": "boolean",
+          "default": false
+        },
+        "return": {
+          "description": "Defines whether the command returns a JSON blob of the DSC Resource's state after the set operation or the state and an array of the properties the DSC Resource modified.",
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "registry",
+          "args": [
+            "config",
+            "set"
+          ],
+          "input": "stdin",
+          "implementsPretest": true,
+          "return": "state"
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json",
+      "title": "Test Method",
+      "description": "Defines how DSC must call the DSC Resource to test if an instance is in the desired state and how to process the output from the DSC Resource.",
+      "type": "object",
+      "required": [
+        "executable",
+        "input"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        },
+        "input": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+        },
+        "return": {
+          "title": "Test Command Return Type",
+          "description": "Defines whether the command returns a JSON blob of the DSC Resource's current state or the state and an array of the properties that are out of the desired state.",
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "registry",
+          "args": [
+            "config",
+            "test"
+          ],
+          "input": "stdin",
+          "return": "state"
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json",
+      "title": "Validate Method",
+      "description": "Defines how DSC must call the DSC Resource to validate the state of an instance. This method is mandatory for DSC Group Resources. It's ignored for all other DSC Resources.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        }
+      },
+      "examples": [
+        {
+          "executable": "dsc",
+          "args": [
+            "config",
+            "validate"
+          ]
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json",
+      "title": "Provider",
+      "description": "Defines the DSC Resource as a DSC Resource Provider. A DSC Resource Provider enables users to manage resources that don't have their own manifests with DSC.",
+      "type": "object",
+      "required": [
+        "list",
+        "config"
+      ],
+      "properties": {
+        "list": {
+          "title": "List Command",
+          "description": "Defines how DSC must call the DSC Resource Provider to list its supported DSC Resources.",
+          "type": "object",
+          "required": [
+            "executable"
+          ],
+          "properties": {
+            "executable": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+            },
+            "args": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+            }
+          }
+        },
+        "config": {
+          "title": "Expected Configuration",
+          "description": "Defines whether the provider expects to receive a full and unprocessed configuration as a single JSON blob over stdin or a sequence of JSON Lines for each child resource's configurations.",
+          "type": "string",
+          "enum": [
+            "full",
+            "sequence"
+          ]
+        }
+      },
+      "examples": [
+        {
+          "config": "full",
+          "list": {
+            "executable": "pwsh",
+            "args": [
+              "-NoLogo",
+              "-NonInteractive",
+              "-NoProfile",
+              "-Command",
+              "./powershellgroup.resource.ps1 List"
+            ]
+          }
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json",
+      "title": "Instance Schema",
+      "description": "Defines how DSC must validate a JSON blob representing an instance of the DSC Resource.",
+      "type": "object",
+      "oneOf": [
+        {
+          "required": [
+            "command"
+          ]
+        },
+        {
+          "required": [
+            "embedded"
+          ]
+        }
+      ],
+      "properties": {
+        "command": {
+          "title": "Instance Schema Command",
+          "description": "Defines how DSC must call the DSC Resource to get the JSON Schema for validating a JSON blob representing an instance of the DSC Resource.",
+          "type": "object",
+          "required": [
+            "executable"
+          ],
+          "properties": {
+            "executable": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+            },
+            "args": {
+              "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+            }
+          }
+        },
+        "embedded": {
+          "title": "Embedded Instance Schema",
+          "description": "Defines the JSON Schema DSC must use to validate a JSON blob representing an instance of the DSC Resource.",
+          "type": "object",
+          "required": [
+            "$schema",
+            "type",
+            "properties"
+          ],
+          "properties": {
+            "type": {
+              "title": "Instance Type",
+              "description": "Defines the JSON type for an instance of the DSC Resource. DSC Resource instances always have the `object` type.",
+              "const": "object"
+            },
+            "$schema": {
+              "title": "DSC Resource instance schema dialect",
+              "description": "Defines which dialect of JSON Schema the DSC Resource is using to validate instances.",
+              "type": "string",
+              "format": "uri-reference",
+              "enum": [
+                "https://json-schema.org/draft/2020-12/schema",
+                "https://json-schema.org/draft/2019-09/schema",
+                "http://json-schema.org/draft-07/schema#"
+              ]
+            },
+            "$id": {
+              "title": "DSC Resource instance schema ID",
+              "description": "Defines the unique ID for the DSC Resource's instance schema. If the instance schema is published to its own public URI, set this keyword to that URI.",
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "properties": {
+              "title": "Instance Properties",
+              "description": "Defines the properties that DSC can retrieve and manage for the resource's instances. This keyword must define at least one property as a key-value pair. The key is the property's name. The value is a subschema that validates the property.",
+              "type": "object",
+              "minProperties": 1,
+              "unevaluatedProperties": {
+                "anyOf": [
+                  {
+                    "$ref": "https://json-schema.org/draft/2020-12/schema"
+                  },
+                  {
+                    "$ref": "https://json-schema.org/draft/2019-09/schema"
+                  },
+                  {
+                    "$ref": "http://json-schema.org/draft-07/schema#"
+                  }
+                ]
+              },
+              "additionalProperties": {},
+              "properties": {
+                "_exist": {
+                  "title": "Standard Property: _exist",
+                  "description": "Indicates that the DSC Resource uses the standard `_exist` property to specify whether an instance should exist as a boolean value that defaults to `true`.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json"
+                  }
+                },
+                "_inDesiredState": {
+                  "title": "Standard Property: _inDesiredState",
+                  "description": "Indicates that the DSC Resource returns this value for it's own `test` method. This read-only property is mandatory when the manifest defines the `test` property. It shouldn't be included if the DSC Resource relies on DSC's synthetic testing.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json"
+                  }
+                },
+                "_purge": {
+                  "title": "Standard Property: _purge",
+                  "description": "Indicates that the DSC Resource uses the standard `_purge` property to specify whether the DSC Resource should remove all non-specified members when it manages an array of members or values.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json"
+                  }
+                },
+                "_rebootRequested": {
+                  "title": "Standard property: _rebootRequested",
+                  "description": "Indicates whether a resource instance requires a reboot after a set operation. To use DSC's built-in reboot notification processing, resources must define this property in their manifest.",
+                  "const": {
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "url": {
+          "title": "Instance Schema URL",
+          "description": "Defines the URL to the DSC Resource's JSON schema for integrating tools.",
+          "type": "string",
+          "format": "uri"
+        }
+      },
+      "examples": [
+        {
+          "command": {
+            "executable": "registry",
+            "args": [
+              "schema"
+            ]
+          }
+        },
+        {
+          "embedded": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "OSInfo",
+            "type": "object",
+            "required": [],
+            "properties": {
+              "$id": {
+                "type": "string"
+              },
+              "architecture": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "bitness": {
+                "$ref": "#/definitions/Bitness"
+              },
+              "codename": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "edition": {
+                "type": [
+                  "string",
+                  "null"
+                ]
+              },
+              "family": {
+                "$ref": "#/definitions/Family"
+              },
+              "version": {
+                "type": "string"
+              }
+            },
+            "additionalProperties": false,
+            "definitions": {
+              "Bitness": {
+                "type": "string",
+                "enum": [
+                  "32",
+                  "64",
+                  "unknown"
+                ]
+              },
+              "Family": {
+                "type": "string",
+                "enum": [
+                  "Linux",
+                  "macOS",
+                  "Windows"
+                ]
+              }
+            }
+          }
+        }
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+      "title": "Executable Command Name",
+      "description": "The name of the command to run.",
+      "type": "string"
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+      "title": "Executable Command Arguments",
+      "description": "The list of arguments to pass to the command.",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+      "title": "Executable Command Input Type",
+      "description": "Defines how DSC should pass input to the command, either as environment variables or JSON over stdin. When this value isn't defined, DSC doesn't send the resource any input.",
+      "type": "string",
+      "enum": [
+        "env",
+        "stdin"
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json",
+      "title": "Return Kind",
+      "type": "string",
+      "enum": [
+        "state",
+        "stateAndDiff"
+      ],
+      "default": "state",
+      "$comment": "While the enumeration for return kind is the same for the `set` and `test`\nmethod, the way it changes the behavior of the command isn't. The description\nkeyword isn't included here because the respective schemas for those methods\ndocument the behavior themselves."
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json",
+      "title": "Instance should exist",
+      "description": "Indicates whether the DSC Resource instance should exist.",
+      "type": "boolean",
+      "default": true,
+      "enum": [
+        false,
+        true
+      ]
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json",
+      "title": "Instance is in the Desired State",
+      "description": "Indicates whether the instance is in the desired state. This property is only returned by the `test` method.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "readOnly": true
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json",
+      "title": "Purge",
+      "description": "Indicates that only the components described in the DSC Resource should exist. If other components exist, the DSC Resource is out of the desired state. When enforcing desired state, the DSC Resource removes unmanaged components.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "writeOnly": true
+    },
+    "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json",
+      "title": "Reboot Requested",
+      "description": "Indicates that the set operation requires a reboot before it's fully complete.",
+      "type": [
+        "boolean",
+        "null"
+      ],
+      "readOnly": true
+    }
+  }
+}

--- a/schemas/2023/10/bundled/resource/manifest.vscode.json
+++ b/schemas/2023/10/bundled/resource/manifest.vscode.json
@@ -1,0 +1,1167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+  "title": "Command-based DSC Resource Manifest",
+  "description": "Defines the information DSC and integrating require to process and call a command-based DSC Resource.",
+  "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the information DSC and integrating require to process and call a command-based DSC\nResource. For DSC to use a manifest on a system, the manifest file must:\n\n1. Be discoverable in the `PATH` environment variable.\n1. Follow the naming convention `<name>.dsc.resource.json`.\n1. Be valid for this schema.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/root?view=dsc-3.0&preserve-view=true\n",
+  "defaultSnippets": [
+    {
+      "label": " Define a resource",
+      "markdownDescription": "Defines a standard resource that:\n\n- Can get the current state of an instance\n- Can set an instance to the desired state\n- Relies on DSC's synthetic testing to determine whether an instance is in the desired state\n- Defines an embedded JSON schema.",
+      "body": {
+        "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "type": "${1:owner.area.group}/${2:${TM_FILENAME_BASE/^(.*?)[\\.]dsc[\\.]resource/$1/}}",
+        "version": "${3:0.1.0}",
+        "description": "${4:Synopsis for the resource's purpose}",
+        "get": {
+          "executable": "${5:executable name}",
+          "args": [
+            "${6:argument}"
+          ],
+          "input": "${7:stdin}"
+        },
+        "set": {
+          "executable": "${8:executable name}",
+          "args": [
+            "${9:argument}"
+          ],
+          "input": "${10:stdin}",
+          "implementsPretest": "^${11:false}",
+          "return": "${12:state}"
+        },
+        "schema": {
+          "embedded": {
+            "${escape_dollar:$}schema": "${13|https://json-schema.org/draft/2020-12/schema,https://json-schema.org/draft/2019-09/schema,http://json-schema.org/draft-07/schema#|}",
+            "type": "object",
+            "properties": {
+              "${14:name}": {
+                "title": "${15:property title}",
+                "description": "${16:explanation of property purpose and usage}",
+                "type": "${17|string,integer,number,array,object,null|}"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "label": " Define a resource (group)",
+      "markdownDescription": "Defines a group resource that expects a list of resource instances and operates on them.",
+      "body": {
+        "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "type": "${1:owner.area.group}/${2:${TM_FILENAME_BASE/^(.*?)[\\.]dsc[\\.]resource/$1/}}",
+        "version": "${3:0.1.0}",
+        "description": "${4:Synopsis for the resource's purpose}",
+        "get": {
+          "executable": "${5:executable name}",
+          "args": [
+            "${6:argument}"
+          ],
+          "input": "${7:stdin}"
+        },
+        "test": {
+          "executable": "${8:executable name}",
+          "args": [
+            "${9:argument}"
+          ],
+          "input": "${10:stdin}",
+          "return": "${12:state}"
+        },
+        "set": {
+          "executable": "${13:executable name}",
+          "args": [
+            "${14:argument}"
+          ],
+          "input": "${15:stdin}",
+          "implementsPretest": "^${16:false}",
+          "return": "${17:state}"
+        },
+        "schema": {
+          "embedded": {
+            "${escape_dollar:$}schema": "${18|https://json-schema.org/draft/2020-12/schema,https://json-schema.org/draft/2019-09/schema,http://json-schema.org/draft-07/schema#|}",
+            "type": "object",
+            "properties": {
+              "resources": {
+                "title": "${19:Resources}",
+                "description": "${20:Defines a list of resource instances to process}",
+                "type": "array",
+                "items": {
+                  "${escape_dollar:$}ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json"
+                }
+              },
+              "${21:name}": {
+                "title": "${22:property title}",
+                "description": "${23:explanation of property purpose and usage}",
+                "type": "${24|string,integer,number,array,object,null|}"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "label": " Define a resource (provider)",
+      "markdownDescription": "Defines a provider resource that enables users to define non-command-based DSC Resources in\nthe configuration.",
+      "body": {
+        "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "type": "${1:owner.area.group}/${2:${TM_FILENAME_BASE/^(.*?)[\\.]dsc[\\.]resource/$1/}}",
+        "version": "${3:0.1.0}",
+        "description": "${4:Synopsis for the resource's purpose}",
+        "get": {
+          "executable": "${5:executable name}",
+          "args": [
+            "${6:argument}"
+          ],
+          "input": "${7:stdin}"
+        },
+        "test": {
+          "executable": "${8:executable name}",
+          "args": [
+            "${9:argument}"
+          ],
+          "input": "${10:stdin}",
+          "return": "${12:state}"
+        },
+        "set": {
+          "executable": "${13:executable name}",
+          "args": [
+            "${14:argument}"
+          ],
+          "input": "${15:stdin}",
+          "implementsPretest": "^${16:false}",
+          "return": "${17:state}"
+        },
+        "provider": {
+          "config": "${18|full,sequence|}",
+          "list": {
+            "executable": "${19:executable name}",
+            "args": [
+              "${20:argument}"
+            ]
+          }
+        },
+        "schema": {
+          "embedded": {
+            "${escape_dollar:$}schema": "${23|https://json-schema.org/draft/2020-12/schema,https://json-schema.org/draft/2019-09/schema,http://json-schema.org/draft-07/schema#|}",
+            "type": "object",
+            "properties": {
+              "resources": {
+                "title": "${24:Resources}",
+                "description": "${25:Defines a list of resource instances to process}",
+                "type": "array",
+                "items": {
+                  "${escape_dollar:$}ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json"
+                }
+              },
+              "${26:name}": {
+                "title": "${27:property title}",
+                "description": "${28:explanation of property purpose and usage}",
+                "type": "${29|string,integer,number,array,object,null|}"
+              }
+            }
+          }
+        }
+      }
+    },
+    {
+      "label": " Define a resource (assertion-only)",
+      "markdownDescription": "Defines an assertion resource that can get the current state of an instance but not configure\nit. By default, the resource relies on DSC's synthetic testing feature. If the resource\nimplements the `test` operation itself, define the `test` property.",
+      "body": {
+        "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "type": "${1:owner.area.group}/${2:${TM_FILENAME_BASE/^(.*?)[\\.]dsc[\\.]resource/$1/}}",
+        "version": "${3:0.1.0}",
+        "description": "${4:Synopsis for the resource's purpose}",
+        "get": {
+          "executable": "${5:executable name}",
+          "args": [
+            "${6:argument}"
+          ],
+          "input": "${7:stdin}"
+        },
+        "schema": {
+          "embedded": {
+            "${escape_dollar:$}schema": "${13|https://json-schema.org/draft/2020-12/schema,https://json-schema.org/draft/2019-09/schema,http://json-schema.org/draft-07/schema#|}",
+            "type": "object",
+            "properties": {
+              "${14:name}": {
+                "title": "${15:property title}",
+                "description": "${16:explanation of property purpose and usage}",
+                "type": "${17|string,integer,number,array,object,null|}"
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
+  "type": "object",
+  "required": [
+    "$schema",
+    "type",
+    "version",
+    "get"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Manifest Schema",
+      "description": "This property must be the canonical URL of the Command-based DSC Resource Manifest schema that the manifest is implemented for.",
+      "type": "string",
+      "format": "uri",
+      "enum": [
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.vscode.json"
+      ],
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThis property must be one of the canonical URLs for the version of the Command-based DSC\nResource Manifest schema that the manifest is implemented for.\n\nFor every version of the schema, there are three valid urls:\n\n```yaml\n.../resource/manifest.json\n```\n\n> The URL to the canonical non-bundled schema. When it's used for validation, the validating\n> client needs to retrieve this schema and every schema it references.\n\n```yaml\n.../bundled/resource/manifest.json\n```\n\n> The URL to the bundled schema. When it's used for validation, the validating client only\n> needs to retrieve this schema.\n> \n> This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can\n> still validate the document when it uses this schema, other tools may error or behave\n> in unexpected ways.\n\n```yaml\n.../bundled/resource/manifest.vscode.json\n```\n\n> The URL to the enhanced authoring schema. This schema is much larger than the other\n> schemas, as it includes additional definitions that provide contextual help and snippets\n> that the others don't include.\n> \n> This schema uses keywords that are only recognized by VS Code. While DSC can still\n> validate the document when it uses this schema, other tools may error or behave in\n> unexpected ways.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/root?view=dsc-3.0&preserve-view=true#schema\n",
+      "markdownEnumDescriptions": [
+        "<!-- force a line break -->\n\n> #### `2023/10` non-bundled\n>\n> Indicates that the resource manifest adheres to the `2023/10` schema. This URL\n> points to the canonical non-bundled schema. When it's used for validation, the\n> validating client needs to retrieve this schema and every schema it references.\n",
+        "<!-- force a line break -->\n\n> #### `2023/10` bundled\n>\n> Indicates that the resource manifest adheres to the `2023/10` schema. This URL\n> points to the bundled schema. When it's used for validation, the validating client\n> only needs to retrieve this schema.\n>\n> This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can\n> still validate the document when it uses this schema, other tools may error or behave\n> in unexpected ways.\n",
+        "<!-- force a line break -->\n\n> #### `2023/10` enhanced authoring\n>\n> Indicates that the resource manifest adheres to the `2023/10` schema. This URL\n> points to the enhanced authoring schema. This schema is much larger than the other\n> schemas, as it includes additional definitions that provide contextual help and\n> snippets that the others don't include.\n>\n> This schema uses keywords that are only recognized by VS Code. While DSC can still\n> validate the document when it uses this schema, other tools may error or behave in\n> unexpected ways.\n",
+        "<!-- force a line break -->\n\n> #### `2023/08` non-bundled\n>\n> Indicates that the resource manifest adheres to the `2023/08` schema. This version\n> is deprecated, and should only be used for compatibility with `alpha.3` and earlier.\n> Migrate to using the `2023/10` of the schema \n\n> This URL points to the canonical non-bundled schema. When it's used for validation, the\n> validating client needs to retrieve this schema and every schema it references.\n",
+        "<!-- force a line break -->\n\n> #### `2023/08` bundled\n>\n> Indicates that the resource manifest adheres to the `2023/08` schema. This URL\n> points to the bundled schema. When it's used for validation, the validating client\n> only needs to retrieve this schema.\n>\n> This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can\n> still validate the document when it uses this schema, other tools may error or behave\n> in unexpected ways.\n",
+        "<!-- force a line break -->\n\n> #### `2023/08` enhanced authoring\n>\n> Indicates that the resource manifest adheres to the `2023/08` schema. This URL\n> points to the enhanced authoring schema. This schema is much larger than the other\n> schemas, as it includes additional definitions that provide contextual help and\n> snippets that the others don't include.\n>\n> This schema uses keywords that are only recognized by VS Code. While DSC can still\n> validate the document when it uses this schema, other tools may error or behave in\n> unexpected ways.\n"
+      ]
+    },
+    "type": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "version": {
+      "title": "Resource Semantic Version",
+      "description": "The semantic version (semver) of the DSC Resource. This version identifies the DSC Resource, not the version of the application it manages.",
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json",
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe semantic version ([semver][02]) of the DSC Resource. This version identifies the DSC\nResource, not the version of the application it manages.\n\nThis value uses the [suggested regular expression][03] to validate whether the string is valid\nsemver. This is the same pattern, made multi-line for easier readability:\n\n```regex\n^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\n(?:-(\n  (?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)\n  (?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))\n*))?\n(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$\n```\n\nThe first line matches the `major.minor.patch` components of the version. The middle lines match\nthe pre-release components. The last line matches the build metadata component.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/root?view=dsc-3.0&preserve-view=true#version\n[02]: https://semver.org/\n[03]: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string\n"
+    },
+    "description": {
+      "title": "Resource Description",
+      "description": "A short synopsis of the DSC Resource's purpose.",
+      "type": "string",
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a short synopsis of the DSC Resource's purpose.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/root?view=dsc-3.0&preserve-view=true#description-1\n"
+    },
+    "tags": {
+      "title": "Tags",
+      "description": "Defines a list of searchable terms for the resource.",
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines a list of searchable terms for the resource.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/root?view=dsc-3.0&preserve-view=true#tags\n",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\w+$",
+        "patternErrorMessage": "Invalid tag. Tags must be a string of alphanumeric characters and underscores. No other\ncharacters are permitted.\n"
+      }
+    },
+    "get": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json"
+    },
+    "export": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json"
+    },
+    "set": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json"
+    },
+    "test": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json"
+    },
+    "validate": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json"
+    },
+    "provider": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json"
+    },
+    "exitCodes": {
+      "title": "Exit Codes",
+      "description": "This property defines a map of valid exit codes for the DSC Resource. DSC always interprets exit code `0` as a successful operation and any other exit code as an error. Use this property to indicate human-readable semantic meanings for the DSC Resource's exit codes.",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[0-9]+$",
+        "patternErrorMessage": "Invalid exit code. Must be a string representing an integer greater than or equal to `0`.\n"
+      },
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false,
+      "default": {
+        "0": "Success",
+        "1": "Error"
+      },
+      "examples": [
+        {
+          "0": "Success",
+          "1": "Invalid parameter",
+          "2": "Invalid input",
+          "3": "Registry error",
+          "4": "JSON serialization failed"
+        }
+      ],
+      "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThis property defines a map of valid exit codes for the DSC Resource. DSC always interprets\nexit code `0` as a successful operation and any other exit code as an error. Use this\nproperty to indicate human-readable semantic meanings for the DSC Resource's exit codes.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/root?view=dsc-3.0&preserve-view=true#exitcodes\n",
+      "defaultSnippets": [
+        {
+          "label": " Defined exit codes",
+          "description": "Defines exit codes with semantic meaning for the resource.",
+          "body": {
+            "0": "Success",
+            "${1:first exit code number}": "${2:first exit code meaning}",
+            "${3:second exit code number}": "${4:second exit code meaning}"
+          }
+        }
+      ]
+    },
+    "schema": {
+      "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json"
+    }
+  },
+  "$defs": {
+    "PowerShell": {
+      "DSC": {
+        "main": {
+          "schemas": {
+            "2023": {
+              "10": {
+                "definitions": {
+                  "resourceType.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+                    "title": "DSC Resource fully qualified type name",
+                    "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+                    "type": "string",
+                    "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nThe namespaced name of the DSC Resource, using the syntax:\n\n```yaml\nowner[.group][.area]/name\n```\n\nFor example:\n\n- `Microsoft.SqlServer/Database`\n- `Microsoft.SqlServer.Database/User`\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/definitions/resourcetype?view=dsc-3.0&preserve-view=true\n",
+                    "patternErrorMessage": "Invalid type name. Valid resource type names always define an owner and a name separated by a\nslash, like `Microsoft/OSInfo`. Type names may optionally include a group and area to namespace\nthe resource under the owner, like `Microsoft.Windows/Registry`.\n"
+                  },
+                  "semver.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json",
+                    "type": "string",
+                    "title": "Semantic Version",
+                    "description": "A valid semantic version (semver) string.\n\nFor reference, see https://semver.org/\n",
+                    "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+                    "patternErrorMessage": "Invalid value, must be a semantic version like `<major>.<minor>.<patch>`, such as `1.2.3`.\n\nThe value may also include pre-release version information and build metadata.\n",
+                    "$comment": "A valid semantic version ([semver][01]) string.\n\nThis value uses the [suggested regular expression][02] to validate whether the string is valid\nsemver. This is the same pattern, made multi-line for easier readability:\n\n```regex\n^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\n(?:-(\n  (?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)\n  (?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))\n*))?\n(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$\n```\n\nThe first line matches the `major.minor.patch` components of the version. The middle lines match\nthe pre-release components. The last line matches the build metadata component.\n\n[01]: https://semver.org/\n[02]: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string\n"
+                  },
+                  "commandExecutable.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                    "title": "Executable Command Name",
+                    "description": "The name of the command to run.",
+                    "type": "string"
+                  },
+                  "commandArgs.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                    "title": "Executable Command Arguments",
+                    "description": "The list of arguments to pass to the command.",
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "inputKind.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+                    "title": "Executable Command Input Type",
+                    "description": "Defines how DSC should pass input to the command, either as environment variables or JSON over stdin. When this value isn't defined, DSC doesn't send the resource any input.",
+                    "type": "string",
+                    "enum": [
+                      "env",
+                      "stdin"
+                    ],
+                    "markdownEnumDescriptions": [
+                      "_Environment variables_\n\n> Indicates that the resource expects the properties of an instance to be specified as\n> environment variables with the same names and casing.\n>\n> This option only supports the following data types for instance properties:\n>\n> - `boolean`\n> - `integer`\n> - `number`\n> - `string`\n> - `array` of `integer` values\n> - `array` of `number` values\n> - `array` of `string` values\n>\n> For non-array values, DSC sets the environment variable to the specified value as-is. When\n> the data type is an array of values, DSC sets the environment variable as a comma-delimited\n> string. For example, the property `foo` with a value of `[1, 2, 3]` is saved in the `foo`\n> environment variable as `\"1,2,3\"`.\n>\n> If the resource needs to support complex properties with an `object` value or multi-type\n> arrays, set this to `stdin` instead.\n",
+                      "_JSON over `stdin`_\n\n> Indicates that the resource expects a JSON blob representing an instance from `stdin`.\n> The JSON must adhere to the instance schema.\n"
+                    ]
+                  },
+                  "returnKind.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json",
+                    "title": "Return Kind",
+                    "type": "string",
+                    "enum": [
+                      "state",
+                      "stateAndDiff"
+                    ],
+                    "default": "state",
+                    "$comment": "While the enumeration for return kind is the same for the `set` and `test`\nmethod, the way it changes the behavior of the command isn't. The description\nkeyword isn't included here because the respective schemas for those methods\ndocument the behavior themselves."
+                  }
+                },
+                "resource": {
+                  "manifest.get.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json",
+                    "title": "Get Method",
+                    "description": "Defines how DSC must call the DSC Resource to get the current state of an instance.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource to get the current state of an instance.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/get?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "executable"
+                    ],
+                    "properties": {
+                      "executable": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/get?view=dsc-3.0&preserve-view=true#executable\n"
+                      },
+                      "args": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"config\", \"get\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry config get\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/get?view=dsc-3.0&preserve-view=true#args\n"
+                      },
+                      "input": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC should pass input to the command, either as environment variables or JSON\nover `stdin`. If this value isn't defined, DSC doesn't send the resource any input when\ninvoking the `get` operation.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/get?view=dsc-3.0&preserve-view=true#input\n"
+                      }
+                    },
+                    "examples": [
+                      {
+                        "executable": "registry",
+                        "args": [
+                          "config",
+                          "get"
+                        ],
+                        "input": "stdin"
+                      },
+                      {
+                        "executable": "osinfo"
+                      }
+                    ],
+                    "defaultSnippets": [
+                      {
+                        "label": " Define without arguments",
+                        "markdownDescription": "Define the get command for the resource when no arguments are required.\n",
+                        "body": {
+                          "input": "${1|stdin,env|}",
+                          "executable": "${2:executable_name}"
+                        }
+                      },
+                      {
+                        "label": " Define with arguments",
+                        "markdownDescription": "Define the get command for the resource when at least one argument is required.\n",
+                        "body": {
+                          "input": "${1|stdin,env|}",
+                          "executable": "${2:executable_name}",
+                          "args": [
+                            "${3:--first-argument}"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "manifest.export.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json",
+                    "title": "Get Method",
+                    "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource to get the current state of every instance.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/export?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "executable"
+                    ],
+                    "properties": {
+                      "executable": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/export?view=dsc-3.0&preserve-view=true#executable\n"
+                      },
+                      "args": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"config\", \"export\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry config export\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/export?view=dsc-3.0&preserve-view=true#args\n"
+                      }
+                    },
+                    "defaultSnippets": [
+                      {
+                        "label": " Define without arguments",
+                        "markdownDescription": "Define the export command for the resource when no arguments are required.\n",
+                        "body": {
+                          "executable": "${1:executable_name}"
+                        }
+                      },
+                      {
+                        "label": " Define with arguments",
+                        "markdownDescription": "Define the export command for the resource when at least one argument is required.\n",
+                        "body": {
+                          "executable": "${1:executable_name}",
+                          "args": [
+                            "${2:--first-argument}"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "manifest.set.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json",
+                    "title": "Set Method",
+                    "description": "Defines how DSC must call the DSC Resource to set the desired state of an instance and how to process the output from the DSC Resource.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource to set the desired state of an instance and how to\nprocess the output from the DSC Resource.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "executable",
+                      "input"
+                    ],
+                    "properties": {
+                      "executable": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#executable\n"
+                      },
+                      "args": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"config\", \"set\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry config set\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#args\n"
+                      },
+                      "input": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC should pass input to the command, either as environment variables or JSON\nover `stdin`.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#input\n"
+                      },
+                      "implementsPretest": {
+                        "title": "Resource Performs Pre-Test",
+                        "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
+                        "type": "boolean",
+                        "default": false,
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines whether the DSC Resource performs its own test to ensure idempotency when calling the\n`set` command. Set this value to `true` if the DSC Resource tests input before modifying\nsystem state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#implementspretest\n"
+                      },
+                      "return": {
+                        "description": "Defines whether the command returns a JSON blob of the DSC Resource's state after the set operation or the state and an array of the properties the DSC Resource modified.",
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines whether the command returns a JSON blob of the DSC Resource's state after the set\noperation or the state and an array of the properties the DSC Resource modified.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#return\n",
+                        "markdownEnumDescriptions": [
+                          "_Final state only_\n\n> Indicates that the resource returns only the instance's final state after the set\n> operation as a JSON blob.\n",
+                          "_Final state and changed properties_\n\n> Indicates that the resource returns the instance's final state and an array of property\n> names that the resource modified.\n"
+                        ]
+                      }
+                    },
+                    "examples": [
+                      {
+                        "executable": "registry",
+                        "args": [
+                          "config",
+                          "set"
+                        ],
+                        "input": "stdin",
+                        "implementsPretest": true,
+                        "return": "state"
+                      }
+                    ],
+                    "defaultSnippets": [
+                      {
+                        "label": " Define without arguments",
+                        "markdownDescription": "Define the `set` command for the resource when no arguments are required.\n",
+                        "body": {
+                          "input": "${1|input,env|}",
+                          "implementsPretest": "^${2|true,false|}",
+                          "return": "${3|state,stateAndDiff|}",
+                          "executable": "${4:executable_name}"
+                        }
+                      },
+                      {
+                        "label": " Define with arguments",
+                        "markdownDescription": "Define the `set` command for the resource when at least one argument is required.\n",
+                        "body": {
+                          "input": "${1|input,env|}",
+                          "implementsPretest": "^${2|true,false|}",
+                          "return": "${3|state,stateAndDiff|}",
+                          "executable": "${4:executable_name}",
+                          "args": [
+                            "${5:--first-argument}"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "manifest.test.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json",
+                    "title": "Test Method",
+                    "description": "Defines how DSC must call the DSC Resource to test if an instance is in the desired state and how to process the output from the DSC Resource.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource to test if an instance is in the desired state and how\nto process the output from the DSC Resource.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/test?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "executable",
+                      "input"
+                    ],
+                    "properties": {
+                      "executable": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#executable\n"
+                      },
+                      "args": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"config\", \"test\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry config test\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#args\n"
+                      },
+                      "input": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC should pass input to the command, either as environment variables or JSON\nover `stdin`.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#input\n"
+                      },
+                      "return": {
+                        "title": "Test Command Return Type",
+                        "description": "Defines whether the command returns a JSON blob of the DSC Resource's current state or the state and an array of the properties that are out of the desired state.",
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines whether the command returns a JSON blob of the DSC Resource's current state or the\nstate and an array of the properties that are out of the desired state.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/test?view=dsc-3.0&preserve-view=true#return\n",
+                        "markdownEnumDescriptions": [
+                          "_Actual state only_\n\n> Indicates that the resource returns only the instance's actual state as a JSON blob.\n",
+                          "_Actual state and differing properties_\n\n> Indicates that the resource returns the instance's actual state and an array of\n> property names that are out of the desired state.\n"
+                        ]
+                      }
+                    },
+                    "examples": [
+                      {
+                        "executable": "registry",
+                        "args": [
+                          "config",
+                          "test"
+                        ],
+                        "input": "stdin",
+                        "return": "state"
+                      }
+                    ],
+                    "defaultSnippets": [
+                      {
+                        "label": " Define without arguments",
+                        "markdownDescription": "Define the `test` command for the resource when no arguments are required.\n",
+                        "body": {
+                          "input": "${1|input,env|}",
+                          "return": "${2|state,stateAndDiff|}",
+                          "executable": "${3:executable_name}"
+                        }
+                      },
+                      {
+                        "label": " Define with arguments",
+                        "markdownDescription": "Define the `test` command for the resource when at least one argument is required.\n",
+                        "body": {
+                          "input": "${1|input,env|}",
+                          "return": "${2|state,stateAndDiff|}",
+                          "executable": "${3:executable_name}",
+                          "args": [
+                            "${4:--first-argument}"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "manifest.validate.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json",
+                    "title": "Validate Method",
+                    "description": "Defines how DSC must call the DSC Resource to validate the state of an instance. This method is mandatory for DSC Group Resources. It's ignored for all other DSC Resources.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource to validate the state of an instance. This method is\nmandatory for DSC Group Resources. It's ignored for all other DSC Resources.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/validate?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "executable"
+                    ],
+                    "properties": {
+                      "executable": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#executable\n"
+                      },
+                      "args": {
+                        "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"config\", \"validate\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry config validate\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#args\n"
+                      }
+                    },
+                    "examples": [
+                      {
+                        "executable": "dsc",
+                        "args": [
+                          "config",
+                          "validate"
+                        ]
+                      }
+                    ],
+                    "defaultSnippets": [
+                      {
+                        "label": " Define without arguments",
+                        "markdownDescription": "Define the `validate` command for the resource when no arguments are required.\n",
+                        "body": {
+                          "executable": "${1:executable_name}"
+                        }
+                      },
+                      {
+                        "label": " Define with arguments",
+                        "markdownDescription": "Define the `validate` command for the resource when at least one argument is required.\n",
+                        "body": {
+                          "executable": "${1:executable_name}",
+                          "args": [
+                            "${2:--first-argument}"
+                          ]
+                        }
+                      }
+                    ]
+                  },
+                  "manifest.provider.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json",
+                    "title": "Provider",
+                    "description": "Defines the DSC Resource as a DSC Resource Provider. A DSC Resource Provider enables users to manage resources that don't have their own manifests with DSC.",
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the DSC Resource as a DSC Resource Provider. A DSC Resource Provider enables users to\nmanage resources that don't have their own manifests with DSC.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserve-view=true\n",
+                    "type": "object",
+                    "required": [
+                      "list",
+                      "config"
+                    ],
+                    "properties": {
+                      "list": {
+                        "title": "List Command",
+                        "description": "Defines how DSC must call the DSC Resource Provider to list its supported DSC Resources.",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource Provider to list its supported DSC Resources.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserve-view=true#list\n",
+                        "type": "object",
+                        "required": [
+                          "executable"
+                        ],
+                        "properties": {
+                          "executable": {
+                            "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserve-view=true#executable\n"
+                          },
+                          "args": {
+                            "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"resources\", \"list\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry resources list\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserve-view=true#args\n"
+                          }
+                        }
+                      },
+                      "config": {
+                        "title": "Expected Configuration",
+                        "description": "Defines whether the provider expects to receive a full and unprocessed configuration as a single JSON blob over stdin or a sequence of JSON Lines for each child resource's configurations.",
+                        "type": "string",
+                        "enum": [
+                          "full",
+                          "sequence"
+                        ],
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines whether the provider expects to receive a full and unprocessed configuration as a\nsingle JSON blob over stdin or a sequence of JSON Lines for each child resource's\nconfigurations.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/provider?view=dsc-3.0&preserve-view=true#config\n",
+                        "markdownEnumDescriptions": [
+                          "_Full and unprocessed config as a JSON blob_\n\n> Indicates that the provider expects a JSON blob containing the full and unprocessed\n> configuration as a single JSON blob over `stdin`.\n",
+                          "_Resource instances as JSON Lines_\n\n> Indicates that the provider expects each resource's configuration as a [JSON Line][01]\n> over `stdin`.\n\n[01]: https://jsonlines.org/\n"
+                        ]
+                      }
+                    },
+                    "examples": [
+                      {
+                        "config": "full",
+                        "list": {
+                          "executable": "pwsh",
+                          "args": [
+                            "-NoLogo",
+                            "-NonInteractive",
+                            "-NoProfile",
+                            "-Command",
+                            "./powershellgroup.resource.ps1 List"
+                          ]
+                        }
+                      }
+                    ],
+                    "defaultSnippets": [
+                      {
+                        "label": " Define without arguments",
+                        "markdownDescription": "Define the provider config kind and `list` command for the resource when no arguments are\nrequired.\n",
+                        "body": {
+                          "config": "$1",
+                          "list": {
+                            "executable": "${2:executable_name}"
+                          }
+                        }
+                      },
+                      {
+                        "label": " Define with arguments",
+                        "markdownDescription": "Define the provider config kind and `list` command for the resource when at least one\nargument is required.\n",
+                        "body": {
+                          "config": "$1",
+                          "list": {
+                            "executable": "${2:executable_name}",
+                            "args": [
+                              "${3:--first-argument}"
+                            ]
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  "manifest.schema.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json",
+                    "title": "Instance Schema",
+                    "description": "Defines how DSC must validate a JSON blob representing an instance of the DSC Resource.",
+                    "type": "object",
+                    "oneOf": [
+                      {
+                        "required": [
+                          "command"
+                        ]
+                      },
+                      {
+                        "required": [
+                          "embedded"
+                        ]
+                      }
+                    ],
+                    "properties": {
+                      "command": {
+                        "title": "Instance Schema Command",
+                        "description": "Defines how DSC must call the DSC Resource to get the JSON Schema for validating a JSON blob representing an instance of the DSC Resource.",
+                        "type": "object",
+                        "required": [
+                          "executable"
+                        ],
+                        "properties": {
+                          "executable": {
+                            "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the name of the command to run. The value must be the name of a command discoverable\nin the system's `PATH` environment variable or the full path to the command. A file extension\nis only required when the command isn't recognizable by the operating system as an\nexecutable.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#executable\n"
+                          },
+                          "args": {
+                            "$ref": "#/$defs/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines an array of strings to pass as arguments to the command. DSC passes the arguments to\nthe command in the order they're specified.\n\nFor example, the given the following definition:\n\n```json\n{\n  \"executable\": \"registry\",\n  \"args\":       [\"schema\", \"resource\"],\n}\n```\n\nDSC invokes the command for the resource as:\n\n```bash\nregistry schema resource\n```\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/set?view=dsc-3.0&preserve-view=true#args\n"
+                          }
+                        },
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must call the DSC Resource to get the JSON Schema for validating a JSON blob\nrepresenting an instance of the DSC Resource.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true#command\n",
+                        "defaultSnippets": [
+                          {
+                            "label": " Define without arguments",
+                            "markdownDescription": "Define the `schema` command for the resource when no arguments are required.\n",
+                            "body": {
+                              "executable": "${1:executable_name}"
+                            }
+                          },
+                          {
+                            "label": " Define with arguments",
+                            "markdownDescription": "Define the `schema` command for the resource when at least one argument is required.\n",
+                            "body": {
+                              "executable": "${1:executable_name}",
+                              "args": [
+                                "${2:--first-argument}"
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      "embedded": {
+                        "title": "Embedded Instance Schema",
+                        "description": "Defines the JSON Schema DSC must use to validate a JSON blob representing an instance of the DSC Resource.",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the JSON Schema DSC must use to validate a JSON blob representing an instance of the\nDSC Resource.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/embedded?view=dsc-3.0&preserve-view=true\n",
+                        "type": "object",
+                        "required": [
+                          "$schema",
+                          "type",
+                          "properties"
+                        ],
+                        "properties": {
+                          "type": {
+                            "title": "Instance Type",
+                            "description": "Defines the JSON type for an instance of the DSC Resource. DSC Resource instances always have the `object` type.",
+                            "const": "object",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the JSON type for an instance of the DSC Resource. DSC Resource instances always\nhave the `object` type.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/embedded?view=dsc-3.0&preserve-view=true#type\n"
+                          },
+                          "$schema": {
+                            "title": "DSC Resource instance schema dialect",
+                            "description": "Defines which dialect of JSON Schema the DSC Resource is using to validate instances.",
+                            "type": "string",
+                            "format": "uri-reference",
+                            "enum": [
+                              "https://json-schema.org/draft/2020-12/schema",
+                              "https://json-schema.org/draft/2019-09/schema",
+                              "http://json-schema.org/draft-07/schema#"
+                            ],
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the JSON type for an instance of the DSC Resource. DSC Resource instances always\nhave the `object` type. DSC only supports JSON Schema Draft 07 and later.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/embedded?view=dsc-3.0&preserve-view=true#type\n",
+                            "markdownEnumDescriptions": [
+                              "_Draft 2020-12 (recommended)_\n\n> Indicates that the resource instance schema adheres to\n> [JSON Schema Draft 2020-12][01].\n>\n> This is the latest published draft of JSON Schema and is the draft future drafts\n> will be most compatible with.\n\n[01]: https://json-schema.org/specification-links.html#2020-12\n",
+                              "_Draft 2019-09_\n\n> Indicates that the resource instance schema adheres to\n> [JSON Schema Draft 2019-09][01].\n>\n> This is the previous published draft of JSON Schema. It's mostly compatible with\n> 2020-12, but less extensible and can't be bundled.\n\n[01]: https://json-schema.org/specification-links.html#draft-2019-09-formerly-known-as-draft-8\n",
+                              "_Draft 07_\n\n> Indicates that the resource instance schema adheres to [JSON Schema Draft 07][01].\n>\n> This is an older published draft of JSON Schema. It's widely used, but incompatible\n> with 2019-09 and later. It's less expressive, extensible, maintainable, and isn't\n> recommended for new schema definitions.\n\n[01]: https://json-schema.org/specification-links.html#draft-7\n"
+                            ]
+                          },
+                          "$id": {
+                            "title": "DSC Resource instance schema ID",
+                            "description": "Defines the unique ID for the DSC Resource's instance schema. If the instance schema is published to its own public URI, set this keyword to that URI.",
+                            "type": "string",
+                            "format": "uri-reference",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the unique ID for the DSC Resource's instance schema. If the instance schema is\npublished to its own public URI, set this keyword to that URI.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true#id\n"
+                          },
+                          "properties": {
+                            "title": "Instance Properties",
+                            "description": "Defines the properties that DSC can retrieve and manage for the resource's instances. This keyword must define at least one property as a key-value pair. The key is the property's name. The value is a subschema that validates the property.",
+                            "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the properties that DSC can retrieve and manage for the resource's instances.\nThis keyword must define at least one property as a key-value pair. The key is the\nproperty's name. The value is a subschema that validates the property.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true#properties\n",
+                            "type": "object",
+                            "minProperties": 1,
+                            "unevaluatedProperties": {
+                              "anyOf": [
+                                {
+                                  "$ref": "https://json-schema.org/draft/2020-12/schema"
+                                },
+                                {
+                                  "$ref": "https://json-schema.org/draft/2019-09/schema"
+                                },
+                                {
+                                  "$ref": "http://json-schema.org/draft-07/schema#"
+                                }
+                              ]
+                            },
+                            "additionalProperties": {
+                              "defaultSnippets": [
+                                {
+                                  "label": " Define a property",
+                                  "markdownDescription": "Define a new property for the resource instance schema.",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "${3|boolean,string,integer,number,array,object,null|}"
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (boolean)",
+                                  "markdownDescription": "Define a new [boolean][01] property for the resource instance schema, requiring the\nvalue to be either `true` or `false`.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/boolean.html",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "boolean"
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (string)",
+                                  "markdownDescription": "Define a new [string][01] property for the resource instance schema, requiring the\nvalue to be a blob of text.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/string.html",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "string"
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (integer)",
+                                  "markdownDescription": "Define a new [integer][01] property for the resource instance schema, requiring the\nvalue to be a number without a fractional part.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/numeric.html",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "integer"
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (number)",
+                                  "markdownDescription": "Define a new [number][01] property for the resource instance schema, requiring the\nvalue to be a number that may include a fractional part.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/numeric.html",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "number"
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (array)",
+                                  "markdownDescription": "Define a new [array][01] property for the resource instance schema, requiring the\nvalue to be a list of values.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/array.html",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "array",
+                                    "items": {
+                                      "type": "${3|boolean,string,integer,number,array,object,null|}"
+                                    }
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (object)",
+                                  "markdownDescription": "Define a new [object][01] property for the resource instance schema, requiring the\nvalue to be a set of key-value pairs.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/object.html",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "type": "object",
+                                    "properties": {
+                                      "${3:propertyName}": {
+                                        "title": "${4:propertyTitle}",
+                                        "description": "${5:explanation of property purpose and usage}",
+                                        "type": "${6|string,integer,number,array,object,null|}"
+                                      }
+                                    }
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (enum)",
+                                  "markdownDescription": "Define a new [enum][01] property for the resource instance schema that only accepts\na defined set of values.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/generic.html#enumerated-values",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "enum": [
+                                      "^${3:\"first value\"}",
+                                      "^${4:\"second value\"}"
+                                    ]
+                                  }
+                                },
+                                {
+                                  "label": " Define a property (const)",
+                                  "markdownDescription": "Define a new [const][01] property for the resource instance schema that only\naccepts a specific value.\n\n[01]: https://json-schema.org/understanding-json-schema/reference/generic.html#constant-values",
+                                  "body": {
+                                    "title": "${1:property title}",
+                                    "description": "${2:explanation of property purpose and usage}",
+                                    "const": "^${3:\"constant value\"}"
+                                  }
+                                }
+                              ]
+                            },
+                            "properties": {
+                              "_exist": {
+                                "title": "Standard Property: _exist",
+                                "description": "Indicates that the DSC Resource uses the standard `_exist` property to specify whether an instance should exist as a boolean value that defaults to `true`.",
+                                "const": {
+                                  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json"
+                                },
+                                "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nIndicates that the resource can enforce whether instances exist, handling whether an\ninstance should be added, updated, or removed during a set operation. The default\nvalue is `true`.\n\nResources that define this property declare that the implementation adheres to the\nfollowing behavior contract:\n\n1. When the desired state for `_exist` is `true`, the resource expects the instance\n   to exist. If it doesn't exist, the resource creates or adds the instance during\n   the set operation.\n1. When the desired state for `_exist` is `false`, the resource expects the instance\n   to not exist. If it does exist, the resource deletes or removes the instance\n   during the set operation.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/properties/exist?view=dsc-3.0&preserve-view=true\n"
+                              },
+                              "_inDesiredState": {
+                                "title": "Standard Property: _inDesiredState",
+                                "description": "Indicates that the DSC Resource returns this value for it's own `test` method. This read-only property is mandatory when the manifest defines the `test` property. It shouldn't be included if the DSC Resource relies on DSC's synthetic testing.",
+                                "const": {
+                                  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json"
+                                },
+                                "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nIndicates that the DSC Resource returns this value for it's own `test` method. This\nproperty is mandatory when the manifest defines the `test` property. It shouldn't\nbe included if the DSC Resource relies on DSC's synthetic testing.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/properties/indesiredstate?view=dsc-3.0&preserve-view=true\n"
+                              },
+                              "_purge": {
+                                "title": "Standard Property: _purge",
+                                "description": "Indicates that the DSC Resource uses the standard `_purge` property to specify whether the DSC Resource should remove all non-specified members when it manages an array of members or values.",
+                                "const": {
+                                  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json"
+                                },
+                                "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nIndicates that the DSC Resource uses the standard `_purge` property to specify\nwhether the DSC Resource should remove all non-specified members when it manages\nan array of members or values.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/properties/purge?view=dsc-3.0&preserve-view=true\n"
+                              },
+                              "_rebootRequested": {
+                                "title": "Standard property: _rebootRequested",
+                                "description": "Indicates whether a resource instance requires a reboot after a set operation. To use DSC's built-in reboot notification processing, resources must define this property in their manifest.",
+                                "const": {
+                                  "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json"
+                                },
+                                "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nIndicates that the DSC Resource uses the standard `_rebootRequested` property to\nreport whether the machine should be rebooted after the `set` method executes.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/properties/rebootrequested?view=dsc-3.0&preserve-view=true\n"
+                              }
+                            },
+                            "defaultSnippets": [
+                              {
+                                "label": " Define an instance property",
+                                "markdownDescription": "Define a property for the resource instance schema.",
+                                "body": {
+                                  "${1:propertyName}": {
+                                    "title": "${2:property title}",
+                                    "description": "${3:explanation of property purpose and usage}",
+                                    "type": "${4|string,integer,number,array,object,null|}"
+                                  }
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      },
+                      "url": {
+                        "title": "Instance Schema URL",
+                        "description": "Defines the URL to the DSC Resource's JSON schema for integrating tools.",
+                        "type": "string",
+                        "format": "uri",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines the URL to the DSC Resource's JSON schema for integrating tools.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true#url\n"
+                      }
+                    },
+                    "examples": [
+                      {
+                        "command": {
+                          "executable": "registry",
+                          "args": [
+                            "schema"
+                          ]
+                        }
+                      },
+                      {
+                        "embedded": {
+                          "$schema": "http://json-schema.org/draft-07/schema#",
+                          "title": "OSInfo",
+                          "type": "object",
+                          "required": [],
+                          "properties": {
+                            "$id": {
+                              "type": "string"
+                            },
+                            "architecture": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "bitness": {
+                              "$ref": "#/definitions/Bitness"
+                            },
+                            "codename": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "edition": {
+                              "type": [
+                                "string",
+                                "null"
+                              ]
+                            },
+                            "family": {
+                              "$ref": "#/definitions/Family"
+                            },
+                            "version": {
+                              "type": "string"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "definitions": {
+                            "Bitness": {
+                              "type": "string",
+                              "enum": [
+                                "32",
+                                "64",
+                                "unknown"
+                              ]
+                            },
+                            "Family": {
+                              "type": "string",
+                              "enum": [
+                                "Linux",
+                                "macOS",
+                                "Windows"
+                              ]
+                            }
+                          }
+                        }
+                      }
+                    ],
+                    "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefines how DSC must validate a JSON blob representing an instance of the DSC Resource.\n\nThe JSON schema can be defined dynamically with the `command` property or statically with the\n`embedded` property.\n\nFor development purposes, it can be more convenient to use the `command` property and avoid\nneeding to adjust both the code and the schema.\n\nMicrosoft recommends using the `embedded` property when publishing a resource publicly. When the\nmanifest declares the schema with the `command` property, DSC calls the command at the beginning\nof any operation using the resource, possibly impacting performance. The schema is also\nunavailable to integrating tools when the resource isn't installed locally. When the schema is\nembedded in the manifest, DSC and integrating tools only need the manifest itself.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true\n",
+                    "defaultSnippets": [
+                      {
+                        "label": " Define as command without arguments",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefine the resource instance schema as a command when no arguments are required.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true#command\n",
+                        "body": {
+                          "command": {
+                            "executable": "${1:executable_name}"
+                          }
+                        }
+                      },
+                      {
+                        "label": " Define as command with arguments",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefine the resource instance schema as a command when at least one argument is required.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/property?view=dsc-3.0&preserve-view=true#command\n",
+                        "body": {
+                          "command": {
+                            "executable": "${1:executable_name}",
+                            "args": [
+                              "${2:--first-argument}"
+                            ]
+                          }
+                        }
+                      },
+                      {
+                        "label": " Define as an embedded schema",
+                        "markdownDescription": "***\n[_Online Documentation_][01]\n***\n\nDefine the resource instance schema embedded in the manifest. This is the preferred option\nfor publicly published resources.\n\n[01]: https://learn.microsoft.com/powershell/dsc/reference/schemas/resource/manifest/schema/embedded?view=dsc-3.0&preserve-view=true\n",
+                        "body": {
+                          "embedded": {
+                            "${escape_dollar:$}schema": "${1|https://json-schema.org/draft/2020-12/schema,https://json-schema.org/draft/2019-09/schema,http://json-schema.org/draft-07/schema#|}",
+                            "type": "object",
+                            "properties": {
+                              "${2:name}": {
+                                "title": "${3:property title}",
+                                "description": "${4:explanation of property purpose and usage}",
+                                "type": "${5|string,integer,number,array,object,null|}"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/2023/10/config/document.json
+++ b/schemas/2023/10/config/document.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json",
+  "title": "DSC Configuration Document schema",
+  "description": "Describes a valid DSC Configuration Document.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "resources"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Schema",
+      "description": "This property must be the canonical URL of the DSC Configuration Document schema that the document is implemented for.",
+      "type": "string",
+      "format": "uri",
+      "enum": [
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/config/document.vscode.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/config/document.vscode.json"
+      ]
+    },
+    "parameters": {
+      "title": "DSC Configuration document parameters",
+      "description": "Defines runtime options for the configuration. Users and integrating tools can override use the defined parameters to pass alternate values to the configuration.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json"
+      }
+    },
+    "variables": {
+      "title": "Configuration variables",
+      "description": "Defines a set of reusable values for the configuration document. The names of this value's properties are the strings used to reference a variable's value.",
+      "type": "object"
+    },
+    "resources": {
+      "title": "DSC Configuration document resources",
+      "description": "Defines a list of DSC Resource instances for the configuration to manage.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json"
+      }
+    },
+    "metadata": {
+      "title": "Configuration metadata",
+      "description": "Defines a set of key-value pairs for the configuration. This metadata isn't validated.",
+      "type": "object"
+    }
+  }
+}

--- a/schemas/2023/10/config/document.parameter.json
+++ b/schemas/2023/10/config/document.parameter.json
@@ -1,0 +1,228 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.parameter.json",
+  "title": "Parameter",
+  "description": "Defines a runtime option for a DSC Configuration Document.",
+  "type": "object",
+  "required": [
+    "type"
+  ],
+  "properties": {
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json"
+    },
+    "defaultValue": {
+      "title": "Default value",
+      "description": "Defines the default value for the parameter.",
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json"
+    },
+    "allowedValues": {
+      "title": "Allowed values",
+      "description": "Defines a list of valid values for the parameter. If the parameter is defined with any other values, it's invalid.",
+      "type": "array",
+      "items": {
+        "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json"
+      }
+    },
+    "description": {
+      "title": "Parameter description",
+      "description": "Defines a synopsis for the parameter explaining its purpose.",
+      "type": "string"
+    },
+    "metadata": {
+      "title": "Parameter metadata",
+      "description": "Defines a set of key-value pairs for the parameter. This metadata isn't validated.",
+      "type": "object"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "int"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "minValue": {
+            "title": "Minimum value",
+            "description": "The minimum valid value for an integer type. If defined with the `maxValue` property, this value must be less than the value of `maxValue`.",
+            "type": "integer"
+          },
+          "maxValue": {
+            "title": "Maximum value",
+            "description": "The maximum valid value for an integer type. If defined with the `minValue` property, this value must be greater than the value of `minValue`.",
+            "type": "integer"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "string"
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "securestring"
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "array"
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "minLength": {
+            "title": "Minimum length",
+            "description": "The minimum valid length for a `string`, `securestring`, or `array`. If defined with the `maxLength` property, this value must be less than the value of `maxLength`.",
+            "type": "integer",
+            "minimum": 0
+          },
+          "maxLength": {
+            "title": "Maximum length",
+            "description": "The maximum valid length for a `string`, `securestring`, or `array`. If defined with the `minLength` property, this value must be less than the value of `minLength`.",
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "string"
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "securestring"
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "defaultValue": {
+            "type": "string"
+          },
+          "allowedValues": {
+            "items": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "oneOf": [
+          {
+            "properties": {
+              "type": {
+                "const": "object"
+              }
+            }
+          },
+          {
+            "properties": {
+              "type": {
+                "const": "secureobject"
+              }
+            }
+          }
+        ]
+      },
+      "then": {
+        "properties": {
+          "defaultValue": {
+            "type": "object"
+          },
+          "allowedValues": {
+            "items": {
+              "type": "object"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "int"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "defaultValue": {
+            "type": "integer"
+          },
+          "allowedValues": {
+            "items": {
+              "type": "integer"
+            }
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "array"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "defaultValue": {
+            "type": "array"
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "type": {
+            "const": "bool"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "defaultValue": {
+            "type": "boolean"
+          },
+          "allowedValues": {
+            "items": {
+              "type": "boolean"
+            }
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/2023/10/config/document.resource.json
+++ b/schemas/2023/10/config/document.resource.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.resource.json",
+  "title": "DSC Resource instance",
+  "description": "Defines an instance of a DSC Resource in a configuration.",
+  "type": "object",
+  "required": [
+    "type",
+    "name"
+  ],
+  "properties": {
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "name": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+    },
+    "dependsOn": {
+      "title": "Instance depends on",
+      "description": "Defines a list of DSC Resource instances that DSC must successfully process before processing this instance. Each value for this property must be the `resourceID()` lookup for another instance in the configuration. Multiple instances can depend on the same instance, but every dependency for an instance must be unique in that instance's `dependsOn` property.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "uniqueItems": true,
+        "pattern": "^\\[resourceId\\(\\s*'\\w+(\\.\\w+){0,2}\\/\\w+'\\s*,\\s*'[a-zA-Z0-9 ]+'\\s*\\)\\]$"
+      }
+    },
+    "properties": {
+      "title": "Managed instance properties",
+      "description": "Defines the properties of the DSC Resource this instance manages. This property's value must be an object. DSC validates the property's value against the DSC Resource's schema.",
+      "type": "object"
+    }
+  }
+}

--- a/schemas/2023/10/definitions/commandArgs.json
+++ b/schemas/2023/10/definitions/commandArgs.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json",
+  "title": "Executable Command Arguments",
+  "description": "The list of arguments to pass to the command.",
+  "type": "array",
+  "items": {
+    "type": "string"
+  }
+}

--- a/schemas/2023/10/definitions/commandExecutable.json
+++ b/schemas/2023/10/definitions/commandExecutable.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json",
+  "title": "Executable Command Name",
+  "description": "The name of the command to run.",
+  "type": "string"
+}

--- a/schemas/2023/10/definitions/hadErrors.json
+++ b/schemas/2023/10/definitions/hadErrors.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json",
+  "title": "Had Errors",
+  "description": "Indicates whether any of the DSC Resources returned a non-zero exit code.",
+  "type": "boolean"
+}

--- a/schemas/2023/10/definitions/inputKind.json
+++ b/schemas/2023/10/definitions/inputKind.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json",
+  "title": "Executable Command Input Type",
+  "description": "Defines how DSC should pass input to the command, either as environment variables or JSON over stdin. When this value isn't defined, DSC doesn't send the resource any input.",
+  "type": "string",
+  "enum": [
+    "env",
+    "stdin"
+  ]
+}

--- a/schemas/2023/10/definitions/instanceName.json
+++ b/schemas/2023/10/definitions/instanceName.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json",
+  "title": "Instance name",
+  "description": "The short, human-readable name for a DSC Resource instance. Must be unique within a DSC Configuration document. Must be a non-empty string containing only letters, numbers, and spaces.",
+  "type": "string",
+  "pattern": "^[a-zA-Z0-9 ]+$",
+  "minLength": 1
+}

--- a/schemas/2023/10/definitions/message.json
+++ b/schemas/2023/10/definitions/message.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/message.json",
+  "title": "Message",
+  "description": "A message emitted by a DSC Resource with associated metadata.",
+  "type": "object",
+  "required": [
+    "name",
+    "type",
+    "message",
+    "level"
+  ],
+  "properties": {
+    "name": {
+      "title": "Message source instance name",
+      "description": "The short, human-readable name for the instance that emitted the message, as defined in the DSC Configuration Document.",
+      "type": "string"
+    },
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "message": {
+      "title": "Message content",
+      "description": "The actual content of the message as emitted by the DSC Resource.",
+      "type": "string",
+      "minLength": 1
+    },
+    "level": {
+      "title": "Message level",
+      "description": "Indicates the severity of the message.",
+      "type": "string",
+      "enum": [
+        "Error",
+        "Warning",
+        "Information"
+      ]
+    }
+  }
+}

--- a/schemas/2023/10/definitions/messages.json
+++ b/schemas/2023/10/definitions/messages.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json",
+  "title": "Messages",
+  "description": "A list of structured messages emitted by the DSC Resources during an operation.",
+  "type": "array",
+  "items": {
+    "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/message.json"
+  }
+}

--- a/schemas/2023/10/definitions/parameters/dataTypes.json
+++ b/schemas/2023/10/definitions/parameters/dataTypes.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/dataTypes.json",
+  "title": "Data Types",
+  "description": "Defines the data type for the parameter value.",
+  "type": "string",
+  "enum": [
+    "string",
+    "securestring",
+    "int",
+    "bool",
+    "object",
+    "secureobject",
+    "array"
+  ]
+}

--- a/schemas/2023/10/definitions/parameters/validValueTypes.json
+++ b/schemas/2023/10/definitions/parameters/validValueTypes.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/parameters/validValueTypes.json",
+  "$comment": "This schema fragment makes it a little easier to compose the valid properties\nfor DSC Configuration document parameters. As-written, values must be one of\nthose on this list - the schema definition for dataType excludes `null` and\nnumbers with fractional parts, like `3.5`.\n",
+  "type": [
+    "string",
+    "integer",
+    "object",
+    "array",
+    "boolean"
+  ]
+}

--- a/schemas/2023/10/definitions/resourceType.json
+++ b/schemas/2023/10/definitions/resourceType.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json",
+  "title": "DSC Resource fully qualified type name",
+  "description": "The namespaced name of the DSC Resource, using the syntax:\n\nowner[.group][.area]/name\n\nFor example:\n\n  - Microsoft.SqlServer/Database\n  - Microsoft.SqlServer.Database/User\n",
+  "type": "string",
+  "pattern": "^\\w+(\\.\\w+){0,2}\\/\\w+$"
+}

--- a/schemas/2023/10/definitions/returnKind.json
+++ b/schemas/2023/10/definitions/returnKind.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json",
+  "title": "Return Kind",
+  "type": "string",
+  "enum": [
+    "state",
+    "stateAndDiff"
+  ],
+  "default": "state",
+  "$comment": "While the enumeration for return kind is the same for the `set` and `test`\nmethod, the way it changes the behavior of the command isn't. The description\nkeyword isn't included here because the respective schemas for those methods\ndocument the behavior themselves."
+}

--- a/schemas/2023/10/definitions/semver.json
+++ b/schemas/2023/10/definitions/semver.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json",
+  "type": "string",
+  "title": "Semantic Version",
+  "description": "A valid semantic version (semver) string.\n\nFor reference, see https://semver.org/\n",
+  "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+  "$comment": "A valid semantic version ([semver][01]) string.\n\nThis value uses the [suggested regular expression][02] to validate whether the string is valid\nsemver. This is the same pattern, made multi-line for easier readability:\n\n```regex\n^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\n(?:-(\n  (?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)\n  (?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))\n*))?\n(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$\n```\n\nThe first line matches the `major.minor.patch` components of the version. The middle lines match\nthe pre-release components. The last line matches the build metadata component.\n\n[01]: https://semver.org/\n[02]: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string\n"
+}

--- a/schemas/2023/10/outputs/config/get.json
+++ b/schemas/2023/10/outputs/config/get.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/get.json",
+  "title": "DSC Configuration get command result",
+  "description": "Represents the data structure returned by the `dsc config get` command.",
+  "type": "object",
+  "required": [
+    "results",
+    "messages",
+    "hadErrors"
+  ],
+  "properties": {
+    "results": {
+      "title": "Results",
+      "description": "The results of the `get` method for every DSC Resource instance in the DSC Configuration Document with the instance's name and type.",
+      "type": "array",
+      "items": {
+        "title": "Get Result",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+          },
+          "type": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+          },
+          "result": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json"
+          }
+        }
+      }
+    },
+    "messages": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json"
+    },
+    "hadErrors": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json"
+    }
+  }
+}

--- a/schemas/2023/10/outputs/config/set.json
+++ b/schemas/2023/10/outputs/config/set.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/set.json",
+  "title": "DSC Configuration set command result",
+  "description": "Represents the data structure returned by the `dsc config set` command.",
+  "type": "object",
+  "required": [
+    "results",
+    "messages",
+    "hadErrors"
+  ],
+  "properties": {
+    "results": {
+      "title": "Results",
+      "description": "The results of the `set` method for every DSC Resource instance in the DSC Configuration Document with the instance's name and type.",
+      "type": "array",
+      "items": {
+        "title": "Set Result",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+          },
+          "type": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+          },
+          "result": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json"
+          }
+        }
+      }
+    },
+    "messages": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json"
+    },
+    "hadErrors": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json"
+    }
+  }
+}

--- a/schemas/2023/10/outputs/config/test.json
+++ b/schemas/2023/10/outputs/config/test.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/config/test.json",
+  "title": "DSC Configuration test command result",
+  "description": "Represents the data structure returned by the `dsc config test` command.",
+  "type": "object",
+  "required": [
+    "results",
+    "messages",
+    "hadErrors"
+  ],
+  "properties": {
+    "results": {
+      "title": "Results",
+      "description": "The results of the `test` method for every DSC Resource instance in the DSC Configuration Document with the instance's name and type.",
+      "type": "array",
+      "items": {
+        "title": "Test Result",
+        "type": "object",
+        "required": [
+          "name",
+          "type",
+          "result"
+        ],
+        "properties": {
+          "name": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/instanceName.json"
+          },
+          "type": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+          },
+          "result": {
+            "$ref": "/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json"
+          }
+        }
+      }
+    },
+    "messages": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/messages.json"
+    },
+    "hadErrors": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/hadErrors.json"
+    }
+  }
+}

--- a/schemas/2023/10/outputs/resource/get.json
+++ b/schemas/2023/10/outputs/resource/get.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/get.json",
+  "title": "dsc resource get result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource get` command.",
+  "type": "object",
+  "required": [
+    "actualState"
+  ],
+  "properties": {
+    "actualState": {
+      "title": "Actual state",
+      "description": "This property always represents the current state of the DSC Resource instance as returned by its `get` method. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    }
+  }
+}

--- a/schemas/2023/10/outputs/resource/list.json
+++ b/schemas/2023/10/outputs/resource/list.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/list.json",
+  "title": "dsc resource list result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource list` command.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "version": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json"
+    },
+    "description": {
+      "title": "Resource Description",
+      "description": "A short synopsis of the DSC Resource's purpose.",
+      "type": "string"
+    },
+    "path": {
+      "title": "Path",
+      "description": "Indicates the path to the DSC Resource on the file system.",
+      "type": "string"
+    },
+    "directory": {
+      "title": "Directory",
+      "description": "Indicates the path to the folder containing the DSC Resource on the file system.",
+      "type": "string"
+    },
+    "implementedAs": {
+      "title": "Implemented as",
+      "description": "Indicates how the DSC Resource was implemented.",
+      "oneOf": [
+        {
+          "title": "Standard implementation",
+          "description": "Indicates that the DSC Resource is implemented as one of the standard implementations built into DSC.",
+          "type": "string",
+          "enum": [
+            "Command"
+          ]
+        },
+        {
+          "title": "Custom implementation",
+          "description": "Indicates that the DSC Resource uses a custom implementation.",
+          "type": "object",
+          "required": [
+            "custom"
+          ],
+          "properties": {
+            "custom": {
+              "title": "Custom implementation name",
+              "description": "The name of the custom implementation.",
+              "type": "string"
+            }
+          }
+        }
+      ]
+    },
+    "author": {
+      "title": "Author",
+      "description": "Indicates the name of the person or organization that developed and maintains the DSC Resource.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "properties": {
+      "title": "Properties",
+      "description": "Defines the DSC Resource's property names.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^\\w+$"
+      }
+    },
+    "requires": {
+      "title": "Required DSC Resource Provider",
+      "description": "Defines the fully qualified type name of the DSC Resource Provider the DSC Resource depends on.",
+      "oneOf": [
+        {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "manifest": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json"
+    }
+  }
+}

--- a/schemas/2023/10/outputs/resource/schema.json
+++ b/schemas/2023/10/outputs/resource/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/schema.json",
+  "title": "DSC Resource schema result",
+  "description": "Describes the return data for a DSC Resource from the `dsc resource schema` command. This command always returns the DSC Resource's JSON schema document.",
+  "type": "object"
+}

--- a/schemas/2023/10/outputs/resource/set.json
+++ b/schemas/2023/10/outputs/resource/set.json
@@ -1,0 +1,33 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/set.json",
+  "title": "dsc resource set result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource set` command.",
+  "type": "object",
+  "required": [
+    "beforeState",
+    "afterState",
+    "changedProperties"
+  ],
+  "properties": {
+    "beforeState": {
+      "title": "State before enforcing",
+      "description": "This property always represents the desired state of the DSC Resource instance before the `set` method runs. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    },
+    "afterState": {
+      "title": "State after enforcing",
+      "description": "This property always represents the current state of the DSC Resource instance as returned by its `set` method after enforcing the desired state. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    },
+    "changedProperties": {
+      "title": "Changed properties",
+      "description": "This property always represents the list of property names for the DSC Resource instance that the `set` method modified. When this value is an empty array, the `set` method didn't enforce any properties for the instance.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/2023/10/outputs/resource/test.json
+++ b/schemas/2023/10/outputs/resource/test.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/resource/test.json",
+  "title": "dsc resource test result",
+  "description": "Describes the return data for a DSC Resource instance from the `dsc resource test` command.",
+  "type": "object",
+  "required": [
+    "desiredState",
+    "actualState",
+    "inDesiredState",
+    "differingProperties"
+  ],
+  "properties": {
+    "desiredState": {
+      "title": "Desired state",
+      "description": "This property always represents the desired state of the DSC Resource instance as specified to DSC.",
+      "type": "object"
+    },
+    "actualState": {
+      "title": "Actual state",
+      "description": "This property always represents the current state of the DSC Resource instance as returned by its `test` method or, if the DSC Resource doesn't define the `test` method, by its `get` method. DSC validates this return value against the DSC Resource's schema.",
+      "type": "object"
+    },
+    "inDesiredState": {
+      "title": "Instance is in the desired state",
+      "description": "This property indicates whether the instance is in the desired state.",
+      "type": "boolean"
+    },
+    "differingProperties": {
+      "title": "Differing properties",
+      "description": "This property always represents the list of property names for the DSC Resource instance that aren't in the desired state. When this property is an empty array, the instance is in the desired state.",
+      "type": "array",
+      "default": [],
+      "items": {
+        "type": "string"
+      }
+    }
+  }
+}

--- a/schemas/2023/10/outputs/schema.json
+++ b/schemas/2023/10/outputs/schema.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/outputs/schema.json",
+  "title": "DSC Resource schema result",
+  "description": "Describes the return data for a DSC Resource from the `dsc schema` command. This command always returns a JSON schema document.",
+  "type": "object"
+}

--- a/schemas/2023/10/resource/manifest.export.json
+++ b/schemas/2023/10/resource/manifest.export.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json",
+  "title": "Get Method",
+  "description": "Defines how DSC must call the DSC Resource to get the current state of every instance.",
+  "type": "object",
+  "required": [
+    "executable"
+  ],
+  "properties": {
+    "executable": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+    },
+    "args": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+    }
+  }
+}

--- a/schemas/2023/10/resource/manifest.get.json
+++ b/schemas/2023/10/resource/manifest.get.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json",
+  "title": "Get Method",
+  "description": "Defines how DSC must call the DSC Resource to get the current state of an instance.",
+  "type": "object",
+  "required": [
+    "executable"
+  ],
+  "properties": {
+    "executable": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+    },
+    "args": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+    },
+    "input": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+    }
+  },
+  "examples": [
+    {
+      "executable": "registry",
+      "args": [
+        "config",
+        "get"
+      ],
+      "input": "stdin"
+    },
+    {
+      "executable": "osinfo"
+    }
+  ]
+}

--- a/schemas/2023/10/resource/manifest.json
+++ b/schemas/2023/10/resource/manifest.json
@@ -1,0 +1,100 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+  "title": "Command-based DSC Resource Manifest",
+  "description": "Defines the information DSC and integrating require to process and call a command-based DSC Resource.",
+  "type": "object",
+  "required": [
+    "$schema",
+    "type",
+    "version",
+    "get"
+  ],
+  "properties": {
+    "$schema": {
+      "title": "Manifest Schema",
+      "description": "This property must be the canonical URL of the Command-based DSC Resource Manifest schema that the manifest is implemented for.",
+      "type": "string",
+      "format": "uri",
+      "enum": [
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
+        "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.vscode.json"
+      ]
+    },
+    "type": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/resourceType.json"
+    },
+    "version": {
+      "title": "Resource Semantic Version",
+      "description": "The semantic version (semver) of the DSC Resource. This version identifies the DSC Resource, not the version of the application it manages.",
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/semver.json"
+    },
+    "description": {
+      "title": "Resource Description",
+      "description": "A short synopsis of the DSC Resource's purpose.",
+      "type": "string"
+    },
+    "tags": {
+      "title": "Tags",
+      "description": "Defines a list of searchable terms for the resource.",
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "type": "string",
+        "pattern": "^\\w+$"
+      }
+    },
+    "get": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.get.json"
+    },
+    "export": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.export.json"
+    },
+    "set": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json"
+    },
+    "test": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json"
+    },
+    "validate": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json"
+    },
+    "provider": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json"
+    },
+    "exitCodes": {
+      "title": "Exit Codes",
+      "description": "This property defines a map of valid exit codes for the DSC Resource. DSC always interprets exit code `0` as a successful operation and any other exit code as an error. Use this property to indicate human-readable semantic meanings for the DSC Resource's exit codes.",
+      "type": "object",
+      "propertyNames": {
+        "pattern": "^[0-9]+$"
+      },
+      "patternProperties": {
+        "^[0-9]+$": {
+          "type": "string"
+        }
+      },
+      "unevaluatedProperties": false,
+      "default": {
+        "0": "Success",
+        "1": "Error"
+      },
+      "examples": [
+        {
+          "0": "Success",
+          "1": "Invalid parameter",
+          "2": "Invalid input",
+          "3": "Registry error",
+          "4": "JSON serialization failed"
+        }
+      ]
+    },
+    "schema": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json"
+    }
+  }
+}

--- a/schemas/2023/10/resource/manifest.provider.json
+++ b/schemas/2023/10/resource/manifest.provider.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.provider.json",
+  "title": "Provider",
+  "description": "Defines the DSC Resource as a DSC Resource Provider. A DSC Resource Provider enables users to manage resources that don't have their own manifests with DSC.",
+  "type": "object",
+  "required": [
+    "list",
+    "config"
+  ],
+  "properties": {
+    "list": {
+      "title": "List Command",
+      "description": "Defines how DSC must call the DSC Resource Provider to list its supported DSC Resources.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        }
+      }
+    },
+    "config": {
+      "title": "Expected Configuration",
+      "description": "Defines whether the provider expects to receive a full and unprocessed configuration as a single JSON blob over stdin or a sequence of JSON Lines for each child resource's configurations.",
+      "type": "string",
+      "enum": [
+        "full",
+        "sequence"
+      ]
+    }
+  },
+  "examples": [
+    {
+      "config": "full",
+      "list": {
+        "executable": "pwsh",
+        "args": [
+          "-NoLogo",
+          "-NonInteractive",
+          "-NoProfile",
+          "-Command",
+          "./powershellgroup.resource.ps1 List"
+        ]
+      }
+    }
+  ]
+}

--- a/schemas/2023/10/resource/manifest.schema.json
+++ b/schemas/2023/10/resource/manifest.schema.json
@@ -1,0 +1,196 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.schema.json",
+  "title": "Instance Schema",
+  "description": "Defines how DSC must validate a JSON blob representing an instance of the DSC Resource.",
+  "type": "object",
+  "oneOf": [
+    {
+      "required": [
+        "command"
+      ]
+    },
+    {
+      "required": [
+        "embedded"
+      ]
+    }
+  ],
+  "properties": {
+    "command": {
+      "title": "Instance Schema Command",
+      "description": "Defines how DSC must call the DSC Resource to get the JSON Schema for validating a JSON blob representing an instance of the DSC Resource.",
+      "type": "object",
+      "required": [
+        "executable"
+      ],
+      "properties": {
+        "executable": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+        },
+        "args": {
+          "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+        }
+      }
+    },
+    "embedded": {
+      "title": "Embedded Instance Schema",
+      "description": "Defines the JSON Schema DSC must use to validate a JSON blob representing an instance of the DSC Resource.",
+      "type": "object",
+      "required": [
+        "$schema",
+        "type",
+        "properties"
+      ],
+      "properties": {
+        "type": {
+          "title": "Instance Type",
+          "description": "Defines the JSON type for an instance of the DSC Resource. DSC Resource instances always have the `object` type.",
+          "const": "object"
+        },
+        "$schema": {
+          "title": "DSC Resource instance schema dialect",
+          "description": "Defines which dialect of JSON Schema the DSC Resource is using to validate instances.",
+          "type": "string",
+          "format": "uri-reference",
+          "enum": [
+            "https://json-schema.org/draft/2020-12/schema",
+            "https://json-schema.org/draft/2019-09/schema",
+            "http://json-schema.org/draft-07/schema#"
+          ]
+        },
+        "$id": {
+          "title": "DSC Resource instance schema ID",
+          "description": "Defines the unique ID for the DSC Resource's instance schema. If the instance schema is published to its own public URI, set this keyword to that URI.",
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "properties": {
+          "title": "Instance Properties",
+          "description": "Defines the properties that DSC can retrieve and manage for the resource's instances. This keyword must define at least one property as a key-value pair. The key is the property's name. The value is a subschema that validates the property.",
+          "type": "object",
+          "minProperties": 1,
+          "unevaluatedProperties": {
+            "anyOf": [
+              {
+                "$ref": "https://json-schema.org/draft/2020-12/schema"
+              },
+              {
+                "$ref": "https://json-schema.org/draft/2019-09/schema"
+              },
+              {
+                "$ref": "http://json-schema.org/draft-07/schema#"
+              }
+            ]
+          },
+          "additionalProperties": {},
+          "properties": {
+            "_exist": {
+              "title": "Standard Property: _exist",
+              "description": "Indicates that the DSC Resource uses the standard `_exist` property to specify whether an instance should exist as a boolean value that defaults to `true`.",
+              "const": {
+                "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json"
+              }
+            },
+            "_inDesiredState": {
+              "title": "Standard Property: _inDesiredState",
+              "description": "Indicates that the DSC Resource returns this value for it's own `test` method. This read-only property is mandatory when the manifest defines the `test` property. It shouldn't be included if the DSC Resource relies on DSC's synthetic testing.",
+              "const": {
+                "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json"
+              }
+            },
+            "_purge": {
+              "title": "Standard Property: _purge",
+              "description": "Indicates that the DSC Resource uses the standard `_purge` property to specify whether the DSC Resource should remove all non-specified members when it manages an array of members or values.",
+              "const": {
+                "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json"
+              }
+            },
+            "_rebootRequested": {
+              "title": "Standard property: _rebootRequested",
+              "description": "Indicates whether a resource instance requires a reboot after a set operation. To use DSC's built-in reboot notification processing, resources must define this property in their manifest.",
+              "const": {
+                "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json"
+              }
+            }
+          }
+        }
+      }
+    },
+    "url": {
+      "title": "Instance Schema URL",
+      "description": "Defines the URL to the DSC Resource's JSON schema for integrating tools.",
+      "type": "string",
+      "format": "uri"
+    }
+  },
+  "examples": [
+    {
+      "command": {
+        "executable": "registry",
+        "args": [
+          "schema"
+        ]
+      }
+    },
+    {
+      "embedded": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "title": "OSInfo",
+        "type": "object",
+        "required": [],
+        "properties": {
+          "$id": {
+            "type": "string"
+          },
+          "architecture": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "bitness": {
+            "$ref": "#/definitions/Bitness"
+          },
+          "codename": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "edition": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "family": {
+            "$ref": "#/definitions/Family"
+          },
+          "version": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false,
+        "definitions": {
+          "Bitness": {
+            "type": "string",
+            "enum": [
+              "32",
+              "64",
+              "unknown"
+            ]
+          },
+          "Family": {
+            "type": "string",
+            "enum": [
+              "Linux",
+              "macOS",
+              "Windows"
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/schemas/2023/10/resource/manifest.set.json
+++ b/schemas/2023/10/resource/manifest.set.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.set.json",
+  "title": "Set Method",
+  "description": "Defines how DSC must call the DSC Resource to set the desired state of an instance and how to process the output from the DSC Resource.",
+  "type": "object",
+  "required": [
+    "executable",
+    "input"
+  ],
+  "properties": {
+    "executable": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+    },
+    "args": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+    },
+    "input": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+    },
+    "implementsPretest": {
+      "title": "Resource Performs Pre-Test",
+      "description": "Defines whether the DSC Resource performs its own test to ensure idempotency when calling the `set` command. Set this value to `true` if the DSC Resource tests input before modifying system state.",
+      "type": "boolean",
+      "default": false
+    },
+    "return": {
+      "description": "Defines whether the command returns a JSON blob of the DSC Resource's state after the set operation or the state and an array of the properties the DSC Resource modified.",
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json"
+    }
+  },
+  "examples": [
+    {
+      "executable": "registry",
+      "args": [
+        "config",
+        "set"
+      ],
+      "input": "stdin",
+      "implementsPretest": true,
+      "return": "state"
+    }
+  ]
+}

--- a/schemas/2023/10/resource/manifest.test.json
+++ b/schemas/2023/10/resource/manifest.test.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.test.json",
+  "title": "Test Method",
+  "description": "Defines how DSC must call the DSC Resource to test if an instance is in the desired state and how to process the output from the DSC Resource.",
+  "type": "object",
+  "required": [
+    "executable",
+    "input"
+  ],
+  "properties": {
+    "executable": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+    },
+    "args": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+    },
+    "input": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/inputKind.json"
+    },
+    "return": {
+      "title": "Test Command Return Type",
+      "description": "Defines whether the command returns a JSON blob of the DSC Resource's current state or the state and an array of the properties that are out of the desired state.",
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/returnKind.json"
+    }
+  },
+  "examples": [
+    {
+      "executable": "registry",
+      "args": [
+        "config",
+        "test"
+      ],
+      "input": "stdin",
+      "return": "state"
+    }
+  ]
+}

--- a/schemas/2023/10/resource/manifest.validate.json
+++ b/schemas/2023/10/resource/manifest.validate.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/manifest.validate.json",
+  "title": "Validate Method",
+  "description": "Defines how DSC must call the DSC Resource to validate the state of an instance. This method is mandatory for DSC Group Resources. It's ignored for all other DSC Resources.",
+  "type": "object",
+  "required": [
+    "executable"
+  ],
+  "properties": {
+    "executable": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandExecutable.json"
+    },
+    "args": {
+      "$ref": "/PowerShell/DSC/main/schemas/2023/10/definitions/commandArgs.json"
+    }
+  },
+  "examples": [
+    {
+      "executable": "dsc",
+      "args": [
+        "config",
+        "validate"
+      ]
+    }
+  ]
+}

--- a/schemas/2023/10/resource/properties/exist.json
+++ b/schemas/2023/10/resource/properties/exist.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/exist.json",
+  "title": "Instance should exist",
+  "description": "Indicates whether the DSC Resource instance should exist.",
+  "type": "boolean",
+  "default": true,
+  "enum": [
+    false,
+    true
+  ]
+}

--- a/schemas/2023/10/resource/properties/inDesiredState.json
+++ b/schemas/2023/10/resource/properties/inDesiredState.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/inDesiredState.json",
+  "title": "Instance is in the Desired State",
+  "description": "Indicates whether the instance is in the desired state. This property is only returned by the `test` method.",
+  "type": [
+    "boolean",
+    "null"
+  ],
+  "readOnly": true
+}

--- a/schemas/2023/10/resource/properties/purge.json
+++ b/schemas/2023/10/resource/properties/purge.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/purge.json",
+  "title": "Purge",
+  "description": "Indicates that only the components described in the DSC Resource should exist. If other components exist, the DSC Resource is out of the desired state. When enforcing desired state, the DSC Resource removes unmanaged components.",
+  "type": [
+    "boolean",
+    "null"
+  ],
+  "writeOnly": true
+}

--- a/schemas/2023/10/resource/properties/rebootRequested.json
+++ b/schemas/2023/10/resource/properties/rebootRequested.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/resource/properties/rebootRequested.json",
+  "title": "Reboot Requested",
+  "description": "Indicates that the set operation requires a reboot before it's fully complete.",
+  "type": [
+    "boolean",
+    "null"
+  ],
+  "readOnly": true
+}

--- a/schemas/examples/foo.dsc.config.yaml
+++ b/schemas/examples/foo.dsc.config.yaml
@@ -1,4 +1,4 @@
-$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
 # Try adding the variables, metadata, and parameters properties,
 # then use IntelliSense to define a few entries.
 

--- a/schemas/examples/foo.dsc.resource.json
+++ b/schemas/examples/foo.dsc.resource.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "../2023/08/bundled/resource/manifest.vscode.json",
+    "$schema": "../2023/10/bundled/resource/manifest.vscode.json",
     "type": "Example/Resource",
     "description": "An example resource using the schema.",
     "version": "0.1.0",

--- a/schemas/examples/foo.dsc.resource.yaml
+++ b/schemas/examples/foo.dsc.resource.yaml
@@ -2,7 +2,7 @@
 #    https://raw.githubusercontent.com/PowerShell/DSC/main/2023/08/resource/manifest.json
 #
 # Hover on the keys to see the documentation. Try changing values and adding new settings.
-manifestVersion: 1.0.0
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/bundled/resource/manifest.vscode.json
 type: Example/Foo
 version: 0.1.0
 description: An example resource to manage the foo application.

--- a/schemas/schemas.config.yaml
+++ b/schemas/schemas.config.yaml
@@ -1,6 +1,6 @@
 host:             https://raw.githubusercontent.com
 prefix:           PowerShell/DSC/main/schemas
-version:          2023/08
+version:          2023/10
 docs_base_url:    https://learn.microsoft.com/powershell/dsc
 docs_version_pin: view=dsc-3.0&preserve-view=true
 bundle_schemas:

--- a/schemas/src/config/document.yaml
+++ b/schemas/src/config/document.yaml
@@ -32,6 +32,11 @@ properties:
     format: uri
     enum:
       - <HOST>/<PREFIX>/<VERSION>/config/document.yaml
+      - <HOST>/<PREFIX>/<VERSION>/bundled/config/document.yaml
+      - <HOST>/<PREFIX>/<VERSION>/bundled/config/document.vscode.yaml
+      - <HOST>/<PREFIX>/2023/08/config/document.yaml
+      - <HOST>/<PREFIX>/2023/08/bundled/config/document.yaml
+      - <HOST>/<PREFIX>/2023/08/bundled/config/document.vscode.yaml
     # VS Code only:
     markdownDescription: |
       ***
@@ -41,12 +46,110 @@ properties:
       This property must be the canonical URL of the DSC Configuration Document schema that the
       document is implemented for.
 
+      For every version of the schema, there are three valid urls:
+
+      ```yaml
+      .../config/document.json
+      ```
+      
+      > The URL to the canonical non-bundled schema. When it's used for validation, the validating
+      > client needs to retrieve this schema and every schema it references.
+        
+      ```yaml
+      .../bundled/config/document.json
+      ```
+      
+      > The URL to the bundled schema. When it's used for validation, the validating client only
+      > needs to retrieve this schema.
+      >
+      > This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can
+      > still validate the document when it uses this schema, other tools may error or behave
+      > in unexpected ways.
+
+      ```yaml
+      .../bundled/config/document.vscode.json
+      ```
+      
+      > The URL to the enhanced authoring schema. This schema is much larger than the other
+      > schemas, as it includes additional definitions that provide contextual help and snippets
+      > that the others don't include.
+      >
+      > This schema uses keywords that are only recognized by VS Code. While DSC can still
+      > validate the document when it uses this schema, other tools may error or behave in
+      > unexpected ways.
+
       [01]: <DOCS_BASE_URL>/reference/schemas/config/document?<DOCS_VERSION_PIN>#schema
     markdownEnumDescriptions:
       - | # <HOST>/<PREFIX>/<VERSION>/config/document.yaml
           <!-- force a line break -->
 
-          > Indicates that the configuration document adheres to the `<VERSION>` schema.
+          > #### `<VERSION>` non-bundled
+          >
+          > Indicates that the configuration document adheres to the `<VERSION>` schema. This URL
+          > points to the canonical non-bundled schema. When it's used for validation, the
+          > validating client needs to retrieve this schema and every schema it references.
+      - | # <HOST>/<PREFIX>/<VERSION>/bundled/config/document.yaml
+          <!-- force a line break -->
+
+          > #### `<VERSION>` bundled
+          >
+          > Indicates that the configuration document adheres to the `<VERSION>` schema. This URL
+          > points to the bundled schema. When it's used for validation, the validating client
+          > only needs to retrieve this schema.
+          >
+          > This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can
+          > still validate the document when it uses this schema, other tools may error or behave
+          > in unexpected ways.
+      - | # <HOST>/<PREFIX>/<VERSION>/bundled/config/document.vscode.yaml
+          <!-- force a line break -->
+
+          > #### `<VERSION>` enhanced authoring
+          >
+          > Indicates that the configuration document adheres to the `<VERSION>` schema. This URL
+          > points to the enhanced authoring schema. This schema is much larger than the other
+          > schemas, as it includes additional definitions that provide contextual help and
+          > snippets that the others don't include.
+          >
+          > This schema uses keywords that are only recognized by VS Code. While DSC can still
+          > validate the document when it uses this schema, other tools may error or behave in
+          > unexpected ways.
+      - | # <HOST>/<PREFIX>/2023/08/config/document.yaml
+          <!-- force a line break -->
+
+          > #### `2023/08` non-bundled
+          >
+          > Indicates that the configuration document adheres to the `2023/08` schema. This version
+          > is deprecated, and should only be used for compatibility with `alpha.3` and earlier.
+          > Migrate to using the `<VERSION>` of the schema 
+          >
+          > This URL points to the canonical non-bundled schema. When it's used for validation, the
+          > validating client needs to retrieve this schema and every schema it references.
+
+      - | # <HOST>/<PREFIX>/2023/08/bundled/config/document.yaml
+          <!-- force a line break -->
+
+          > #### `2023/08` bundled
+          >
+          > Indicates that the configuration document adheres to the `2023/08` schema. This URL
+          > points to the bundled schema. When it's used for validation, the validating client
+          > only needs to retrieve this schema.
+          >
+          > This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can
+          > still validate the document when it uses this schema, other tools may error or behave
+          > in unexpected ways.
+      - | # <HOST>/<PREFIX>/2023/08/bundled/config/document.vscode.yaml
+          <!-- force a line break -->
+
+          > #### `2023/08` enhanced authoring
+          >
+          > Indicates that the configuration document adheres to the `2023/08` schema. This URL
+          > points to the enhanced authoring schema. This schema is much larger than the other
+          > schemas, as it includes additional definitions that provide contextual help and
+          > snippets that the others don't include.
+          >
+          > This schema uses keywords that are only recognized by VS Code. While DSC can still
+          > validate the document when it uses this schema, other tools may error or behave in
+          > unexpected ways.
 
   parameters:
     title: DSC Configuration document parameters

--- a/schemas/src/resource/manifest.yaml
+++ b/schemas/src/resource/manifest.yaml
@@ -177,20 +177,125 @@ properties:
     type:   string
     format: uri
     enum:
+      - <HOST>/<PREFIX>/<VERSION>/resource/manifest.yaml
       - <HOST>/<PREFIX>/<VERSION>/bundled/resource/manifest.yaml
+      - <HOST>/<PREFIX>/<VERSION>/bundled/resource/manifest.vscode.yaml
+      - <HOST>/<PREFIX>/2023/08/resource/manifest.yaml
+      - <HOST>/<PREFIX>/2023/08/bundled/resource/manifest.yaml
+      - <HOST>/<PREFIX>/2023/08/bundled/resource/manifest.vscode.yaml
     # VS Code Only
     markdownDescription: |
       ***
       [_Online Documentation_][01]
       ***
 
-      This property must be the canonical URL of the Command-based DSC Resource Manifest schema
-      that the manifest is implemented for.
+      This property must be one of the canonical URLs for the version of the Command-based DSC
+      Resource Manifest schema that the manifest is implemented for.
+      
+      For every version of the schema, there are three valid urls:
+
+      ```yaml
+      .../resource/manifest.json
+      ```
+      
+      > The URL to the canonical non-bundled schema. When it's used for validation, the validating
+      > client needs to retrieve this schema and every schema it references.
+
+      ```yaml
+      .../bundled/resource/manifest.json
+      ```
+      
+      > The URL to the bundled schema. When it's used for validation, the validating client only
+      > needs to retrieve this schema.
+      > 
+      > This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can
+      > still validate the document when it uses this schema, other tools may error or behave
+      > in unexpected ways.
+
+      ```yaml
+      .../bundled/resource/manifest.vscode.json
+      ```
+      
+      > The URL to the enhanced authoring schema. This schema is much larger than the other
+      > schemas, as it includes additional definitions that provide contextual help and snippets
+      > that the others don't include.
+      > 
+      > This schema uses keywords that are only recognized by VS Code. While DSC can still
+      > validate the document when it uses this schema, other tools may error or behave in
+      > unexpected ways.
 
       [01]: <DOCS_BASE_URL>/reference/schemas/resource/manifest/root?<DOCS_VERSION_PIN>#schema
     markdownEnumDescriptions:
-      - | # 1.0
-          _Initial release_
+      - | # <HOST>/<PREFIX>/<VERSION>/resource/manifest.yaml
+          <!-- force a line break -->
+
+          > #### `<VERSION>` non-bundled
+          >
+          > Indicates that the resource manifest adheres to the `<VERSION>` schema. This URL
+          > points to the canonical non-bundled schema. When it's used for validation, the
+          > validating client needs to retrieve this schema and every schema it references.
+      - | # <HOST>/<PREFIX>/<VERSION>/bundled/resource/manifest.yaml
+          <!-- force a line break -->
+
+          > #### `<VERSION>` bundled
+          >
+          > Indicates that the resource manifest adheres to the `<VERSION>` schema. This URL
+          > points to the bundled schema. When it's used for validation, the validating client
+          > only needs to retrieve this schema.
+          >
+          > This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can
+          > still validate the document when it uses this schema, other tools may error or behave
+          > in unexpected ways.
+      - | # <HOST>/<PREFIX>/<VERSION>/bundled/resource/manifest.vscode.yaml
+          <!-- force a line break -->
+
+          > #### `<VERSION>` enhanced authoring
+          >
+          > Indicates that the resource manifest adheres to the `<VERSION>` schema. This URL
+          > points to the enhanced authoring schema. This schema is much larger than the other
+          > schemas, as it includes additional definitions that provide contextual help and
+          > snippets that the others don't include.
+          >
+          > This schema uses keywords that are only recognized by VS Code. While DSC can still
+          > validate the document when it uses this schema, other tools may error or behave in
+          > unexpected ways.
+      - | # <HOST>/<PREFIX>/2023/08/resource/manifest.yaml
+          <!-- force a line break -->
+
+          > #### `2023/08` non-bundled
+          >
+          > Indicates that the resource manifest adheres to the `2023/08` schema. This version
+          > is deprecated, and should only be used for compatibility with `alpha.3` and earlier.
+          > Migrate to using the `<VERSION>` of the schema 
+          
+          > This URL points to the canonical non-bundled schema. When it's used for validation, the
+          > validating client needs to retrieve this schema and every schema it references.
+
+      - | # <HOST>/<PREFIX>/2023/08/bundled/resource/manifest.yaml
+          <!-- force a line break -->
+
+          > #### `2023/08` bundled
+          >
+          > Indicates that the resource manifest adheres to the `2023/08` schema. This URL
+          > points to the bundled schema. When it's used for validation, the validating client
+          > only needs to retrieve this schema.
+          >
+          > This schema uses the bundling model introduced for JSON Schema 2020-12. While DSC can
+          > still validate the document when it uses this schema, other tools may error or behave
+          > in unexpected ways.
+      - | # <HOST>/<PREFIX>/2023/08/bundled/resource/manifest.vscode.yaml
+          <!-- force a line break -->
+
+          > #### `2023/08` enhanced authoring
+          >
+          > Indicates that the resource manifest adheres to the `2023/08` schema. This URL
+          > points to the enhanced authoring schema. This schema is much larger than the other
+          > schemas, as it includes additional definitions that provide contextual help and
+          > snippets that the others don't include.
+          >
+          > This schema uses keywords that are only recognized by VS Code. While DSC can still
+          > validate the document when it uses this schema, other tools may error or behave in
+          > unexpected ways.
   type:
     $ref: /<PREFIX>/<VERSION>/definitions/resourceType.yaml
   version:

--- a/tools/test_group_resource/src/main.rs
+++ b/tools/test_group_resource/src/main.rs
@@ -24,7 +24,7 @@ fn main() {
                 requires: Some("Test/TestGroup".to_string()),
                 manifest: Some(serde_json::to_value(ResourceManifest {
                     description: Some("This is a test resource.".to_string()),
-                    schema_version: "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json".to_string(),
+                    schema_version: dsc_lib::dscresources::resource_manifest::ManifestSchemaUri::Version2023_10,
                     resource_type: "Test/TestResource1".to_string(),
                     version: "1.0.0".to_string(),
                     tags: None,
@@ -54,7 +54,7 @@ fn main() {
                 requires: Some("Test/TestGroup".to_string()),
                 manifest: Some(serde_json::to_value(ResourceManifest {
                     description: Some("This is a test resource.".to_string()),
-                    schema_version: "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json".to_string(),
+                    schema_version: dsc_lib::dscresources::resource_manifest::ManifestSchemaUri::Version2023_10,
                     resource_type: "Test/TestResource2".to_string(),
                     version: "1.0.1".to_string(),
                     tags: None,


### PR DESCRIPTION
# PR Summary

This change converts the string constants for the canonical schema URIs for both the configuration document and resource manifest schemas to enums, defining the valid URIs as variants.

For each supported version of a schema, there are three variants:

1. `Version<YYYY>_<MM>` - The canonical URI to the non-bundled schema. Using this schema requires retrieving every referenced schema, but it is also the least-munged.
1. `Bundled<YYYY>_<MM>` - The canonical URI to the bundled schema. When using this schema, only the bundled schema needs to be retrieved.
1. `VSCode<YYYY>_<MM>` - The canonical URI to the enhanced authoring schema. This schema is specifically implemented to support contextual help and DevX when authoring in VS Code. It is much larger than the other schemas.

Which gives six variants:

- `Version2023_08`, `Bundled2023_08`, and `VSCode2023_08` for 2023/08
- `Version2023_10`, `Bundled2023_10`, and `VSCode2023_10` for 2023/10

Currently, the specified schema is not actually used by DSC to validate the document or manifest. In the future, we could use the version to identify how to validate and process the data.

## PR Context

With the breaking changes made in recent PRs, and keeping in mind that we will eventually need to handle different versions of the schema, this PR:

- Lays the groundwork for handling multiple valid versions of the schema, even though both of these will probably be dropped when we move to beta
- Resolves #224