### PR TITLE
Fix parameters to work with property values

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -21,7 +21,7 @@ jsonschema = "0.17"
 schemars = { version = "0.8.12" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-serde_yaml = { version = "0.9" }
+serde_yaml = { version = "0.9.3" }
 syntect = { version = "5.0", features = ["default-fancy"], default-features = false }
 sysinfo = { version = "0.29.10" }
 thiserror = "1.0"

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -27,12 +27,7 @@ Describe 'dsc config get tests' {
     It 'will fail if resource schema does not match' -Skip:(!$IsWindows) {
         $jsonPath = Join-Path $PSScriptRoot '../examples/invalid_schema.dsc.yaml'
         $config = Get-Content $jsonPath -Raw
-        $out = $config | dsc config get | ConvertFrom-Json
+        $null = $config | dsc config get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 2
-        $out.hadErrors | Should -BeTrue
-        $out.results.Count | Should -Be 0
-        $out.messages.Count | Should -Be 2
-        $out.messages[0].level | Should -BeExactly 'Error'
-        $out.messages[1].level | Should -BeExactly 'Error'
     }
 }

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -245,7 +245,7 @@ Describe 'Parameters tests' {
         - name: os
           type: Microsoft/OSInfo
           properties:
-            family: '[parameters(''osFamily'')]'
+            family: "[parameters('osFamily')]"
 '@
 
       $out = dsc -i $config_yaml config -p $params test | ConvertFrom-Json

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -248,7 +248,7 @@ Describe 'Parameters tests' {
             family: "[parameters('osFamily')]"
 '@
 
-      $out = dsc -i $config_yaml config -p $params test | ConvertFrom-Json
+      $out = dsc -i $config_yaml config -p "$params" test | ConvertFrom-Json
       $LASTEXITCODE | Should -Be 0
       $out.results[0].result.actualState.family | Should -BeExactly $os
       $out.results[0].result.inDesiredState | Should -BeTrue

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -229,7 +229,7 @@ Describe 'Parameters tests' {
         parameters = @{
           osFamily = $os
         }
-      } | ConvertTo-Json -Compress
+      } | ConvertTo-Json
 
       $config_yaml = @'
         $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
@@ -248,7 +248,7 @@ Describe 'Parameters tests' {
             family: "[parameters('osFamily')]"
 '@
 
-      $out = dsc -i $config_yaml config -p "$params" test | ConvertFrom-Json
+      $out = dsc -i $config_yaml config -p $params test | ConvertFrom-Json
       $LASTEXITCODE | Should -Be 0
       $out.results[0].result.actualState.family | Should -BeExactly $os
       $out.results[0].result.inDesiredState | Should -BeTrue

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -245,7 +245,7 @@ Describe 'Parameters tests' {
         - name: os
           type: Microsoft/OSInfo
           properties:
-            family: "[parameters('osFamily')]"
+            family: '[parameters(''osFamily'')]'
 '@
 
       $out = dsc -i $config_yaml config -p $params test | ConvertFrom-Json

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -31,11 +31,11 @@ Describe 'Parameters tests' {
         }
 
         $LASTEXITCODE | Should -Be 0
-        $out.results[0].result.actualState.text | Should -BeExactly '"hello"'
+        $out.results[0].result.actualState.text | Should -BeExactly 'hello'
     }
 
     It 'Input is <type>' -TestCases @(
-        @{ type = 'string'; value = 'hello'; expected = '"hello"' }
+        @{ type = 'string'; value = 'hello'; expected = 'hello' }
         @{ type = 'int'; value = 42; expected = 42 }
         @{ type = 'bool'; value = $true; expected = $true }
         @{ type = 'array'; value = @('hello', 'world'); expected = '["hello","world"]' }
@@ -213,6 +213,44 @@ Describe 'Parameters tests' {
 
         $out = $config_yaml | dsc config get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out.results[0].result.actualState.text | Should -BeExactly '"hello",7,false,["hello","world"]'
+        $out.results[0].result.actualState.text | Should -BeExactly 'hello,7,false,["hello","world"]'
+    }
+
+    It 'property value uses parameter value' {
+      $os = 'Windows'
+      if ($IsLinux) {
+        $os = 'Linux'
+      }
+      elseif ($IsMacOS) {
+        $os = 'macOS'
+      }
+
+      $params = @{
+        parameters = @{
+          osFamily = $os
+        }
+      } | ConvertTo-Json -Compress
+
+      $config_yaml = @'
+        $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+        parameters:
+          osFamily:
+            type: string
+            defaultValue: Windows
+            allowedValues:
+              - Windows
+              - Linux
+              - macOS
+        resources:
+        - name: os
+          type: Microsoft/OSInfo
+          properties:
+            family: "[parameters('osFamily')]"
+'@
+
+      $out = dsc -i $config_yaml config -p $params test | ConvertFrom-Json
+      $LASTEXITCODE | Should -Be 0
+      $out.results[0].result.actualState.family | Should -BeExactly $os
+      $out.results[0].result.inDesiredState | Should -BeTrue
     }
 }

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -19,7 +19,7 @@ tree-sitter = "~0.20.10"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
 
 [dev-dependencies]
-serde_yaml = "0.9"
+serde_yaml = "0.9.3"
 
 [build-dependencies]
 cc="*"

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -62,7 +62,7 @@ impl DscResource {
     }
 
     fn validate_input(&self, input: &str) -> Result<(), DscError> {
-        if input.len() == 0 {
+        if input.is_empty() {
             return Ok(());
         }
         let Some(manifest) = &self.manifest else {

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -62,6 +62,9 @@ impl DscResource {
     }
 
     fn validate_input(&self, input: &str) -> Result<(), DscError> {
+        if input.len() == 0 {
+            return Ok(());
+        }
         let Some(manifest) = &self.manifest else {
             return Err(DscError::MissingManifest(self.type_name.clone()));
         };

--- a/dsc_lib/src/functions/parameters.rs
+++ b/dsc_lib/src/functions/parameters.rs
@@ -28,6 +28,14 @@ impl Function for Parameters {
         };
         debug!("parameters key: {key}");
         if context.parameters.contains_key(key) {
+            let value = &context.parameters[key];
+            // we have to check if it's a string as a to_string() will put the string in quotes as part of the value
+            if value.is_string() {
+                if let Some(value) = value.as_str() {
+                    return Ok(FunctionResult::String(value.to_string()));
+                }
+            }
+
             Ok(FunctionResult::Object(context.parameters[key].clone()))
         }
         else {

--- a/osinfo/osinfo.dsc.resource.json
+++ b/osinfo/osinfo.dsc.resource.json
@@ -66,7 +66,7 @@
                     "type": "string",
                     "enum": [
                         "Linux",
-                        "MacOS",
+                        "macOS",
                         "Windows"
                     ],
                     "title": "Operating system family",

--- a/osinfo/src/config.rs
+++ b/osinfo/src/config.rs
@@ -41,6 +41,7 @@ pub enum Bitness {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub enum Family {
     Linux,
+    #[serde(rename = "macOS")]
     MacOS,
     Windows,
 }

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -12,7 +12,7 @@ Describe 'osinfo resource tests' {
             $out.actualState.family | Should -BeExactly 'Linux'
         }
         elseif ($IsMacOS) {
-            $out.actualState.family | Should -BeExactly 'MacOS'
+            $out.actualState.family | Should -BeExactly 'macOS'
         }
 
         $out.actualState.version | Should -Not -BeNullOrEmpty
@@ -50,7 +50,7 @@ Describe 'osinfo resource tests' {
             $out.resources[0].properties.family | Should -BeExactly 'Linux'
         }
         elseif ($IsMacOS) {
-            $out.resources[0].properties.family | Should -BeExactly 'MacOS'
+            $out.resources[0].properties.family | Should -BeExactly 'macOS'
         }
     }
 }

--- a/powershellgroup/powershellgroup.dsc.resource.json
+++ b/powershellgroup/powershellgroup.dsc.resource.json
@@ -55,6 +55,16 @@
       "input": "stdin",
       "return": "state"
       },
+    "validate": {
+        "executable": "pwsh",
+        "args": [
+          "-NoLogo",
+          "-NonInteractive",
+          "-NoProfile",
+          "-Command",
+          "$Input | ./powershellgroup.resource.ps1 Validate"
+          ]
+      },  
     "exitCodes": {
       "0": "Success",
       "1": "Error"

--- a/powershellgroup/powershellgroup.resource.ps1
+++ b/powershellgroup/powershellgroup.resource.ps1
@@ -3,7 +3,7 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet('List','Get','Set','Test')]
+    [ValidateSet('List','Get','Set','Test','Validate')]
     $Operation = 'List',
     [Switch]
     $WinPS = $false,
@@ -326,6 +326,11 @@ elseif ($Operation -eq 'Test')
     }
 
     $result | ConvertTo-Json
+}
+elseif ($Operation -eq 'Validate')
+{
+    # TODO: this is placeholder
+    @{ valid = $true } | ConvertTo-Json
 }
 else
 {

--- a/wmigroup/wmigroup.dsc.resource.json.optout
+++ b/wmigroup/wmigroup.dsc.resource.json.optout
@@ -30,6 +30,16 @@
       ],
       "input": "stdin"
     },
+    "validate": {
+        "executable": "powershell",
+        "args": [
+          "-NoLogo",
+          "-NonInteractive",
+          "-NoProfile",
+          "-Command",
+          "$Input | ./wmigroup.resource.ps1 Validate"
+          ]
+      },  
     "exitCodes": {
       "0": "Success",
       "1": "Error"

--- a/wmigroup/wmigroup.resource.ps1
+++ b/wmigroup/wmigroup.resource.ps1
@@ -3,7 +3,7 @@
 
 [CmdletBinding()]
 param(
-    [ValidateSet('List','Get','Set','Test')]
+    [ValidateSet('List','Get','Set','Test','Validate')]
     $Operation = 'List',
     [Parameter(ValueFromPipeline)]
     $stdinput
@@ -122,6 +122,11 @@ elseif ($Operation -eq 'Get')
     }
 
     $result | ConvertTo-Json -Compress
+}
+elseif ($Operation -eq 'Validate')
+{
+    # TODO: this is placeholder
+    @{ valid = $true } | ConvertTo-Json
 }
 else
 {

--- a/y2j/Cargo.toml
+++ b/y2j/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dependencies]
 atty = { version = "0.2" }
 serde_json = { version = "1.0", features = ["preserve_order"] }
-serde_yaml = { version = "0.9" }
+serde_yaml = { version = "0.9.3" }
 syntect = { version = "5.0", features = ["default-fancy"], default-features = false }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Before this PR, resources were being statically validated against their schema.  This fails because a property value may use an expression and that string may fail schema validation as the expression hasn't been invoked yet.  This change moves resource input validation later when the resource is actually getting invoked and expressions have been invoked.

There was also an issue where string parameters were being returned enclosed in quotes, this PR also fixes that issue.

Also added mock `validate` implementation for PowerShellGroup and WmiGroup resources rather than have code in DSC to skip validation.
