### PR TITLE
Added debug trace with DSC version

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -13,7 +13,7 @@ pub enum OutputFormat {
 }
 
 #[derive(Debug, Parser)]
-#[clap(name = "dsc", version = "3.0.0-alpha.4", about = "Apply configuration or invoke specific DSC resources", long_about = None)]
+#[clap(name = "dsc", version = env!("CARGO_PKG_VERSION"), about = "Apply configuration or invoke specific DSC resources", long_about = None)]
 pub struct Args {
     /// The subcommand to run
     #[clap(subcommand)]

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -8,7 +8,7 @@ use clap_complete::generate;
 use std::io::{self, Read};
 use std::process::exit;
 use sysinfo::{Process, ProcessExt, RefreshKind, System, SystemExt, get_current_pid, ProcessRefreshKind};
-use tracing::{Level, error, info, warn};
+use tracing::{Level, error, info, warn, debug};
 
 #[cfg(debug_assertions)]
 use crossterm::event;
@@ -44,6 +44,8 @@ fn main() {
     if tracing::subscriber::set_global_default(subscriber).is_err() {
         eprintln!("Unable to set global default subscriber");
     }
+
+    debug!("Running dsc {}", env!("CARGO_PKG_VERSION"));
 
     let input = if args.input.is_some() {
         args.input


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

2 updates with this PR:
1) Changed Clap::Args::version (used in `dsc -V`) to use value from `dsc\Cargo.toml`. This makes one less place to update when dsc version is incremented after a release.
2) Added debug statement with the current dsc version; e.g.:

```
PS C:\DSCv3> dsc -l trace resource get -r Microsoft/OSInfo
  2023-11-01T22:59:24.235180Z DEBUG dsc: Running dsc 3.0.0-alpha.4
    at src\main.rs:48
```
