### PR TITLE
Add example `brew` resource

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -93,16 +93,17 @@ New-Item -ItemType Directory $target > $null
 # make sure dependencies are built first so clippy runs correctly
 $windows_projects = @("pal", "ntreg", "ntstatuserror", "ntuserinfo", "registry")
 $projects = @(
-    "dsc",
-    "dsc_lib",
-    "file_lib",
-    "osinfo",
-    "powershellgroup",
-    "process",
-    "tools/dsctest",
-    "tools/test_group_resource",
-    "tree-sitter-dscexpression",
+    "tree-sitter-dscexpression"
+    "dsc_lib"
+    "file_lib"
+    "dsc"
+    "osinfo"
+    "process"
+    "tools/test_group_resource"
     "y2j"
+    "powershellgroup"
+    "resources/brew"
+    "tools/dsctest"
 )
 $pedantic_unclean_projects = @("ntreg")
 $clippy_unclean_projects = @("tree-sitter-dscexpression")
@@ -156,9 +157,13 @@ foreach ($project in $projects) {
             Copy-Item "$path/$binary" $target -ErrorAction Ignore
         }
 
+        if (Test-Path "./copy_files.txt") {
+            Get-Content "./copy_files.txt" | ForEach-Object {
+                Copy-Item $_ $target -Force -ErrorAction Ignore
+            }
+        }
+
         Copy-Item "*.dsc.resource.json" $target -Force -ErrorAction Ignore
-        Copy-Item "*.resource.ps1" $target -Force -ErrorAction Ignore
-        Copy-Item "*.command.json" $target -Force -ErrorAction Ignore
 
     } finally {
         Pop-Location

--- a/dsc/examples/brew.dsc.yaml
+++ b/dsc/examples/brew.dsc.yaml
@@ -1,0 +1,19 @@
+# Example to see if PowerShell 7 is installed, install it, or get all installed packages
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+resources:
+- name: assertions
+  type: DSC/AssertionGroup
+  properties:
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+    resources:
+    - name: os_check
+      type: Microsoft/OSInfo
+      properties:
+        family: MacOS
+- name: brew
+  type: DSC.PackageManagement/Brew
+  properties:
+    packageName: powershell
+    _exist: true
+  dependsOn:
+  - "[resourceId('DSC/AssertionGroup','assertions')]"

--- a/dsc/examples/brew_export.dsc.yaml
+++ b/dsc/examples/brew_export.dsc.yaml
@@ -1,0 +1,7 @@
+# Example to see if PowerShell 7 is installed, install it, or get all installed packages
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+resources:
+- name: brew
+  type: DSC.PackageManagement/Brew
+  properties:
+    packageName: none

--- a/dsc/examples/brew_uninstall.dsc.yaml
+++ b/dsc/examples/brew_uninstall.dsc.yaml
@@ -14,6 +14,6 @@ resources:
   type: DSC.PackageManagement/Brew
   properties:
     packageName: gitui
-    _exist: true
+    _exist: false
   dependsOn:
   - "[resourceId('DSC/AssertionGroup','assertions')]"

--- a/powershellgroup/copy_files.txt
+++ b/powershellgroup/copy_files.txt
@@ -1,0 +1,1 @@
+powershellgroup.resource.ps1

--- a/resources/brew/brew.dsc.resource.json
+++ b/resources/brew/brew.dsc.resource.json
@@ -1,0 +1,66 @@
+{
+    "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
+    "type": "DSC.PackageManagement/Brew",
+    "description": "DSC resource to manage Homebrew packages",
+    "tags": [
+        "macOS",
+        "brew",
+        "PackageManagement"
+    ],
+    "version": "0.1.0",
+    "get": {
+        "executable": "brew.dsc.resource.sh",
+        "args": [
+            "get"
+        ],
+        "input": "env"
+    },
+    "set": {
+        "executable": "brew.dsc.resource.sh",
+        "args": [
+            "set"
+        ],
+        "input": "env"
+    },
+    "export": {
+        "executable": "brew.dsc.resource.sh",
+        "args": [
+            "export"
+        ],
+        "input": "env"
+    },
+    "exitCodes": {
+        "0": "Success",
+        "1": "Invalid parameter"
+    },
+    "schema": {
+        "embedded": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/resources/DSC/PackageManagement/Brew/v0.1.0/schema.json",
+            "title": "Brew",
+            "description": "Managed packages using Homebrew",
+            "type": "object",
+            "required": [
+                "packageName"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "packageName": {
+                    "type": "string",
+                    "title": "Package Name",
+                    "description": "Defines the name of the package to query or install"
+                },
+                "version": {
+                    "type": "string",
+                    "title": "Version",
+                    "description": "Defines the version of the package to install"
+                },
+                "_exist": {
+                    "type": "boolean",
+                    "title": "Exist",
+                    "description": "Defines if the package should exist or not"
+                }
+            }
+        }
+    }
+}

--- a/resources/brew/brew.dsc.resource.json
+++ b/resources/brew/brew.dsc.resource.json
@@ -20,7 +20,8 @@
         "args": [
             "set"
         ],
-        "input": "env"
+        "input": "env",
+        "implementsPretest": true
     },
     "export": {
         "executable": "brew.dsc.resource.sh",

--- a/resources/brew/brew.dsc.resource.sh
+++ b/resources/brew/brew.dsc.resource.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+export exist=true
+
+check_args() {
+    if [[ -z $packageName ]]; then
+        echo "packageName not set"
+        exit 1
+    fi
+}
+
+to_json() {
+    while read line; do
+        echo $line | awk '{print "{ \"packageName\": \""$1"\", \"version\": \""$2"\", \"_exist\": "ENVIRON["exist"]" }"}'
+    done
+}
+
+if [ $# -eq 0 ]; then
+    echo "Command not provided, valid commands: get, export"
+    exit 1
+elif [[ $1 == "get" ]]; then
+    check_args
+    output="$(brew list ${packageName} --versions)"
+    if [[ $? -ne 0 ]]; then
+        export exist=false
+        output="${packageName}"
+    fi
+    echo $output | to_json
+elif [[ $1 == "set" ]]; then
+    check_args
+    if [[ -z $_exist ]]; then
+        _exist=true
+    fi
+    if [[ $_exist = true ]]; then
+        brew install "${packageName}"
+    else
+        brew uninstall "${packageName}"
+    fi
+elif [[ $1 == "export" ]]; then
+    brew list --versions | to_json
+else
+    echo "Invalid command, valid commands: get, export"
+    exit 1
+fi

--- a/resources/brew/brew.dsc.resource.sh
+++ b/resources/brew/brew.dsc.resource.sh
@@ -4,6 +4,7 @@
 # Licensed under the MIT License.
 
 export exist=true
+export NONINTERACTIVE=1
 
 check_args() {
     if [[ -z $packageName ]]; then

--- a/resources/brew/brew.dsc.resource.sh
+++ b/resources/brew/brew.dsc.resource.sh
@@ -6,6 +6,8 @@
 export exist=true
 export NONINTERACTIVE=1
 
+# $packageName and $_exist are sent as env vars by dsc converting the JSON input to name/value pairs
+
 check_args() {
     if [[ -z $packageName ]]; then
         echo "packageName not set"
@@ -20,19 +22,20 @@ to_json() {
 }
 
 if [ $# -eq 0 ]; then
-    echo "Command not provided, valid commands: get, export"
+    echo "Command not provided, valid commands: get, set, export"
     exit 1
 elif [[ $1 == "get" ]]; then
     check_args
     output="$(brew list ${packageName} --versions)"
     if [[ $? -ne 0 ]]; then
-        export exist=false
+        exist=false
         output="${packageName}"
     fi
     echo $output | to_json
 elif [[ $1 == "set" ]]; then
     check_args
     if [[ -z $_exist ]]; then
+        # if $_exist is not defined in the input, it defaults to `true`
         _exist=true
     fi
     if [[ $_exist = true ]]; then
@@ -43,6 +46,6 @@ elif [[ $1 == "set" ]]; then
 elif [[ $1 == "export" ]]; then
     brew list --versions | to_json
 else
-    echo "Invalid command, valid commands: get, export"
+    echo "Invalid command, valid commands: get, set, export"
     exit 1
 fi

--- a/resources/brew/copy_files.txt
+++ b/resources/brew/copy_files.txt
@@ -1,0 +1,1 @@
+brew.dsc.resource.sh


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Demo resource for `brew` to manage packages on macOS.

Also updated `build.ps1` with a new `copy_files.txt` for resources that don't need a build step where the file indicates the files to be copied to the target folder.

A seperate PR will move the other resources under the `resources` folder.

## PR Context

This demos a bash script resource using env var arguments
