### PR TITLE
Static linking the MSVC runtime

### DIFF
--- a/dsc/.cargo/config.toml
+++ b/dsc/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/dsc/.cargo/config.toml
+++ b/dsc/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/dsc_lib/.cargo/config.toml
+++ b/dsc_lib/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/dsc_lib/.cargo/config.toml
+++ b/dsc_lib/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/osinfo/.cargo/config.toml
+++ b/osinfo/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/osinfo/.cargo/config.toml
+++ b/osinfo/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/process/.cargo/config.toml
+++ b/process/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/process/.cargo/config.toml
+++ b/process/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/registry/.cargo/config.toml
+++ b/registry/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/registry/.cargo/config.toml
+++ b/registry/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/tools/dsctest/.cargo/config.toml
+++ b/tools/dsctest/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/tools/dsctest/.cargo/config.toml
+++ b/tools/dsctest/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/tools/test_group_resource/.cargo/config.toml
+++ b/tools/test_group_resource/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/tools/test_group_resource/.cargo/config.toml
+++ b/tools/test_group_resource/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/y2j/.cargo/config.toml
+++ b/y2j/.cargo/config.toml
@@ -1,0 +1,2 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]

--- a/y2j/.cargo/config.toml
+++ b/y2j/.cargo/config.toml
@@ -1,2 +1,4 @@
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-C", "target-feature=+crt-static"]
+[target.aarch64-pc-windows-msvc]
+rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
# PR Summary

Fix #256 

This PR forces static linking of MSVC runtime to avoid errors like `vcruntime140.dll was not found` on clean Windows machines.
[This uses `rustflags/+crt-static`](https://rust-lang.github.io/rfcs/1721-crt-static.html).

Side note: beware of [a bug in the area of static linking](https://github.com/rust-lang/rust/issues/71651) (looks like DSC project is not impacted by this at this point).

Fix was verified on a clean Windows Server 2022.
