### PR TITLE
Added --logging-level arg

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -24,6 +24,8 @@ pub struct Args {
     pub input: Option<String>,
     #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource")]
     pub input_file: Option<String>,
+    #[clap(short = 'd', long, help = "Use detailed tracing", action=clap::ArgAction::SetTrue)]
+    pub debug: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -25,7 +25,7 @@ pub struct Args {
     pub input: Option<String>,
     #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource")]
     pub input_file: Option<String>,
-    #[clap(short = 'l', long = "logging-level", help = "Log level to display", value_enum, default_value = "Info")]
+    #[clap(short = 'l', long = "logging-level", help = "Log level to display", value_enum, default_value = "info")]
     pub logging_level: LogLevel,
 }
 

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -3,6 +3,7 @@
 
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
+use crate::util::LogLevel;
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
@@ -24,8 +25,8 @@ pub struct Args {
     pub input: Option<String>,
     #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource")]
     pub input_file: Option<String>,
-    #[clap(short = 'd', long, help = "Use detailed tracing", action=clap::ArgAction::SetTrue)]
-    pub debug: bool,
+    #[clap(short = 'l', long = "logging-level", help = "Log level to display", value_enum, default_value = "Info")]
+    pub logging_level: LogLevel,
 }
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -31,7 +31,14 @@ fn main() {
 
     let args = Args::parse();
 
-    let tracing_level = if args.debug {Level::DEBUG} else {Level::WARN};
+    let tracing_level = match args.logging_level {
+        util::LogLevel::Error => Level::ERROR,
+        util::LogLevel::Warning => Level::WARN,
+        util::LogLevel::Info => Level::INFO,
+        util::LogLevel::Debug => Level::DEBUG,
+        util::LogLevel::Trace => Level::TRACE,
+    };
+
     // create subscriber that writes all events to stderr
     let subscriber = tracing_subscriber::fmt().pretty().with_max_level(tracing_level).with_writer(std::io::stderr).finish();
     if tracing::subscriber::set_global_default(subscriber).is_err() {

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -35,6 +35,16 @@ pub const EXIT_INVALID_INPUT: i32 = 4;
 pub const EXIT_VALIDATION_FAILED: i32 = 5;
 pub const EXIT_CTRL_C: i32 = 6;
 
+#[derive(Debug)]
+#[derive(clap::ValueEnum, Clone)]
+pub enum LogLevel {
+   Error,
+   Warning,
+   Info,
+   Debug,
+   Trace
+}
+
 /// Get string representation of JSON value.
 ///
 /// # Arguments

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -147,8 +147,8 @@ resources:
         $LASTEXITCODE | Should -Be 2
     }
 
-    It '--debug has effect' {
-        dsc -d resource get -r Microsoft/OSInfo 2> $TestDrive/tracing.txt
+    It '--logging-level has effect' {
+        dsc -l debug resource get -r Microsoft/OSInfo 2> $TestDrive/tracing.txt
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'DEBUG'
         $LASTEXITCODE | Should -Be 0
     }

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -147,4 +147,9 @@ resources:
         $LASTEXITCODE | Should -Be 2
     }
 
+    It '--debug has effect' {
+        dsc -d resource get -r Microsoft/OSInfo 2> $TestDrive/tracing.txt
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'DEBUG'
+        $LASTEXITCODE | Should -Be 0
+    }
 }


### PR DESCRIPTION
# PR Summary

This PR adds `--logging-level` / `-l` arg that specifies the level of tracing messages printed to stderr.
```
   Error,
   Warning,
   Info,
   Debug,
   Trace
```

A value from this list will also enable all above levels; for example "--logging-level Debug" will enable `Error`, `Warning`, `Info` and `Debug`.

Help Example:
```
PS C:\DSCv3> dsc --help                                   
...
Options:
  ...
  -l, --logging-level <LOGGING_LEVEL>  Log level to display [default: Info] [possible values: error, warning, info, debug, trace]
...
```

Usage example:
```
PS C:\DSCv3> dsc -l debug resource get -r Microsoft/OSInfo
  2023-11-01T17:18:53.142033Z DEBUG dsc_lib::discovery::command_discovery: Found Microsoft/OSInfo in C:\DSCv3\bin\debug\osinfo.dsc.resource.json
    at C:\DSCv3\dsc_lib\src\discovery\command_discovery.rs:86

  2023-11-01T17:18:53.142987Z DEBUG dsc::resource_command: resource.type_name - Microsoft/OSInfo implemented_as - Command
    at src\resource_command.rs:27

  2023-11-01T17:18:53.143721Z  INFO dsc_lib::dscresources::command_resource: Invoking get Microsoft/OSInfo using osinfo
    at C:\DSCv3\dsc_lib\src\dscresources\command_resource.rs:50

  2023-11-01T17:18:53.144443Z DEBUG dsc_lib::dscresources::command_resource: Invoking command osinfo with args None
    at C:\DSCv3\dsc_lib\src\dscresources\command_resource.rs:412

actualState:
  $id: https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json
  family: Windows
  version: 10.0.22631
  edition: Windows 11 Enterprise
  bitness: '64'
```