### PR TITLE
Updated main version to 3.0.0-alpha.5

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsc"
-version = "3.0.0-alpha.4"
+version = "3.0.0-alpha.5"
 edition = "2021"
 
 [profile.release]

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsc_lib"
-version = "3.0.0-alpha.4"
+version = "3.0.0-alpha.5"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# PR Summary

`alpha.4` was just released, so updating version in the branches to `alpha.5`.