### PR TITLE
Add parameters support

### DIFF
--- a/dsc/examples/osinfo.parameters.yaml
+++ b/dsc/examples/osinfo.parameters.yaml
@@ -1,0 +1,2 @@
+parameters:
+  osFamily: macOS

--- a/dsc/examples/osinfo_parameters.dsc.yaml
+++ b/dsc/examples/osinfo_parameters.dsc.yaml
@@ -1,0 +1,14 @@
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+parameters:
+  osFamily:
+    type: string
+    defaultValue: Windows
+    allowedValues:
+      - Windows
+      - Linux
+      - macOS
+resources:
+- name: os
+  type: Microsoft/OSInfo
+  properties:
+    family: "[parameters('osFamily')]"

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -40,6 +40,10 @@ pub enum SubCommand {
     Config {
         #[clap(subcommand)]
         subcommand: ConfigSubCommand,
+        #[clap(short, long, help = "Parameters to pass to the configuration as JSON or YAML", conflicts_with = "parameters_file")]
+        parameters: Option<String>,
+        #[clap(short = 'f', long, help = "Parameters to pass to the configuration as a JSON or YAML file", conflicts_with = "parameters")]
+        parameters_file: Option<String>,
     },
     #[clap(name = "resource", about = "Invoke a specific DSC resource")]
     Resource {

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -81,8 +81,20 @@ fn main() {
             let mut cmd = Args::command();
             generate(shell, &mut cmd, "dsc", &mut io::stdout());
         },
-        SubCommand::Config { subcommand } => {
-            subcommand::config(&subcommand, &args.format, &input);
+        SubCommand::Config { subcommand, parameters, parameters_file } => {
+            if let Some(file_name) = parameters_file {
+                info!("Reading parameters from file {}", file_name);
+                match std::fs::read_to_string(file_name) {
+                    Ok(parameters) => subcommand::config(&subcommand, &Some(parameters), &args.format, &input),
+                    Err(err) => {
+                        error!("Error: Failed to read parameters file: {err}");
+                        exit(util::EXIT_INVALID_INPUT);
+                    }
+                }
+            }
+            else {
+                subcommand::config(&subcommand, &parameters, &args.format, &input);
+            }
         },
         SubCommand::Resource { subcommand } => {
             subcommand::resource(&subcommand, &args.format, &input);

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -20,6 +20,7 @@ Describe 'Parameters tests' {
                 text: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = 'hello' }} | ConvertTo-Json -Compress
+        write-verbose -verbose $params_json
         if ($inputType -eq 'file') {
             $file_path = "$TestDrive/test.parameters.json"
             Set-Content -Path $file_path -Value $params_json

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -20,7 +20,7 @@ Describe 'Parameters tests' {
                 text: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = 'hello' }} | ConvertTo-Json
-        write-verbose -verbose $params_json
+
         if ($inputType -eq 'file') {
             $file_path = "$TestDrive/test.parameters.json"
             Set-Content -Path $file_path -Value $params_json
@@ -53,7 +53,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
@@ -79,7 +79,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $null = $config_yaml | dsc config -p $params_json get
         $LASTEXITCODE | Should -Be 4
@@ -106,7 +106,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $null = $config_yaml | dsc config -p $params_json get
         $LASTEXITCODE | Should -Be 4
@@ -132,7 +132,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $null = $config_yaml | dsc config -p $params_json get
         $LASTEXITCODE | Should -Be 4
@@ -156,7 +156,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $null = $config_yaml | dsc config -p $params_json get
         $LASTEXITCODE | Should -Be 4
@@ -182,7 +182,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $null = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 4

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -1,0 +1,217 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Parameters tests' {
+    It 'Input can be provided as <inputType>' -TestCases @(
+        @{ inputType = 'string' }
+        @{ inputType = 'file' }
+    ) {
+        param($inputType)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: string
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = 'hello' }} | ConvertTo-Json -Compress
+        if ($inputType -eq 'file') {
+            $file_path = "$TestDrive/test.parameters.json"
+            Set-Content -Path $file_path -Value $params_json
+            $out = $config_yaml | dsc config -f $file_path get | ConvertFrom-Json
+        }
+        else {
+            $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
+        }
+
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].result.actualState.text | Should -BeExactly '"hello"'
+    }
+
+    It 'Input is <type>' -TestCases @(
+        @{ type = 'string'; value = 'hello'; expected = '"hello"' }
+        @{ type = 'int'; value = 42; expected = 42 }
+        @{ type = 'bool'; value = $true; expected = $true }
+        @{ type = 'array'; value = @('hello', 'world'); expected = '["hello","world"]' }
+    ) {
+        param($type, $value, $expected)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: $type
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+
+        $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].result.actualState.text | Should -BeExactly $expected
+    }
+
+    It 'Input is incorrect type <type>' -TestCases @(
+        @{ type = 'string'; value = 42 }
+        @{ type = 'int'; value = 'hello' }
+        @{ type = 'bool'; value = 'hello' }
+        @{ type = 'array'; value = 'hello' }
+    ) {
+        param($type, $value)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: $type
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+
+        $null = $config_yaml | dsc config -p $params_json get
+        $LASTEXITCODE | Should -Be 4
+    }
+
+    It 'Input length is wrong for <type>' -TestCases @(
+        @{ type = 'string'; value = 'hi' }
+        @{ type = 'string'; value = 'hello' }
+        @{ type = 'array'; value = @('hello', 'there') }
+        @{ type = 'array'; value = @('hello', 'there', 'bye', 'now') }
+    ) {
+        param($type, $value)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: $type
+                minLength: 3
+                maxLength: 3
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+
+        $null = $config_yaml | dsc config -p $params_json get
+        $LASTEXITCODE | Should -Be 4
+    }
+
+    It 'Input number value is out of range for <min> and <max>' -TestCases @(
+        @{ value = 42; min = 43; max = 44 }
+        @{ value = 42; min = 41; max = 41 }
+        @{ value = 42; min = 43; max = 41 }
+    ) {
+        param($type, $value, $min, $max)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: int
+                minValue: $min
+                maxValue: $max
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+
+        $null = $config_yaml | dsc config -p $params_json get
+        $LASTEXITCODE | Should -Be 4
+    }
+
+    It 'Input is not in the allowed value list for <type>' -TestCases @(
+        @{ type = 'string'; value = 'hello'; allowed = @('world', 'planet') }
+        @{ type = 'int'; value = 42; allowed = @(43, 44) }
+    ) {
+        param($type, $value, $allowed)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: $type
+                allowedValues: $($allowed | ConvertTo-Json -Compress)
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+
+        $null = $config_yaml | dsc config -p $params_json get
+        $LASTEXITCODE | Should -Be 4
+    }
+
+    It 'Length constraint is incorrectly applied to <type> with <constraint>' -TestCases @(
+        @{ type = 'int'; value = 42; constraint = 'minLength' }
+        @{ type = 'int'; value = 42; constraint = 'maxLength' }
+        @{ type = 'bool'; value = $true; constraint = 'minLength' }
+        @{ type = 'bool'; value = $true; constraint = 'maxLength' }
+    ) {
+        param($type, $value, $constraint)
+
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: $type
+                ${constraint}: 3
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[parameters(''param1'')]'
+"@
+        $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json -Compress
+
+        $null = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 4
+    }
+
+    It 'Default value is used when not provided' {
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            parameters:
+              param1:
+                type: string
+                defaultValue: 'hello'
+              param2:
+                type: int
+                defaultValue: 7
+              param3:
+                type: bool
+                defaultValue: false
+              param4:
+                type: array
+                defaultValue: ['hello', 'world']
+            resources:
+            - name: Echo
+              type: Test/Echo
+              properties:
+                text: '[concat(parameters(''param1''),'','',parameters(''param2''),'','',parameters(''param3''),'','',parameters(''param4''))]'
+"@
+
+        $out = $config_yaml | dsc config get | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].result.actualState.text | Should -BeExactly '"hello",7,false,["hello","world"]'
+    }
+}

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -19,7 +19,7 @@ Describe 'Parameters tests' {
               properties:
                 text: '[parameters(''param1'')]'
 "@
-        $params_json = @{ parameters = @{ param1 = 'hello' }} | ConvertTo-Json -Compress
+        $params_json = @{ parameters = @{ param1 = 'hello' }} | ConvertTo-Json
         write-verbose -verbose $params_json
         if ($inputType -eq 'file') {
             $file_path = "$TestDrive/test.parameters.json"

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -30,13 +30,13 @@ pub struct Parameter {
     #[serde(rename = "allowedValues", skip_serializing_if = "Option::is_none")]
     pub allowed_values: Option<Vec<Value>>,
     #[serde(rename = "minValue", skip_serializing_if = "Option::is_none")]
-    pub min_value: Option<Value>,
+    pub min_value: Option<i64>,
     #[serde(rename = "maxValue", skip_serializing_if = "Option::is_none")]
-    pub max_value: Option<Value>,
+    pub max_value: Option<i64>,
     #[serde(rename = "minLength", skip_serializing_if = "Option::is_none")]
-    pub min_length: Option<Value>,
+    pub min_length: Option<i64>,
     #[serde(rename = "maxLength", skip_serializing_if = "Option::is_none")]
-    pub max_length: Option<Value>,
+    pub max_length: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -11,11 +11,18 @@ pub struct Context {
 }
 
 impl Context {
+    #[must_use]
     pub fn new() -> Self {
         Self {
             parameters: HashMap::new(),
             _variables: HashMap::new(),
             _outputs: HashMap::new(),
         }
+    }
+}
+
+impl Default for Context {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -1,0 +1,21 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use serde_json::Value;
+use std::collections::HashMap;
+
+pub struct Context {
+    pub parameters: HashMap<String, Value>,
+    pub _variables: HashMap<String, Value>,
+    pub _outputs: HashMap<String, Value>, // This is eventually for References function to get output from resources
+}
+
+impl Context {
+    pub fn new() -> Self {
+        Self {
+            parameters: HashMap::new(),
+            _variables: HashMap::new(),
+            _outputs: HashMap::new(),
+        }
+    }
+}

--- a/dsc_lib/src/configure/contraints.rs
+++ b/dsc_lib/src/configure/contraints.rs
@@ -5,17 +5,39 @@ use crate::configure::config_doc::Parameter;
 use crate::DscError;
 use serde_json::Value;
 
+/// Checks that the given value matches the given parameter length constraints.
+///
+/// # Arguments
+///
+/// * `name` - The name of the parameter.
+/// * `value` - The value of the parameter.
+/// * `constraint` - The constraints on the parameter.
+///
+/// # Returns
+///
+/// * `Ok(())` if the value matches the constraints.
+/// * `Err(DscError::Validation)` if the value does not match the constraints.
+///
+/// # Errors
+///
+/// * `DscError::Validation` if the value does not match the constraints.
 pub fn check_length(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
     if let Some(min_length) = constraint.min_length {
         if value.is_string() {
-            let value = value.as_str().unwrap();
-            if value.len() < min_length as usize {
+            let Some(value) = value.as_str() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint but is null")));
+            };
+
+            if value.len() < usize::try_from(min_length)? {
                 return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint of {min_length} but is {0}", value.len())));
             }
         }
         else if value.is_array() {
-            let value = value.as_array().unwrap();
-            if value.len() < min_length as usize {
+            let Some(value) = value.as_array() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint but is null")));
+            };
+
+            if value.len() < usize::try_from(min_length)? {
                 return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint of {min_length} but is {0}", value.len())));
             }
         }
@@ -26,14 +48,20 @@ pub fn check_length(name: &str, value: &Value, constraint: &Parameter) -> Result
 
     if let Some(max_length) = constraint.max_length {
         if value.is_string() {
-            let value = value.as_str().unwrap();
-            if value.len() > max_length as usize {
+            let Some(value) = value.as_str() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint but is null")));
+            };
+
+            if value.len() > usize::try_from(max_length)? {
                 return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint of {max_length} but is {0}", value.len())));
             }
         }
         else if value.is_array() {
-            let value = value.as_array().unwrap();
-            if value.len() > max_length as usize {
+            let Some(value) = value.as_array() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint but is null")));
+            };
+
+            if value.len() > usize::try_from(max_length)? {
                 return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint of {max_length} but is {0}", value.len())));
             }
         }
@@ -45,12 +73,31 @@ pub fn check_length(name: &str, value: &Value, constraint: &Parameter) -> Result
     Ok(())
 }
 
+/// Checks that the given value matches the given number value constraints.
+///
+/// # Arguments
+///
+/// * `name` - The name of the parameter.
+/// * `value` - The value of the parameter.
+/// * `constraint` - The constraints on the parameter.
+///
+/// # Returns
+///
+/// * `Ok(())` if the value matches the constraints.
+/// * `Err(DscError::Validation)` if the value does not match the constraints.
+///
+/// # Errors
+///
+/// * `DscError::Validation` if the value does not match the constraints.
 pub fn check_number(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
     if let Some(min_value) = constraint.min_value {
         if value.is_i64() && value.as_i64().is_some() {
-            let value = value.as_i64().unwrap();
+            let Some(value) = value.as_i64() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum value constraint but is null")));
+            };
+
             if value < min_value {
-                return Err(DscError::Validation(format!("Parameter '{name}' has minimum value constraint of {min_value} but is {0}", value)));
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum value constraint of {min_value} but is {value}")));
             }
         }
         else {
@@ -60,9 +107,12 @@ pub fn check_number(name: &str, value: &Value, constraint: &Parameter) -> Result
 
     if let Some(max_value) = constraint.max_value {
         if value.is_i64() && value.as_i64().is_some() {
-            let value = value.as_i64().unwrap();
+            let Some(value) = value.as_i64() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum value constraint but is null")));
+            };
+
             if value > max_value {
-                return Err(DscError::Validation(format!("Parameter '{name}' has maximum value constraint of {max_value} but is {0}", value)));
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum value constraint of {max_value} but is {value}")));
             }
         }
         else {
@@ -73,16 +123,38 @@ pub fn check_number(name: &str, value: &Value, constraint: &Parameter) -> Result
     Ok(())
 }
 
+/// Checks that the given value matches the given allowed values constraints.
+///
+/// # Arguments
+///
+/// * `name` - The name of the parameter.
+/// * `value` - The value of the parameter.
+/// * `constraint` - The constraints on the parameter.
+///
+/// # Returns
+///
+/// * `Ok(())` if the value matches the constraints.
+/// * `Err(DscError::Validation)` if the value does not match the constraints.
+///
+/// # Errors
+///
+/// * `DscError::Validation` if the value does not match the constraints.
 pub fn check_allowed_values(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
     if let Some(allowed_values) = &constraint.allowed_values {
         if value.is_string() && value.as_str().is_some(){
-            let value = value.as_str().unwrap();
+            let Some(value) = value.as_str() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has allowed values constraint but is null")));
+            };
+
             if !allowed_values.contains(&Value::String(value.to_string())) {
                 return Err(DscError::Validation(format!("Parameter '{name}' has value not in the allowed values list")));
             }
         }
         else if value.is_i64() && value.as_i64().is_some() {
-            let value = value.as_i64().unwrap();
+            let Some(value) = value.as_i64() else {
+                return Err(DscError::Validation(format!("Parameter '{name}' has allowed values constraint but is null")));
+            };
+
             if !allowed_values.contains(&Value::Number(value.into())) {
                 return Err(DscError::Validation(format!("Parameter '{name}' has value not in the allowed values list")));
             }

--- a/dsc_lib/src/configure/contraints.rs
+++ b/dsc_lib/src/configure/contraints.rs
@@ -89,7 +89,7 @@ pub fn check_length(name: &str, value: &Value, constraint: &Parameter) -> Result
 /// # Errors
 ///
 /// * `DscError::Validation` if the value does not match the constraints.
-pub fn check_number(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
+pub fn check_number_limits(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
     if let Some(min_value) = constraint.min_value {
         if value.is_i64() && value.as_i64().is_some() {
             let Some(value) = value.as_i64() else {

--- a/dsc_lib/src/configure/contraints.rs
+++ b/dsc_lib/src/configure/contraints.rs
@@ -1,0 +1,98 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::configure::config_doc::Parameter;
+use crate::DscError;
+use serde_json::Value;
+
+pub fn check_length(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
+    if let Some(min_length) = constraint.min_length {
+        if value.is_string() {
+            let value = value.as_str().unwrap();
+            if value.len() < min_length as usize {
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint of {min_length} but is {0}", value.len())));
+            }
+        }
+        else if value.is_array() {
+            let value = value.as_array().unwrap();
+            if value.len() < min_length as usize {
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint of {min_length} but is {0}", value.len())));
+            }
+        }
+        else {
+            return Err(DscError::Validation(format!("Parameter '{name}' has minimum length constraint but is not a string or array")));
+        }
+    }
+
+    if let Some(max_length) = constraint.max_length {
+        if value.is_string() {
+            let value = value.as_str().unwrap();
+            if value.len() > max_length as usize {
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint of {max_length} but is {0}", value.len())));
+            }
+        }
+        else if value.is_array() {
+            let value = value.as_array().unwrap();
+            if value.len() > max_length as usize {
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint of {max_length} but is {0}", value.len())));
+            }
+        }
+        else {
+            return Err(DscError::Validation(format!("Parameter '{name}' has maximum length constraint but is not a string or array")));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn check_number(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
+    if let Some(min_value) = constraint.min_value {
+        if value.is_i64() && value.as_i64().is_some() {
+            let value = value.as_i64().unwrap();
+            if value < min_value {
+                return Err(DscError::Validation(format!("Parameter '{name}' has minimum value constraint of {min_value} but is {0}", value)));
+            }
+        }
+        else {
+            return Err(DscError::Validation(format!("Parameter '{name}' has minimum value constraint but is not an integer")));
+        }
+    }
+
+    if let Some(max_value) = constraint.max_value {
+        if value.is_i64() && value.as_i64().is_some() {
+            let value = value.as_i64().unwrap();
+            if value > max_value {
+                return Err(DscError::Validation(format!("Parameter '{name}' has maximum value constraint of {max_value} but is {0}", value)));
+            }
+        }
+        else {
+            return Err(DscError::Validation(format!("Parameter '{name}' has maximum value constraint but is not an integer")));
+        }
+    }
+
+    Ok(())
+}
+
+pub fn check_allowed_values(name: &str, value: &Value, constraint: &Parameter) -> Result<(), DscError> {
+    if let Some(allowed_values) = &constraint.allowed_values {
+        if value.is_string() && value.as_str().is_some(){
+            let value = value.as_str().unwrap();
+            if !allowed_values.contains(&Value::String(value.to_string())) {
+                return Err(DscError::Validation(format!("Parameter '{name}' has value not in the allowed values list")));
+            }
+        }
+        else if value.is_i64() && value.as_i64().is_some() {
+            let value = value.as_i64().unwrap();
+            if !allowed_values.contains(&Value::Number(value.into())) {
+                return Err(DscError::Validation(format!("Parameter '{name}' has value not in the allowed values list")));
+            }
+        }
+        else {
+            return Err(DscError::Validation(format!("Parameter '{name}' has allowed values constraint but is not a string or integer")));
+        }
+    }
+
+    Ok(())
+}
+
+// TODO: check nullable

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -13,7 +13,7 @@ use self::context::Context;
 use self::config_doc::{Configuration, DataType};
 use self::depends_on::get_resource_invocation_order;
 use self::config_result::{ConfigurationGetResult, ConfigurationSetResult, ConfigurationTestResult, ConfigurationExportResult, ResourceMessage, MessageLevel};
-use self::contraints::{check_length, check_number, check_allowed_values};
+use self::contraints::{check_length, check_number_limits, check_allowed_values};
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
@@ -341,7 +341,7 @@ impl Configurator {
             if let Some(constraint) = parameters_constraints.get(&name) {
                 check_length(&name, &value, constraint)?;
                 check_allowed_values(&name, &value, constraint)?;
-                check_number(&name, &value, constraint)?;
+                check_number_limits(&name, &value, constraint)?;
                 // TODO: additional array constraints
                 // TODO: object constraints
 

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -3,24 +3,31 @@
 
 use jsonschema::JSONSchema;
 
+use crate::configure::parameters::ParametersInput;
 use crate::dscerror::DscError;
 use crate::dscresources::dscresource::Invoke;
 use crate::DscResource;
 use crate::discovery::Discovery;
 use crate::parser::Statement;
-use self::config_doc::Configuration;
+use self::context::Context;
+use self::config_doc::{Configuration, DataType};
 use self::depends_on::get_resource_invocation_order;
 use self::config_result::{ConfigurationGetResult, ConfigurationSetResult, ConfigurationTestResult, ConfigurationExportResult, ResourceMessage, MessageLevel};
+use self::contraints::{check_length, check_number, check_allowed_values};
 use serde_json::{Map, Value};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
 
+pub mod context;
 pub mod config_doc;
 pub mod config_result;
+pub mod contraints;
 pub mod depends_on;
+pub mod parameters;
 
 pub struct Configurator {
     config: String,
+    context: Context,
     discovery: Discovery,
     statement_parser: Statement,
 }
@@ -131,6 +138,7 @@ impl Configurator {
         let discovery = Discovery::new()?;
         Ok(Configurator {
             config: config.to_owned(),
+            context: Context::new(),
             discovery,
             statement_parser: Statement::new()?,
         })
@@ -154,7 +162,7 @@ impl Configurator {
         if had_errors {
             return Ok(result);
         }
-        for resource in get_resource_invocation_order(&config, &mut self.statement_parser)? {
+        for resource in get_resource_invocation_order(&config, &mut self.statement_parser, &self.context)? {
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -191,7 +199,7 @@ impl Configurator {
         if had_errors {
             return Ok(result);
         }
-        for resource in get_resource_invocation_order(&config, &mut self.statement_parser)? {
+        for resource in get_resource_invocation_order(&config, &mut self.statement_parser, &self.context)? {
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -228,7 +236,7 @@ impl Configurator {
         if had_errors {
             return Ok(result);
         }
-        for resource in get_resource_invocation_order(&config, &mut self.statement_parser)? {
+        for resource in get_resource_invocation_order(&config, &mut self.statement_parser, &self.context)? {
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -292,6 +300,87 @@ impl Configurator {
         result.result = Some(conf);
 
         Ok(result)
+    }
+
+    pub fn set_parameters(&mut self, parameters_input: &Option<Value>) -> Result<(), DscError> {
+        // set default parameters first
+        let config = serde_json::from_str::<Configuration>(self.config.as_str())?;
+        let Some(parameters) = &config.parameters else {
+            if parameters_input.is_none() {
+                return Ok(());
+            }
+            return Err(DscError::Validation("No parameters defined in configuration".to_string()));
+        };
+
+        for (name, parameter) in parameters {
+            if let Some(default_value) = &parameter.default_value {
+                // TODO: default values can be expressions
+                // TODO: validate default value matches the type
+                self.context.parameters.insert(name.clone(), default_value.clone());
+            }
+        }
+
+        let Some(parameters_input) = parameters_input else {
+            return Ok(());
+        };
+
+        let parameters: HashMap<String, Value> = serde_json::from_value::<ParametersInput>(parameters_input.clone())?.parameters;
+        let Some(parameters_constraints) = &config.parameters else {
+            return Err(DscError::Validation("No parameters defined in configuration".to_string()));
+        };
+        for (name, value) in parameters {
+            if let Some(constraint) = parameters_constraints.get(&name) {
+                check_length(&name, &value, &constraint)?;
+                check_allowed_values(&name, &value, &constraint)?;
+                check_number(&name, &value, &constraint)?;
+                // TODO: additional array constraints
+                // TODO: object constraints
+
+                match constraint.parameter_type {
+                    DataType::String => {
+                        if !value.is_string() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not a string")));
+                        }
+                    },
+                    DataType::Int => {
+                        if !value.is_i64() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not an integer")));
+                        }
+                    },
+                    DataType::Bool => {
+                        if !value.is_boolean() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not a boolean")));
+                        }
+                    },
+                    DataType::Array => {
+                        if !value.is_array() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not an array")));
+                        }
+                    },
+                    DataType::Object => {
+                        if !value.is_object() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not an object")));
+                        }
+                    },
+                    DataType::SecureString => {
+                        if !value.is_string() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not a string")));
+                        }
+                    },
+                    DataType::SecureObject => {
+                        if !value.is_object() {
+                            return Err(DscError::Validation(format!("Parameter '{name}' is not an object")));
+                        }
+                    },
+                }
+
+                self.context.parameters.insert(name.clone(), value.clone());
+            }
+            else {
+                return Err(DscError::Validation(format!("Parameter '{name}' not defined in configuration")));
+            }
+        }
+        Ok(())
     }
 
     fn find_duplicate_resource_types(config: &Configuration) -> Vec<String>
@@ -418,7 +507,7 @@ impl Configurator {
                                     let Some(statement) = element.as_str() else {
                                         return Err(DscError::Parser("Array element could not be transformed as string".to_string()));
                                     };
-                                    let statement_result = self.statement_parser.parse_and_execute(statement)?;
+                                    let statement_result = self.statement_parser.parse_and_execute(statement, &self.context)?;
                                     result_array.push(Value::String(statement_result));
                                 }
                                 _ => {
@@ -433,7 +522,7 @@ impl Configurator {
                         let Some(statement) = value.as_str() else {
                             return Err(DscError::Parser(format!("Property value '{value}' could not be transformed as string")));
                         };
-                        let statement_result = self.statement_parser.parse_and_execute(statement)?;
+                        let statement_result = self.statement_parser.parse_and_execute(statement, &self.context)?;
                         result.insert(name.clone(), Value::String(statement_result));
                     },
                     _ => {

--- a/dsc_lib/src/configure/parameters.rs
+++ b/dsc_lib/src/configure/parameters.rs
@@ -7,6 +7,6 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub struct ParametersInput {
+pub struct Input {
     pub parameters: HashMap<String, Value>,
 }

--- a/dsc_lib/src/configure/parameters.rs
+++ b/dsc_lib/src/configure/parameters.rs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct ParametersInput {
+    pub parameters: HashMap<String, Value>,
+}

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -64,6 +64,9 @@ pub enum DscError {
     #[error("Not implemented: {0}")]
     NotImplemented(String),
 
+    #[error("Number conversion error: {0}")]
+    NumberConversion(#[from] std::num::TryFromIntError),
+
     #[error("Operation: {0}")]
     Operation(String),
 

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -4,6 +4,7 @@
 use base64::{Engine as _, engine::general_purpose};
 
 use crate::DscError;
+use crate::configure::context::Context;
 use crate::parser::functions::{FunctionArg, FunctionResult};
 use super::{Function, AcceptedArgKind};
 
@@ -23,7 +24,7 @@ impl Function for Base64 {
         1
     }
 
-    fn invoke(&self, args: &[FunctionArg]) -> Result<FunctionResult, DscError> {
+    fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
         let FunctionArg::String(arg) = args.get(0).unwrap() else {
             return Err(DscError::Parser("Invalid argument type".to_string()));
         };
@@ -33,26 +34,27 @@ impl Function for Base64 {
 
 #[cfg(test)]
 mod tests {
+    use crate::configure::context::Context;
     use crate::parser::Statement;
 
     #[test]
     fn strings() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[base64('hello world')]").unwrap();
+        let result = parser.parse_and_execute("[base64('hello world')]", &Context::new()).unwrap();
         assert_eq!(result, "aGVsbG8gd29ybGQ=");
     }
 
     #[test]
     fn numbers() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[base64(123)]");
+        let result = parser.parse_and_execute("[base64(123)]", &Context::new());
         assert!(result.is_err());
     }
 
     #[test]
     fn nested() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[base64(base64('hello world'))]").unwrap();
+        let result = parser.parse_and_execute("[base64(base64('hello world'))]", &Context::new()).unwrap();
         assert_eq!(result, "YUdWc2JHOGdkMjl5YkdRPQ==");
     }
 }

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -25,7 +25,7 @@ impl Function for Base64 {
     }
 
     fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
-        let FunctionArg::String(arg) = args.get(0).unwrap() else {
+        let FunctionArg::String(arg) = args.first().unwrap() else {
             return Err(DscError::Parser("Invalid argument type".to_string()));
         };
         Ok(FunctionResult::String(general_purpose::STANDARD.encode(arg)))

--- a/dsc_lib/src/functions/concat.rs
+++ b/dsc_lib/src/functions/concat.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::DscError;
+use crate::configure::context::Context;
 use crate::functions::{Function, FunctionArg, FunctionResult, AcceptedArgKind};
 use tracing::debug;
 
@@ -21,7 +22,7 @@ impl Function for Concat {
         vec![AcceptedArgKind::String, AcceptedArgKind::Integer]
     }
 
-    fn invoke(&self, args: &[FunctionArg]) -> Result<FunctionResult, DscError> {
+    fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
         let mut result = String::new();
         for arg in args {
             match arg {
@@ -43,47 +44,48 @@ impl Function for Concat {
 
 #[cfg(test)]
 mod tests {
+    use crate::configure::context::Context;
     use crate::parser::Statement;
 
     #[test]
     fn strings() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a', 'b')]").unwrap();
+        let result = parser.parse_and_execute("[concat('a', 'b')]", &Context::new()).unwrap();
         assert_eq!(result, "ab");
     }
 
     #[test]
     fn strings_with_spaces() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a ', ' ', ' b')]").unwrap();
+        let result = parser.parse_and_execute("[concat('a ', ' ', ' b')]", &Context::new()).unwrap();
         assert_eq!(result, "a   b");
     }
 
     #[test]
     fn numbers() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat(1, 2)]").unwrap();
+        let result = parser.parse_and_execute("[concat(1, 2)]", &Context::new()).unwrap();
         assert_eq!(result, "12");
     }
 
     #[test]
     fn string_and_numbers() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a', 1, 'b', 2)]").unwrap();
+        let result = parser.parse_and_execute("[concat('a', 1, 'b', 2)]", &Context::new()).unwrap();
         assert_eq!(result, "a1b2");
     }
 
     #[test]
     fn nested() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]").unwrap();
+        let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]", &Context::new()).unwrap();
         assert_eq!(result, "abcd");
     }
 
     #[test]
     fn invalid_one_parameter() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a')]");
+        let result = parser.parse_and_execute("[concat('a')]", &Context::new());
         assert!(result.is_err());
     }
 }

--- a/dsc_lib/src/functions/parameters.rs
+++ b/dsc_lib/src/functions/parameters.rs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+use crate::configure::context::Context;
+use crate::functions::{Function, FunctionArg, FunctionResult, AcceptedArgKind};
+use tracing::debug;
+
+#[derive(Debug, Default)]
+pub struct Parameters {}
+
+impl Function for Parameters {
+    fn min_args(&self) -> usize {
+        1
+    }
+
+    fn max_args(&self) -> usize {
+        1
+    }
+
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::String]
+    }
+
+    fn invoke(&self, args: &[FunctionArg], context: &Context) -> Result<FunctionResult, DscError> {
+        let key = match &args[0] {
+            FunctionArg::String(value) => value,
+            _ => {
+                return Err(DscError::Parser("Invalid argument type".to_string()));
+            }
+        };
+        debug!("parameters key: {key}");
+        if context.parameters.contains_key(key) {
+            Ok(FunctionResult::Object(context.parameters[key].clone()))
+        }
+        else {
+            return Err(DscError::Parser(format!("Parameter '{key}' not found in context")));
+        }
+    }
+}

--- a/dsc_lib/src/functions/parameters.rs
+++ b/dsc_lib/src/functions/parameters.rs
@@ -23,18 +23,15 @@ impl Function for Parameters {
     }
 
     fn invoke(&self, args: &[FunctionArg], context: &Context) -> Result<FunctionResult, DscError> {
-        let key = match &args[0] {
-            FunctionArg::String(value) => value,
-            _ => {
-                return Err(DscError::Parser("Invalid argument type".to_string()));
-            }
+        let FunctionArg::String(key) = &args[0] else {
+            return Err(DscError::Parser("Invalid argument type".to_string()));
         };
         debug!("parameters key: {key}");
         if context.parameters.contains_key(key) {
             Ok(FunctionResult::Object(context.parameters[key].clone()))
         }
         else {
-            return Err(DscError::Parser(format!("Parameter '{key}' not found in context")));
+            Err(DscError::Parser(format!("Parameter '{key}' not found in context")))
         }
     }
 }

--- a/dsc_lib/src/functions/resource_id.rs
+++ b/dsc_lib/src/functions/resource_id.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::DscError;
+use crate::configure::context::Context;
 use crate::functions::{Function, FunctionArg, FunctionResult, AcceptedArgKind};
 
 #[derive(Debug, Default)]
@@ -20,7 +21,7 @@ impl Function for ResourceId {
         vec![AcceptedArgKind::String]
     }
 
-    fn invoke(&self, args: &[FunctionArg]) -> Result<FunctionResult, DscError> {
+    fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
         let mut result = String::new();
         // first argument is the type and must contain only 1 slash
         match &args[0] {
@@ -57,40 +58,41 @@ impl Function for ResourceId {
 
 #[cfg(test)]
 mod tests {
+    use crate::configure::context::Context;
     use crate::parser::Statement;
 
     #[test]
     fn strings() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[resourceId('a/b', 'c')]").unwrap();
+        let result = parser.parse_and_execute("[resourceId('a/b', 'c')]", &Context::new()).unwrap();
         assert_eq!(result, "a/b:c");
     }
 
     #[test]
     fn strings_with_dots() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[resourceId('a.b/c', 'd')]").unwrap();
+        let result = parser.parse_and_execute("[resourceId('a.b/c', 'd')]", &Context::new()).unwrap();
         assert_eq!(result, "a.b/c:d");
     }
 
     #[test]
     fn invalid_type() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[resourceId('a/b/c','d')]");
+        let result = parser.parse_and_execute("[resourceId('a/b/c','d')]", &Context::new());
         assert!(result.is_err());
     }
 
     #[test]
     fn invalid_name() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[resourceId('a','b/c')]");
+        let result = parser.parse_and_execute("[resourceId('a','b/c')]", &Context::new());
         assert!(result.is_err());
     }
 
     #[test]
     fn invalid_one_parameter() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[resourceId('a')]");
+        let result = parser.parse_and_execute("[resourceId('a')]", &Context::new());
         assert!(result.is_err());
     }
 }

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -3,6 +3,7 @@
 
 use tree_sitter::Node;
 
+use crate::configure::context::Context;
 use crate::dscerror::DscError;
 use crate::functions::FunctionDispatcher;
 use crate::parser::functions::{Function, FunctionResult};
@@ -59,8 +60,8 @@ impl Expression {
     /// # Errors
     ///
     /// This function will return an error if the expression fails to execute.
-    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher) -> Result<String, DscError> {
-        let result = self.function.invoke(function_dispatcher)?;
+    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<String, DscError> {
+        let result = self.function.invoke(function_dispatcher, context)?;
         if let Some(member_access) = &self.member_access {
             match result {
                 FunctionResult::String(_) => {

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -5,6 +5,7 @@ use serde_json::Value;
 use tree_sitter::Node;
 
 use crate::DscError;
+use crate::configure::context::Context;
 use crate::parser::{
     expressions::Expression,
     FunctionDispatcher,
@@ -58,14 +59,14 @@ impl Function {
     /// # Errors
     ///
     /// This function will return an error if the function fails to execute.
-    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher) -> Result<FunctionResult, DscError> {
+    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<FunctionResult, DscError> {
         // if any args are expressions, we need to invoke those first
         let mut resolved_args: Vec<FunctionArg> = vec![];
         if let Some(args) = &self.args {
             for arg in args {
                 match arg {
                     FunctionArg::Expression(expression) => {
-                        let value = expression.invoke(function_dispatcher)?;
+                        let value = expression.invoke(function_dispatcher, context)?;
                         resolved_args.push(FunctionArg::String(value));
                     },
                     _ => {
@@ -75,7 +76,7 @@ impl Function {
             }
         }
 
-        function_dispatcher.invoke(&self.name, &resolved_args)
+        function_dispatcher.invoke(&self.name, &resolved_args, context)
     }
 }
 

--- a/process/Cargo.toml
+++ b/process/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sysinfo = "*"
+sysinfo = "0.30"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/process/src/main.rs
+++ b/process/src/main.rs
@@ -5,7 +5,7 @@ mod process_info;
 use std::env;
 use std::process::exit;
 use std::io::{self, Read};
-use sysinfo::{ProcessExt, System, SystemExt, PidExt};
+use sysinfo::System;
 use crate::process_info::ProcessInfo;
 
 fn get_task_list() -> Vec<ProcessInfo>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Added:

- `dsc` CLI can accept parameters JSON/YAML as string or file
- parameters are validated against constraints (some TODOs in the code to fill in later)
- context added to configurator keeping necessary state for parameters but also future use for variables/references

The osinfo example YAMLs currently do not work due to schema validation happening before expression execution

## PR Context

Fix https://github.com/PowerShell/DSC/issues/49