### PR TITLE
Implement use of tree-sitter parser

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -92,14 +92,18 @@ New-Item -ItemType Directory $target > $null
 
 # make sure dependencies are built first so clippy runs correctly
 $windows_projects = @("pal", "ntreg", "ntstatuserror", "ntuserinfo", "registry")
+
+# projects are in dependency order
 $projects = @(
-    "tree-sitter-dscexpression"
-    "dsc_lib"
-    "file_lib"
-    "dsc"
-    "osinfo"
-    "process"
-    "tools/test_group_resource"
+    "tree-sitter-dscexpression",
+    "dsc_lib",
+    "file_lib",
+    "dsc",
+    "osinfo",
+    "powershellgroup",
+    "process",
+    "tools/dsctest",
+    "tools/test_group_resource",
     "y2j"
     "powershellgroup"
     "resources/brew"

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -162,12 +162,9 @@ pub fn export(dsc: &mut DscManager, resource: &str, format: &Option<OutputFormat
 
     let mut conf = Configuration::new();
 
-    match add_resource_export_results_to_configuration(&dsc_resource, &mut conf) {
-        Ok(()) => (),
-        Err(err) => {
-            error!("Error: {err}");
-            exit(EXIT_DSC_ERROR);
-        }
+    if let Err(err) = add_resource_export_results_to_configuration(&dsc_resource, &mut conf) {
+        error!("Error: {err}");
+        exit(EXIT_DSC_ERROR);
     }
 
     let json = match serde_json::to_string(&conf) {
@@ -190,13 +187,10 @@ pub fn get_resource(dsc: &mut DscManager, resource: &str) -> DscResource {
                 exit(EXIT_INVALID_ARGS);
             }
 
-            match dsc.initialize_discovery() {
-                Ok(()) => (),
-                Err(err) => {
-                    error!("Error: {err}");
-                    exit(EXIT_DSC_ERROR);
-                }
-            };
+            if let Err(err) = dsc.initialize_discovery() {
+                error!("Error: {err}");
+                exit(EXIT_DSC_ERROR);
+            }
             let resources: Vec<DscResource> = dsc.find_resource(resource).collect();
             match resources.len() {
                 0 => {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -14,7 +14,7 @@ use dsc_lib::{
     dscresources::dscresource::{ImplementedAs, Invoke},
     dscresources::resource_manifest::{import_manifest, ResourceManifest},
 };
-use jsonschema::{JSONSchema, ValidationError};
+use jsonschema::JSONSchema;
 use serde_yaml::Value;
 use std::process::exit;
 
@@ -272,18 +272,15 @@ pub fn validate_config(config: &str) {
                         },
                     };
                     let properties = resource_block["properties"].clone();
-                    let _result: Result<(), ValidationError> = match compiled_schema.validate(&properties) {
-                        Ok(()) => Ok(()),
-                        Err(err) => {
-                            let mut error = String::new();
-                            for e in err {
-                                error.push_str(&format!("{e} "));
-                            }
-
-                            error!("Error: Resource {type_name} failed validation: {error}");
-                            exit(EXIT_VALIDATION_FAILED);
-                        },
-                    };
+                    let validation = compiled_schema.validate(&properties);
+                    if let Err(err) = validation {
+                        let mut error = String::new();
+                        for e in err {
+                            error.push_str(&format!("{e} "));
+                        }
+                        error!("Error: Resource {type_name} failed validation: {error}");
+                        exit(EXIT_VALIDATION_FAILED);
+                    }
                 }
             }
         }
@@ -303,13 +300,10 @@ pub fn resource(subcommand: &ResourceSubCommand, format: &Option<OutputFormat>, 
 
     match subcommand {
         ResourceSubCommand::List { resource_name, description, tags } => {
-            match dsc.initialize_discovery() {
-                Ok(()) => (),
-                Err(err) => {
-                    error!("Error: {err}");
-                    exit(EXIT_DSC_ERROR);
-                }
-            };
+            if let Err(err) = dsc.initialize_discovery() {
+                error!("Error: {err}");
+                exit(EXIT_DSC_ERROR);
+            }
             let mut write_table = false;
             let mut table = Table::new(&["Type", "Version", "Requires", "Description"]);
             if format.is_none() && atty::is(Stream::Stdout) {

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -4,6 +4,7 @@ version = "3.0.0-alpha.4"
 edition = "2021"
 
 [dependencies]
+base64 = "0.21"
 derive_builder ="0.12"
 jsonschema = "0.17"
 regex = "1.7"

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -14,6 +14,11 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 thiserror = "1.0"
 chrono = "0.4.26"
 tracing = "0.1.37"
+tree-sitter = "~0.20.10"
+tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
 
 [dev-dependencies]
 serde_yaml = "0.9"
+
+[build-dependencies]
+cc="*"

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -12,7 +12,6 @@ use self::depends_on::get_resource_invocation_order;
 use self::config_result::{ConfigurationGetResult, ConfigurationSetResult, ConfigurationTestResult, ConfigurationExportResult, ResourceMessage, MessageLevel};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
-use tree_sitter::Parser;
 
 pub mod config_doc;
 pub mod config_result;
@@ -21,7 +20,6 @@ pub mod depends_on;
 pub struct Configurator {
     config: String,
     discovery: Discovery,
-    parser: Parser,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -70,13 +68,10 @@ impl Configurator {
     pub fn new(config: &str) -> Result<Configurator, DscError> {
         let mut discovery = Discovery::new()?;
         discovery.initialize()?;
-        let mut parser = Parser::new();
-        parser.set_language(tree_sitter_dscexpression::language())?;
 
         Ok(Configurator {
             config: config.to_owned(),
             discovery,
-            parser,
         })
     }
 
@@ -317,16 +312,5 @@ impl Configurator {
         }
 
         Ok((config, messages, has_errors))
-    }
-
-    fn try_parse_expression(&self, expression: &str) -> Result<String, DscError> {
-        let tree = self.parser.parse(expression, None).unwrap();
-        let root_node = tree.root_node();
-        let child_node = root_node.child(0).unwrap_or_else(Error(DscError::Parser("Child node not found".to_string())));
-        match child_node.kind() {
-            "stringLiteral" => {
-
-            }
-        }
     }
 }

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -5,6 +5,7 @@ use reqwest::StatusCode;
 use thiserror::Error;
 use chrono::{Local, DateTime};
 use tracing::{error, warn};
+use tree_sitter::LanguageError;
 
 #[derive(Error, Debug)]
 pub enum DscError {
@@ -35,6 +36,9 @@ pub enum DscError {
     #[error("JSON: {0}")]
     Json(#[from] serde_json::Error),
 
+    #[error("Language: {0}")]
+    Language(#[from] LanguageError),
+
     #[error("Manifest: {0}\nJSON: {1}")]
     Manifest(String, serde_json::Error),
 
@@ -52,6 +56,9 @@ pub enum DscError {
 
     #[error("Operation: {0}")]
     Operation(String),
+
+    #[error("Parser: {0}")]
+    Parser(String),
 
     #[error("Resource not found: {0}")]
     ResourceNotFound(String),

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use std::str::Utf8Error;
+
 use reqwest::StatusCode;
 use thiserror::Error;
 use chrono::{Local, DateTime};
@@ -9,6 +11,9 @@ use tree_sitter::LanguageError;
 
 #[derive(Error, Debug)]
 pub enum DscError {
+    #[error("Function boolean argument conversion error: {0}")]
+    BooleanConversion(#[from] std::str::ParseBoolError),
+
     #[error("Command: Resource '{0}' [Exit code {1}] {2}")]
     Command(String, i32, String),
 
@@ -21,6 +26,9 @@ pub enum DscError {
     #[error("HTTP status: {0}")]
     HttpStatus(StatusCode),
 
+    #[error("Function integer argument conversion error: {0}")]
+    IntegerConversion(#[from] std::num::ParseIntError),
+
     #[error("Regex: {0}")]
     Regex(#[from] regex::Error),
 
@@ -29,6 +37,9 @@ pub enum DscError {
 
     #[error("Unsupported manifest version: {0}.  Must be: {1}")]
     InvalidManifestSchemaVersion(String, String),
+
+    #[error("Invalid function parameter count for '{0}', expected {1}, got {2}")]
+    InvalidFunctionParameterCount(String, usize, usize),
 
     #[error("IO: {0}")]
     Io(#[from] std::io::Error),
@@ -68,6 +79,9 @@ pub enum DscError {
 
     #[error("No Schema: {0}")]
     SchemaNotAvailable(String),
+
+    #[error("Utf-8 conversion error: {0}")]
+    Utf8Conversion(#[from] Utf8Error),
 
     #[error("Unknown: {code:?} {message:?}")]
     Unknown {

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -492,18 +492,16 @@ fn verify_json(resource: &ResourceManifest, cwd: &str, json: &str) -> Result<(),
         },
     };
     let json: Value = serde_json::from_str(json)?;
-    let result = match compiled_schema.validate(&json) {
-        Ok(()) => Ok(()),
-        Err(err) => {
-            let mut error = String::new();
-            for e in err {
-                error.push_str(&format!("{e} "));
-            }
+    if let Err(err) = compiled_schema.validate(&json) {
+        let mut error = String::new();
+        for e in err {
+            error.push_str(&format!("{e} "));
+        }
 
-            Err(DscError::Schema(error))
-        },
-    };
-    result
+        return Err(DscError::Schema(error));
+    }
+
+    Ok(())
 }
 
 fn json_to_hashmap(json: &str) -> Result<HashMap<String, String>, DscError> {

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -29,7 +29,7 @@ impl Function for Base64 {
                 return Err(DscError::Parser("Invalid argument type".to_string()));
             }
         };
-        Ok(FunctionResult::String(general_purpose::STANDARD_NO_PAD.encode(arg)))
+        Ok(FunctionResult::String(general_purpose::STANDARD.encode(arg)))
     }
 }
 
@@ -55,6 +55,6 @@ mod tests {
     fn nested() {
         let mut parser = StatementParser::new().unwrap();
         let result = parser.parse_and_execute("[base64(base64('hello world'))]").unwrap();
-        assert_eq!(result, "YUdWc2JHOHRZbUZ3YVdOc2JHbGhibVFnWm1Gd2FXVnVkR2x2Ym5SbGNuQnZjMlZ5ZEdsbGJuUmxjaUJqYjIwPQ==");
+        assert_eq!(result, "YUdWc2JHOGdkMjl5YkdRPQ==");
     }
 }

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use base64::{Engine as _, engine::general_purpose};
+use crate::DscError;
+use crate::parser::functions::{FunctionArg, FunctionResult};
+use super::{Function, AcceptedArgKind};
+
+#[derive(Debug)]
+pub struct Base64 {}
+
+impl Function for Base64 {
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::String]
+    }
+
+    fn min_args(&self) -> usize {
+        1
+    }
+
+    fn max_args(&self) -> usize {
+        1
+    }
+
+    fn invoke(&self, args: &Vec<FunctionArg>) -> Result<FunctionResult, DscError> {
+        let arg = match args.get(0).unwrap() {
+            FunctionArg::String(value) => value,
+            _ => {
+                return Err(DscError::Parser("Invalid argument type".to_string()));
+            }
+        };
+        Ok(FunctionResult::String(general_purpose::STANDARD_NO_PAD.encode(arg)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::StatementParser;
+
+    #[test]
+    fn strings() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[base64('hello world')]").unwrap();
+        assert_eq!(result, "aGVsbG8gd29ybGQ=");
+    }
+
+    #[test]
+    fn numbers() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[base64(123)]");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn nested() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[base64(base64('hello world'))]").unwrap();
+        assert_eq!(result, "YUdWc2JHOHRZbUZ3YVdOc2JHbGhibVFnWm1Gd2FXVnVkR2x2Ym5SbGNuQnZjMlZ5ZEdsbGJuUmxjaUJqYjIwPQ==");
+    }
+}

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -7,7 +7,7 @@ use crate::DscError;
 use crate::parser::functions::{FunctionArg, FunctionResult};
 use super::{Function, AcceptedArgKind};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Base64 {}
 
 impl Function for Base64 {

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -22,12 +22,9 @@ impl Function for Base64 {
         1
     }
 
-    fn invoke(&self, args: &Vec<FunctionArg>) -> Result<FunctionResult, DscError> {
-        let arg = match args.get(0).unwrap() {
-            FunctionArg::String(value) => value,
-            _ => {
-                return Err(DscError::Parser("Invalid argument type".to_string()));
-            }
+    fn invoke(&self, args: &[FunctionArg]) -> Result<FunctionResult, DscError> {
+        let FunctionArg::String(arg) = args.get(0).unwrap() else {
+            return Err(DscError::Parser("Invalid argument type".to_string()));
         };
         Ok(FunctionResult::String(general_purpose::STANDARD.encode(arg)))
     }
@@ -35,25 +32,25 @@ impl Function for Base64 {
 
 #[cfg(test)]
 mod tests {
-    use crate::parser::StatementParser;
+    use crate::parser::Statement;
 
     #[test]
     fn strings() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[base64('hello world')]").unwrap();
         assert_eq!(result, "aGVsbG8gd29ybGQ=");
     }
 
     #[test]
     fn numbers() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[base64(123)]");
         assert!(result.is_err());
     }
 
     #[test]
     fn nested() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[base64(base64('hello world'))]").unwrap();
         assert_eq!(result, "YUdWc2JHOGdkMjl5YkdRPQ==");
     }

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use base64::{Engine as _, engine::general_purpose};
+
 use crate::DscError;
 use crate::parser::functions::{FunctionArg, FunctionResult};
 use super::{Function, AcceptedArgKind};

--- a/dsc_lib/src/functions/concat.rs
+++ b/dsc_lib/src/functions/concat.rs
@@ -1,0 +1,80 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+use crate::functions::{Function, FunctionArg, FunctionResult, AcceptedArgKind};
+
+#[derive(Debug)]
+pub struct Concat {}
+
+impl Function for Concat {
+    fn min_args(&self) -> usize {
+        2
+    }
+
+    fn max_args(&self) -> usize {
+        usize::MAX
+    }
+
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::String, AcceptedArgKind::Integer]
+    }
+
+    fn invoke(&self, args: &Vec<FunctionArg>) -> Result<FunctionResult, DscError> {
+        let mut result = String::new();
+        for arg in args {
+            match arg {
+                FunctionArg::String(value) => {
+                    result.push_str(value);
+                },
+                FunctionArg::Integer(value) => {
+                    result.push_str(&value.to_string());
+                },
+                _ => {
+                    return Err(DscError::Parser("Invalid argument type".to_string()));
+                }
+            }
+        }
+        Ok(FunctionResult::String(result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::StatementParser;
+
+    #[test]
+    fn strings() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a', 'b')]").unwrap();
+        assert_eq!(result, "ab");
+    }
+
+    #[test]
+    fn strings_with_spaces() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a ', ' ', ' b')]").unwrap();
+        assert_eq!(result, "a   b");
+    }
+
+    #[test]
+    fn numbers() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[concat(1, 2)]").unwrap();
+        assert_eq!(result, "12");
+    }
+
+    #[test]
+    fn string_and_numbers() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a', 1, 'b', 2)]").unwrap();
+        assert_eq!(result, "a1b2");
+    }
+
+    #[test]
+    fn nested() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]").unwrap();
+        assert_eq!(result, "abcd");
+    }
+}

--- a/dsc_lib/src/functions/concat.rs
+++ b/dsc_lib/src/functions/concat.rs
@@ -77,4 +77,11 @@ mod tests {
         let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]").unwrap();
         assert_eq!(result, "abcd");
     }
+
+    #[test]
+    fn invalid_one_parameter() {
+        let mut parser = StatementParser::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a')]");
+        assert!(result.is_err());
+    }
 }

--- a/dsc_lib/src/functions/concat.rs
+++ b/dsc_lib/src/functions/concat.rs
@@ -4,7 +4,7 @@
 use crate::DscError;
 use crate::functions::{Function, FunctionArg, FunctionResult, AcceptedArgKind};
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Concat {}
 
 impl Function for Concat {

--- a/dsc_lib/src/functions/concat.rs
+++ b/dsc_lib/src/functions/concat.rs
@@ -20,7 +20,7 @@ impl Function for Concat {
         vec![AcceptedArgKind::String, AcceptedArgKind::Integer]
     }
 
-    fn invoke(&self, args: &Vec<FunctionArg>) -> Result<FunctionResult, DscError> {
+    fn invoke(&self, args: &[FunctionArg]) -> Result<FunctionResult, DscError> {
         let mut result = String::new();
         for arg in args {
             match arg {
@@ -41,46 +41,46 @@ impl Function for Concat {
 
 #[cfg(test)]
 mod tests {
-    use crate::parser::StatementParser;
+    use crate::parser::Statement;
 
     #[test]
     fn strings() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[concat('a', 'b')]").unwrap();
         assert_eq!(result, "ab");
     }
 
     #[test]
     fn strings_with_spaces() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[concat('a ', ' ', ' b')]").unwrap();
         assert_eq!(result, "a   b");
     }
 
     #[test]
     fn numbers() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[concat(1, 2)]").unwrap();
         assert_eq!(result, "12");
     }
 
     #[test]
     fn string_and_numbers() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[concat('a', 1, 'b', 2)]").unwrap();
         assert_eq!(result, "a1b2");
     }
 
     #[test]
     fn nested() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]").unwrap();
         assert_eq!(result, "abcd");
     }
 
     #[test]
     fn invalid_one_parameter() {
-        let mut parser = StatementParser::new().unwrap();
+        let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[concat('a')]");
         assert!(result.is_err());
     }

--- a/dsc_lib/src/functions/mod.rs
+++ b/dsc_lib/src/functions/mod.rs
@@ -1,0 +1,82 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::collections::HashMap;
+use crate::DscError;
+use crate::parser::functions::{FunctionArg, FunctionResult};
+use tracing::debug;
+
+pub mod base64;
+pub mod concat;
+
+#[derive(Debug, PartialEq)]
+pub enum AcceptedArgKind {
+    String,
+    Integer,
+    Boolean,
+}
+
+pub trait Function {
+    fn min_args(&self) -> usize;
+    fn max_args(&self) -> usize;
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind>;
+    fn invoke(&self, args: &Vec<FunctionArg>) -> Result<FunctionResult, DscError>;
+}
+
+pub struct FunctionDispatcher {
+    functions: HashMap<String, Box<dyn Function>>,
+}
+
+impl FunctionDispatcher {
+    pub fn new() -> Self {
+        let mut functions: HashMap<String, Box<dyn Function>> = HashMap::new();
+        functions.insert("base64".to_string(), Box::new(base64::Base64{}));
+        functions.insert("concat".to_string(), Box::new(concat::Concat{}));
+        Self {
+            functions,
+        }
+    }
+
+    pub fn invoke(&self, name: &str, args: &Vec<FunctionArg>) -> Result<FunctionResult, DscError> {
+        let function = self.functions.get(name);
+        match function {
+            Some(function) => {
+                // check if arg number are valid
+                if args.len() < function.min_args() {
+                    return Err(DscError::Parser(format!("Function {0} requires at least {1} arguments", name, function.min_args())));
+                }
+                if args.len() > function.max_args() {
+                    return Err(DscError::Parser(format!("Function {0} requires at most {1} arguments", name, function.max_args())));
+                }
+                // check if arg types are valid
+                for arg in args {
+                    match arg {
+                        FunctionArg::String(_) => {
+                            if !function.accepted_arg_types().contains(&AcceptedArgKind::String) {
+                                return Err(DscError::Parser(format!("Function {0} does not accept string arguments", name)));
+                            }
+                        },
+                        FunctionArg::Integer(_) => {
+                            if !function.accepted_arg_types().contains(&AcceptedArgKind::Integer) {
+                                return Err(DscError::Parser(format!("Function {0} does not accept integer arguments", name)));
+                            }
+                        },
+                        FunctionArg::Boolean(_) => {
+                            if !function.accepted_arg_types().contains(&AcceptedArgKind::Boolean) {
+                                return Err(DscError::Parser(format!("Function {0} does not accept boolean arguments", name)));
+                            }
+                        },
+                        FunctionArg::Expression(_) => {
+                            debug!("An expression was not resolved before invoking a function");
+                            return Err(DscError::Parser("Error in parsing".to_string()));
+                        }
+                    }
+                }
+
+
+                function.invoke(args)
+            },
+            None => Err(DscError::Parser(format!("Unknown function {0}", name))),
+        }
+    }
+}

--- a/dsc_lib/src/functions/mod.rs
+++ b/dsc_lib/src/functions/mod.rs
@@ -2,9 +2,10 @@
 // Licensed under the MIT License.
 
 use std::collections::HashMap;
+use tracing::debug;
+
 use crate::DscError;
 use crate::parser::functions::{FunctionArg, FunctionResult};
-use tracing::debug;
 
 pub mod base64;
 pub mod concat;
@@ -12,9 +13,9 @@ pub mod concat;
 /// The kind of argument that a function accepts.
 #[derive(Debug, PartialEq)]
 pub enum AcceptedArgKind {
-    String,
-    Integer,
     Boolean,
+    Integer,
+    String,
 }
 
 /// A function that can be invoked.
@@ -73,7 +74,7 @@ impl FunctionDispatcher {
                     return Err(DscError::Parser(format!("Function '{name}' requires at least {0} arguments", function.min_args())));
                 }
                 if args.len() > function.max_args() {
-                    return Err(DscError::Parser(format!("Function '{name}' requires at most {0} arguments", function.max_args())));
+                    return Err(DscError::Parser(format!("Function '{name}' supports at most {0} arguments", function.max_args())));
                 }
                 // check if arg types are valid
                 for arg in args {
@@ -99,7 +100,6 @@ impl FunctionDispatcher {
                         }
                     }
                 }
-
 
                 function.invoke(args)
             },

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -1,16 +1,16 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use discovery::ResourceIterator;
+use dscerror::DscError;
+use dscresources::{dscresource::{DscResource, Invoke}, invoke_result::{GetResult, SetResult, TestResult}};
+
 pub mod configure;
 pub mod discovery;
-pub mod dscresources;
 pub mod dscerror;
+pub mod dscresources;
 pub mod functions;
 pub mod parser;
-
-use dscerror::DscError;
-use discovery::ResourceIterator;
-use dscresources::{dscresource::{DscResource, Invoke}, invoke_result::{GetResult, SetResult, TestResult}};
 
 pub struct DscManager {
     discovery: discovery::Discovery,

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -5,6 +5,8 @@ pub mod configure;
 pub mod discovery;
 pub mod dscresources;
 pub mod dscerror;
+pub mod functions;
+pub mod parser;
 
 use dscerror::DscError;
 use discovery::ResourceIterator;

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -8,12 +8,12 @@ use crate::functions::FunctionDispatcher;
 use crate::parser::functions::{Function, FunctionResult};
 
 #[derive(Clone)]
-pub struct Expression<'a> {
-    function: Function<'a>,
+pub struct Expression {
+    function: Function,
     member_access: Option<Vec<String>>,
 }
 
-impl<'a> Expression<'a> {
+impl Expression {
     /// Create a new `Expression` instance.
     ///
     /// # Arguments
@@ -25,7 +25,7 @@ impl<'a> Expression<'a> {
     /// # Errors
     ///
     /// This function will return an error if the expression node is not valid.
-    pub fn new(function_dispatcher: &'a FunctionDispatcher, statement_bytes: &[u8], expression: &Node) -> Result<Self, DscError> {
+    pub fn new(function_dispatcher: &FunctionDispatcher, statement_bytes: &[u8], expression: &Node) -> Result<Self, DscError> {
         let Some(function) = expression.child_by_field_name("function") else {
             return Err(DscError::Parser("Function node not found".to_string()));
         };
@@ -59,8 +59,8 @@ impl<'a> Expression<'a> {
     /// # Errors
     ///
     /// This function will return an error if the expression fails to execute.
-    pub fn invoke(&self) -> Result<String, DscError> {
-        let result = self.function.invoke()?;
+    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher) -> Result<String, DscError> {
+        let result = self.function.invoke(function_dispatcher)?;
         if let Some(member_access) = &self.member_access {
             match result {
                 FunctionResult::String(_) => {

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -13,6 +13,17 @@ pub struct Expression<'a> {
 }
 
 impl<'a> Expression<'a> {
+    /// Create a new `Expression` instance.
+    ///
+    /// # Arguments
+    ///
+    /// * `function_dispatcher` - The function dispatcher to use.
+    /// * `statement` - The statement that the expression is part of.
+    /// * `expression` - The expression node.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the expression node is not valid.
     pub fn new(function_dispatcher: &'a FunctionDispatcher, statement: &str, expression: &Node) -> Result<Self, DscError> {
         let Some(function) = expression.child_by_field_name("function") else {
             return Err(DscError::Parser("Function node not found".to_string()));
@@ -42,6 +53,11 @@ impl<'a> Expression<'a> {
         })
     }
 
+    /// Invoke the expression.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the expression fails to execute.
     pub fn invoke(&self) -> Result<String, DscError> {
         let result = self.function.invoke()?;
         if let Some(member_access) = &self.member_access {
@@ -52,7 +68,7 @@ impl<'a> Expression<'a> {
                 FunctionResult::Object(object) => {
                     let mut value = object;
                     if !value.is_object() {
-                        return Err(DscError::Parser(format!("Member access on non-object value {0}", value.to_string())));
+                        return Err(DscError::Parser(format!("Member access on non-object value '{value}'")));
                     }
                     for member in member_access {
                         value = value[member].clone();

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -30,13 +30,13 @@ impl Expression {
             return Err(DscError::Parser("Function node not found".to_string()));
         };
         let function = Function::new(statement_bytes, &function)?;
-        let member_access = if let Some(member_access) = expression.child_by_field_name("members") {
-            if member_access.is_error() {
+        let member_access = if let Some(members) = expression.child_by_field_name("members") {
+            if members.is_error() {
                 return Err(DscError::Parser("Error parsing dot-notation".to_string()));
             }
             let mut result = vec![];
-            let mut cursor = member_access.walk();
-            for member in member_access.children(&mut cursor) {
+            let mut cursor = members.walk();
+            for member in members.children(&mut cursor) {
                 if member.is_error() {
                     return Err(DscError::Parser("Error parsing dot-notation member".to_string()));
                 }

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use tree_sitter::Node;
+
 use crate::dscerror::DscError;
 use crate::functions::FunctionDispatcher;
 use crate::parser::functions::{Function, FunctionResult};
-use tree_sitter::Node;
 
 #[derive(Clone)]
 pub struct Expression<'a> {

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -18,11 +18,17 @@ impl<'a> Expression<'a> {
             return Err(DscError::Parser("Function node not found".to_string()));
         };
         let function = Function::new(function_dispatcher, statement, &function)?;
-        let member_access = match expression.child_by_field_name("member_access") {
+        let member_access = match expression.child_by_field_name("members") {
             Some(member_access) => {
+                if member_access.is_error() {
+                    return Err(DscError::Parser("Error parsing dot-notation".to_string()));
+                }
                 let mut result = vec![];
                 let mut cursor = member_access.walk();
                 for member in member_access.children(&mut cursor) {
+                    if member.is_error() {
+                        return Err(DscError::Parser("Error parsing dot-notation member".to_string()));
+                    }
                     let value = member.utf8_text(statement.as_bytes())?;
                     result.push(value.to_string());
                 }

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -30,23 +30,23 @@ impl<'a> Expression<'a> {
             return Err(DscError::Parser("Function node not found".to_string()));
         };
         let function = Function::new(function_dispatcher, statement, &function)?;
-        let member_access = match expression.child_by_field_name("members") {
-            Some(member_access) => {
-                if member_access.is_error() {
-                    return Err(DscError::Parser("Error parsing dot-notation".to_string()));
+        let member_access = if let Some(member_access) = expression.child_by_field_name("members") {
+            if member_access.is_error() {
+                return Err(DscError::Parser("Error parsing dot-notation".to_string()));
+            }
+            let mut result = vec![];
+            let mut cursor = member_access.walk();
+            for member in member_access.children(&mut cursor) {
+                if member.is_error() {
+                    return Err(DscError::Parser("Error parsing dot-notation member".to_string()));
                 }
-                let mut result = vec![];
-                let mut cursor = member_access.walk();
-                for member in member_access.children(&mut cursor) {
-                    if member.is_error() {
-                        return Err(DscError::Parser("Error parsing dot-notation member".to_string()));
-                    }
-                    let value = member.utf8_text(statement.as_bytes())?;
-                    result.push(value.to_string());
-                }
-                Some(result)
-            },
-            None => None,
+                let value = member.utf8_text(statement.as_bytes())?;
+                result.push(value.to_string());
+            }
+            Some(result)
+        }
+        else {
+            None
         };
         Ok(Expression {
             function,

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::dscerror::DscError;
+use crate::functions::FunctionDispatcher;
+use crate::parser::functions::{Function, FunctionResult};
+use tree_sitter::Node;
+
+#[derive(Clone)]
+pub struct Expression<'a> {
+    function: Function<'a>,
+    member_access: Option<Vec<String>>,
+}
+
+impl<'a> Expression<'a> {
+    pub fn new(function_dispatcher: &'a FunctionDispatcher, statement: &str, expression: &Node) -> Result<Self, DscError> {
+        let Some(function) = expression.child_by_field_name("function") else {
+            return Err(DscError::Parser("Function node not found".to_string()));
+        };
+        let function = Function::new(function_dispatcher, statement, &function)?;
+        let member_access = match expression.child_by_field_name("member_access") {
+            Some(member_access) => {
+                let mut result = vec![];
+                let mut cursor = member_access.walk();
+                for member in member_access.children(&mut cursor) {
+                    let value = member.utf8_text(statement.as_bytes())?;
+                    result.push(value.to_string());
+                }
+                Some(result)
+            },
+            None => None,
+        };
+        Ok(Expression {
+            function,
+            member_access,
+        })
+    }
+
+    pub fn invoke(&self) -> Result<String, DscError> {
+        let result = self.function.invoke()?;
+        if let Some(member_access) = &self.member_access {
+            match result {
+                FunctionResult::String(_) => {
+                    Err(DscError::Parser("Member access on string not supported".to_string()))
+                },
+                FunctionResult::Object(object) => {
+                    let mut value = object;
+                    if !value.is_object() {
+                        return Err(DscError::Parser(format!("Member access on non-object value {0}", value.to_string())));
+                    }
+                    for member in member_access {
+                        value = value[member].clone();
+                    }
+                    Ok(value.to_string())
+                }
+            }
+        }
+        else {
+            match result {
+                FunctionResult::String(value) => Ok(value),
+                FunctionResult::Object(object) => Ok(object.to_string()),
+            }
+        }
+    }
+}

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -25,11 +25,11 @@ impl Expression {
     /// # Errors
     ///
     /// This function will return an error if the expression node is not valid.
-    pub fn new(function_dispatcher: &FunctionDispatcher, statement_bytes: &[u8], expression: &Node) -> Result<Self, DscError> {
+    pub fn new(statement_bytes: &[u8], expression: &Node) -> Result<Self, DscError> {
         let Some(function) = expression.child_by_field_name("function") else {
             return Err(DscError::Parser("Function node not found".to_string()));
         };
-        let function = Function::new(function_dispatcher, statement_bytes, &function)?;
+        let function = Function::new(statement_bytes, &function)?;
         let member_access = if let Some(member_access) = expression.child_by_field_name("members") {
             if member_access.is_error() {
                 return Err(DscError::Parser("Error parsing dot-notation".to_string()));

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -25,11 +25,11 @@ impl<'a> Expression<'a> {
     /// # Errors
     ///
     /// This function will return an error if the expression node is not valid.
-    pub fn new(function_dispatcher: &'a FunctionDispatcher, statement: &str, expression: &Node) -> Result<Self, DscError> {
+    pub fn new(function_dispatcher: &'a FunctionDispatcher, statement_bytes: &[u8], expression: &Node) -> Result<Self, DscError> {
         let Some(function) = expression.child_by_field_name("function") else {
             return Err(DscError::Parser("Function node not found".to_string()));
         };
-        let function = Function::new(function_dispatcher, statement, &function)?;
+        let function = Function::new(function_dispatcher, statement_bytes, &function)?;
         let member_access = if let Some(member_access) = expression.child_by_field_name("members") {
             if member_access.is_error() {
                 return Err(DscError::Parser("Error parsing dot-notation".to_string()));
@@ -40,7 +40,7 @@ impl<'a> Expression<'a> {
                 if member.is_error() {
                     return Err(DscError::Parser("Error parsing dot-notation member".to_string()));
                 }
-                let value = member.utf8_text(statement.as_bytes())?;
+                let value = member.utf8_text(statement_bytes)?;
                 result.push(value.to_string());
             }
             Some(result)

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -42,12 +42,12 @@ impl Function {
     /// # Errors
     ///
     /// This function will return an error if the function node is not valid.
-    pub fn new(function_dispatcher: &FunctionDispatcher, statement_bytes: &[u8], function: &Node) -> Result<Self, DscError> {
+    pub fn new(statement_bytes: &[u8], function: &Node) -> Result<Self, DscError> {
         let Some(function_name) = function.child_by_field_name("name") else {
             return Err(DscError::Parser("Function name node not found".to_string()));
         };
         let function_args = function.child_by_field_name("args");
-        let args = convert_args_node(function_dispatcher, statement_bytes, &function_args)?;
+        let args = convert_args_node(statement_bytes, &function_args)?;
         Ok(Function{
             name: function_name.utf8_text(statement_bytes)?.to_string(),
             args})
@@ -79,7 +79,7 @@ impl Function {
     }
 }
 
-fn convert_args_node(function_dispatcher: &FunctionDispatcher, statement_bytes: &[u8], args: &Option<Node>) -> Result<Option<Vec<FunctionArg>>, DscError> {
+fn convert_args_node(statement_bytes: &[u8], args: &Option<Node>) -> Result<Option<Vec<FunctionArg>>, DscError> {
     let Some(args) = args else {
         return Ok(None);
     };
@@ -101,7 +101,7 @@ fn convert_args_node(function_dispatcher: &FunctionDispatcher, statement_bytes: 
             },
             "expression" => {
                 // TODO: this is recursive, we may want to stop at a specific depth
-                let expression = Expression::new(function_dispatcher, statement_bytes, &arg)?;
+                let expression = Expression::new(statement_bytes, &arg)?;
                 result.push(FunctionArg::Expression(expression));
             },
             _ => {

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use tree_sitter::Node;
+
+use crate::DscError;
+use crate::parser::{
+    expressions::Expression,
+    FunctionDispatcher,
+};
+use serde_json::Value;
+
+#[derive(Clone)]
+pub struct Function<'a> {
+    name: String,
+    args: Option<Vec<FunctionArg<'a>>>,
+    function_dispatcher: &'a FunctionDispatcher,
+}
+
+#[derive(Clone)]
+pub enum FunctionArg<'a> {
+    String(String),
+    Integer(i32),
+    Boolean(bool),
+    Expression(Expression<'a>),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum FunctionResult {
+    String(String),
+    Object(Value),
+}
+
+impl<'a> Function<'a> {
+    pub fn new(function_dispatcher: &'a FunctionDispatcher, statement: &str, function: &Node) -> Result<Self, DscError> {
+        let Some(function_name) = function.child_by_field_name("name") else {
+            return Err(DscError::Parser("Function name node not found".to_string()));
+        };
+        let function_args = function.child_by_field_name("args");
+        let args = convert_args_node(function_dispatcher, statement, &function_args)?;
+        Ok(Function{
+            function_dispatcher,
+            name: function_name.utf8_text(statement.as_bytes())?.to_string(),
+            args})
+    }
+
+    pub fn invoke(&self) -> Result<FunctionResult, DscError> {
+        // if any args are expressions, we need to invoke those first
+        let mut resolved_args: Option<Vec<FunctionArg>> = None;
+        if let Some(args) = &self.args {
+            resolved_args = Some(vec![]);
+            for arg in args {
+                match arg {
+                    FunctionArg::Expression(expression) => {
+                        let value = expression.invoke()?;
+                        resolved_args.as_mut().unwrap().push(FunctionArg::String(value));
+                    },
+                    _ => {
+                        resolved_args.as_mut().unwrap().push(arg.clone());
+                    }
+                }
+            }
+        }
+
+        let args = match resolved_args {
+            Some(args) => args,
+            None => vec![],
+        };
+
+        self.function_dispatcher.invoke(&self.name, &args)
+    }
+}
+
+fn convert_args_node<'a>(function_dispatcher: &'a FunctionDispatcher, statement: &str, args: &Option<Node>) -> Result<Option<Vec<FunctionArg<'a>>>, DscError> {
+    let Some(args) = args else {
+        return Ok(None);
+    };
+    let mut result = vec![];
+    let mut cursor = args.walk();
+    for arg in args.named_children(&mut cursor) {
+        match arg.kind() {
+            "string" => {
+                let value = arg.utf8_text(statement.as_bytes())?;
+                result.push(FunctionArg::String(value.to_string()));
+            },
+            "number" => {
+                let value = arg.utf8_text(statement.as_bytes())?;
+                result.push(FunctionArg::Integer(value.parse::<i32>()?));
+            },
+            "boolean" => {
+                let value = arg.utf8_text(statement.as_bytes())?;
+                result.push(FunctionArg::Boolean(value.parse::<bool>()?));
+            },
+            "expression" => {
+                // TODO: this is recursive, we may want to stop at a specific depth
+                let expression = Expression::new(function_dispatcher, statement, &arg)?;
+                result.push(FunctionArg::Expression(expression));
+            },
+            _ => {
+                return Err(DscError::Parser(format!("Unknown argument type '{0}'", arg.kind())));
+            }
+        }
+    }
+    Ok(Some(result))
+}

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use serde_json::Value;
 use tree_sitter::Node;
 
 use crate::DscError;
@@ -8,7 +9,6 @@ use crate::parser::{
     expressions::Expression,
     FunctionDispatcher,
 };
-use serde_json::Value;
 
 #[derive(Clone)]
 pub struct Function<'a> {

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -59,22 +59,23 @@ impl Statement {
             return Err(DscError::Parser("Error parsing statement child".to_string()));
         }
         let kind = child_node.kind();
+        let statement_bytes = statement.as_bytes();
         match kind {
             "stringLiteral" | "bracketInStringLiteral" => {
-                let Ok(value) = child_node.utf8_text(statement.as_bytes()) else {
+                let Ok(value) = child_node.utf8_text(statement_bytes) else {
                     return Err(DscError::Parser("Error parsing string literal".to_string()));
                 };
                 Ok(value.to_string())
             },
             "escapedStringLiteral" => {
                 // need to remove the first character: [[ => [
-                let Ok(value) = child_node.utf8_text(statement.as_bytes()) else {
+                let Ok(value) = child_node.utf8_text(statement_bytes) else {
                     return Err(DscError::Parser("Error parsing escaped string literal".to_string()));
                 };
                 Ok(value[1..].to_string())
             },
             "expression" => {
-                let expression = Expression::new(&self.function_dispatcher, statement, &child_node)?;
+                let expression = Expression::new(&self.function_dispatcher, statement_bytes, &child_node)?;
                 Ok(expression.invoke()?)
             },
             _ => {

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::dscerror::DscError;
+use crate::functions::FunctionDispatcher;
+use tree_sitter::Parser;
+use expressions::Expression;
+
+pub mod expressions;
+pub mod functions;
+
+pub struct StatementParser {
+    parser: Parser,
+    function_dispatcher: FunctionDispatcher,
+}
+
+impl StatementParser {
+    pub fn new() -> Result<Self, DscError> {
+        let mut parser = Parser::new();
+        parser.set_language(tree_sitter_dscexpression::language())?;
+        let function_dispatcher = FunctionDispatcher::new();
+        Ok(Self {
+            parser,
+            function_dispatcher,
+        })
+    }
+
+    pub fn parse_and_execute(&mut self, statement: &str) -> Result<String, DscError> {
+        let tree = &mut self.parser.parse(statement, None).unwrap();
+        let root_node = tree.root_node();
+        let root_node_kind = root_node.kind();
+        if root_node_kind != "statement" {
+            return Err(DscError::Parser("Invalid statement".to_string()));
+        }
+        let Some(child_node) = root_node.named_child(0) else {
+            return Err(DscError::Parser("Child node not found".to_string()));
+        };
+        let kind = child_node.kind();
+        match kind {
+            "stringLiteral" | "bracketInStringLiteral" => {
+                let value = child_node.utf8_text(statement.as_bytes()).unwrap();
+                Ok(value.to_string())
+            },
+            "escapedStringLiteral" => {
+                // need to remove the first character: [[ => [
+                let value = child_node.utf8_text(statement.as_bytes()).unwrap();
+                Ok(value[1..].to_string())
+            },
+            "expression" => {
+                let expression = Expression::new(&self.function_dispatcher, statement, &child_node)?;
+                Ok(expression.invoke()?)
+            },
+            _ => {
+                Err(DscError::Parser(format!("Unknown expression type {0}", child_node.kind())))
+            }
+        }
+    }
+}

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -76,7 +76,7 @@ impl Statement {
             },
             "expression" => {
                 let expression = Expression::new(&self.function_dispatcher, statement_bytes, &child_node)?;
-                Ok(expression.invoke()?)
+                Ok(expression.invoke(&self.function_dispatcher)?)
             },
             _ => {
                 Err(DscError::Parser(format!("Unknown expression type {0}", child_node.kind())))

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -1,10 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use expressions::Expression;
+use tree_sitter::Parser;
+
 use crate::dscerror::DscError;
 use crate::functions::FunctionDispatcher;
-use tree_sitter::Parser;
-use expressions::Expression;
 
 pub mod expressions;
 pub mod functions;

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -75,7 +75,7 @@ impl Statement {
                 Ok(value[1..].to_string())
             },
             "expression" => {
-                let expression = Expression::new(&self.function_dispatcher, statement_bytes, &child_node)?;
+                let expression = Expression::new(statement_bytes, &child_node)?;
                 Ok(expression.invoke(&self.function_dispatcher)?)
             },
             _ => {

--- a/registry/src/main.rs
+++ b/registry/src/main.rs
@@ -90,12 +90,9 @@ fn main() {
         },
         args::SubCommand::Config { subcommand } => {
             let json: String;
-            match regconfighelper::validate_config(&config) {
-                Ok(()) => {},
-                Err(err) => {
-                    eprintln!("Error validating config: {err}");
-                    exit(EXIT_INVALID_INPUT);
-                }
+            if let Err(err) = regconfighelper::validate_config(&config) {
+                eprintln!("Error validating config: {err}");
+                exit(EXIT_INVALID_INPUT);
             }
 
             if config.exist.is_none() {

--- a/registry/src/regconfighelper.rs
+++ b/registry/src/regconfighelper.rs
@@ -99,7 +99,7 @@ pub fn config_set(config: &Registry) -> Result<String, RegistryError> {
                         None => {
                             // just verify that the value exists
                             match reg_key.get_value(value_name) {
-                                Ok(_) => {},
+                                Ok(()) => {},
                                 Err(NtStatusError { status: NtStatusErrorKind::ObjectNameNotFound, .. }) => {
                                     reg_key.set_value(value_name, &NtRegistryValueData::None)?;
                                 },

--- a/registry/src/regconfighelper.rs
+++ b/registry/src/regconfighelper.rs
@@ -99,7 +99,7 @@ pub fn config_set(config: &Registry) -> Result<String, RegistryError> {
                         None => {
                             // just verify that the value exists
                             match reg_key.get_value(value_name) {
-                                Ok(()) => {},
+                                Ok(_) => {},
                                 Err(NtStatusError { status: NtStatusErrorKind::ObjectNameNotFound, .. }) => {
                                     reg_key.set_value(value_name, &NtRegistryValueData::None)?;
                                 },

--- a/tree-sitter-dscexpression/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/invalid_expressions.txt
@@ -40,9 +40,10 @@ Missing parameter
       (expression
         (function
           (functionName)
-          (number)
-          (ERROR)
-          (number))))
+          (arguments
+            (number)
+            (ERROR)
+            (number)))))
 
 =====
 Escaped bracket

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -24,7 +24,7 @@ Simple expression
 =====
 Multiple arguments
 =====
-[myFunction('argString', 1, true)]
+[myFunction('argString', 1, -1, true)]
 ---
 
     (statement
@@ -32,6 +32,7 @@ Multiple arguments
         (function
           (functionName)
           (string)
+          (number)
           (number)
           (boolean))))
 

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -1,7 +1,7 @@
 =====
 Function no args
 =====
-[functionOne()]
+[function1()]
 ---
 
     (statement
@@ -41,7 +41,7 @@ Multiple arguments
 =====
 Nested functions
 =====
-[functionOne('argString', functionTwo(1, functionThree('threeString', 3), 2), 'oneString')]
+[function1('argString', function2(1, functionThree('threeString', 3), 2), 'oneString')]
 ---
 
     (statement

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -19,7 +19,8 @@ Simple expression
       (expression
         (function
           (functionName)
-          (string))))
+          (arguments
+            (string)))))
 
 =====
 Multiple arguments
@@ -31,10 +32,11 @@ Multiple arguments
       (expression
         (function
           (functionName)
-          (string)
-          (number)
-          (number)
-          (boolean))))
+          (arguments
+            (string)
+            (number)
+            (number)
+            (boolean)))))
 
 =====
 Nested functions
@@ -46,18 +48,21 @@ Nested functions
       (expression
         (function
           (functionName)
-          (string)
-          (expression
-            (function
-              (functionName)
-              (number)
-              (expression
-                (function
-                  (functionName)
-                  (string)
-                  (number)))
-              (number)))
-          (string))))
+          (arguments
+            (string)
+            (expression
+              (function
+                (functionName)
+                (arguments
+                  (number)
+                  (expression
+                    (function
+                      (functionName)
+                      (arguments
+                        (string)
+                        (number))))
+                  (number))))
+            (string)))))
 
 =====
 Function with dot-notation
@@ -69,9 +74,11 @@ Function with dot-notation
       (expression
         (function
           (functionName)
-          (string))
-        (memberName)
-        (memberName)))
+          (arguments
+            (string)))
+        (memberAccess
+          (memberName)
+          (memberName))))
 
 =====
 Nested dot-notation
@@ -83,10 +90,14 @@ Nested dot-notation
       (expression
         (function
           (functionName)
-          (expression
-            (function
-              (functionName)
-              (number))
-            (memberName)
-            (memberName)))
-        (memberName)))
+          (arguments
+            (expression
+              (function
+                (functionName)
+                (arguments
+                  (number)))
+              (memberAccess
+                (memberName)
+                (memberName)))))
+        (memberAccess
+          (memberName))))

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -18,19 +18,19 @@ module.exports = grammar({
     escapedStringLiteral: $ => token(prec(PREC.ESCAPEDSTRING, seq('[[', /.*?/))),
     bracketInStringLiteral: $ => token(prec(PREC.BRACKETINSTRING, seq('[', /.*?/, ']', /.+?/))),
     _expressionString: $ => prec(PREC.EXPRESSIONSTRING, seq('[', $.expression, ']')),
-    expression: $ => seq(field('function', $.function), field('members', optional($._members))),
+    expression: $ => seq(field('function', $.function), field('members', optional($.memberAccess))),
     stringLiteral: $ => token(prec(PREC.STRINGLITERAL, /[^\[].*?/)),
 
-    function: $ => seq(field('name', $.functionName), '(', field('args', optional($._arguments)), ')'),
+    function: $ => seq(field('name', $.functionName), '(', field('args', optional($.arguments)), ')'),
     functionName: $ => /[a-zA-Z]+/,
-    _arguments: $ => seq($._argument, repeat(seq(',', $._argument))),
+    arguments: $ => seq($._argument, repeat(seq(',', $._argument))),
     _argument: $ => choice($.expression, $.string, $.number, $.boolean),
 
     string: $ => seq("'", /[^']*/, "'"),
     number: $ => /-?\d+/,
     boolean: $ => choice('true', 'false'),
 
-    _members: $ => repeat1($._member),
+    memberAccess: $ => repeat1($._member),
     _member: $ => seq('.', $.memberName),
     memberName: $ => /[a-zA-Z0-9_-]+/,
   }

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -22,11 +22,12 @@ module.exports = grammar({
     stringLiteral: $ => token(prec(PREC.STRINGLITERAL, /[^\[].*?/)),
 
     function: $ => seq(field('name', $.functionName), '(', field('args', optional($.arguments)), ')'),
-    functionName: $ => /[a-zA-Z]+/,
+    functionName: $ => /[a-z][a-zA-Z0-9]*/,
     arguments: $ => seq($._argument, repeat(seq(',', $._argument))),
-    _argument: $ => choice($.expression, $.string, $.number, $.boolean),
+    _argument: $ => choice($.expression, seq('\'', $.string, '\''), $.number, $.boolean),
 
-    string: $ => seq("'", /[^']*/, "'"),
+    // ARM strings do not allow to contain single-quote characters
+    string: $ => /[^']*/,
     number: $ => /-?\d+/,
     boolean: $ => choice('true', 'false'),
 

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -18,16 +18,16 @@ module.exports = grammar({
     escapedStringLiteral: $ => token(prec(PREC.ESCAPEDSTRING, seq('[[', /.*?/))),
     bracketInStringLiteral: $ => token(prec(PREC.BRACKETINSTRING, seq('[', /.*?/, ']', /.+?/))),
     _expressionString: $ => prec(PREC.EXPRESSIONSTRING, seq('[', $.expression, ']')),
-    expression: $ => seq($.function, optional($._members)),
+    expression: $ => seq(field('function', $.function), field('members', optional($._members))),
     stringLiteral: $ => token(prec(PREC.STRINGLITERAL, /[^\[].*?/)),
 
-    function: $ => seq($.functionName, '(', optional($._arguments), ')'),
+    function: $ => seq(field('name', $.functionName), '(', field('args', optional($._arguments)), ')'),
     functionName: $ => /[a-zA-Z]+/,
     _arguments: $ => seq($._argument, repeat(seq(',', $._argument))),
     _argument: $ => choice($.expression, $.string, $.number, $.boolean),
 
     string: $ => seq("'", /[^']*/, "'"),
-    number: $ => /\d+/,
+    number: $ => /-?\d+/,
     boolean: $ => choice('true', 'false'),
 
     _members: $ => repeat1($._member),

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -24,8 +24,9 @@ module.exports = grammar({
     function: $ => seq(field('name', $.functionName), '(', field('args', optional($.arguments)), ')'),
     functionName: $ => /[a-z][a-zA-Z0-9]*/,
     arguments: $ => seq($._argument, repeat(seq(',', $._argument))),
-    _argument: $ => choice($.expression, seq('\'', $.string, '\''), $.number, $.boolean),
+    _argument: $ => choice($.expression, $._quotedString, $.number, $.boolean),
 
+    _quotedString: $ => seq('\'', $.string, '\''),
     // ARM strings do not allow to contain single-quote characters
     string: $ => /[^']*/,
     number: $ => /-?\d+/,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- The primary change is to use the generated tree-sitter parser.
- Grammar was updated to have parent node for `arguments` and `member_access`
- Grammar updated so that `string` arguments don't include the quotes
- The statement parser creates `expression` which can contain `functions`
- Added `base64` and `concat` functions for testing
- Some clippy fixes as the rules appeared to have been updated

Note that this parser is not integrated yet with config.  That will come next replacing `resourceId()` with real function.
