### PR TITLE
Enable tracing formats

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -25,5 +25,5 @@ serde_yaml = { version = "0.9.3" }
 syntect = { version = "5.0", features = ["default-fancy"], default-features = false }
 sysinfo = { version = "0.29.10" }
 thiserror = "1.0"
-tracing = "0.1.37"
-tracing-subscriber = "0.3.17"
+tracing = { version = "0.1.37" }
+tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -3,13 +3,28 @@
 
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
-use crate::util::LogLevel;
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
     Json,
     PrettyJson,
     Yaml,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+pub enum TraceFormat {
+    Default,
+    Plaintext,
+    Json,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+pub enum TraceLevel {
+   Error,
+   Warning,
+   Info,
+   Debug,
+   Trace
 }
 
 #[derive(Debug, Parser)]
@@ -19,14 +34,16 @@ pub struct Args {
     #[clap(subcommand)]
     pub subcommand: SubCommand,
     /// The output format to use
-    #[clap(short = 'f', long)]
+    #[clap(short = 'o', long)]
     pub format: Option<OutputFormat>,
     #[clap(short = 'i', long, help = "The input to pass to the configuration or resource", conflicts_with = "input_file")]
     pub input: Option<String>,
     #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource")]
     pub input_file: Option<String>,
-    #[clap(short = 'l', long = "logging-level", help = "Log level to display", value_enum, default_value = "info")]
-    pub logging_level: LogLevel,
+    #[clap(short = 'l', long, help = "Trace level to use", value_enum, default_value = "warning")]
+    pub trace_level: TraceLevel,
+    #[clap(short = 'f', long, help = "Trace format to use", value_enum, default_value = "default")]
+    pub trace_format: TraceFormat,
 }
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -20,11 +20,11 @@ pub enum TraceFormat {
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum TraceLevel {
-   Error,
-   Warning,
-   Info,
-   Debug,
-   Trace
+    Error,
+    Warning,
+    Info,
+    Debug,
+    Trace
 }
 
 #[derive(Debug, Parser)]

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -56,15 +56,15 @@ fn main() {
         TraceFormat::Plaintext => {
             layer
                 .with_ansi(false)
-                .with_level(false)
+                .with_level(true)
                 .with_line_number(false)
                 .boxed()
         },
         TraceFormat::Json => {
             layer
-                .with_ansi(true)
-                .with_level(false)
-                .with_line_number(false)
+                .with_ansi(false)
+                .with_level(true)
+                .with_line_number(true)
                 .json()
                 .boxed()
         }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -35,16 +35,6 @@ pub const EXIT_INVALID_INPUT: i32 = 4;
 pub const EXIT_VALIDATION_FAILED: i32 = 5;
 pub const EXIT_CTRL_C: i32 = 6;
 
-#[derive(Debug)]
-#[derive(clap::ValueEnum, Clone)]
-pub enum LogLevel {
-   Error,
-   Warning,
-   Info,
-   Debug,
-   Trace
-}
-
 /// Get string representation of JSON value.
 ///
 /// # Arguments

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -1,0 +1,47 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'tracing tests' {
+    It 'trace level <level> works' -TestCases @(
+        @{ level = 'error' }
+        # @{ level = 'WARNING' } TODO: currently no warnings are emitted
+        @{ level = 'info' }
+        @{ level = 'debug' }
+        # @{ level = 'trace' } TODO:L currently no trace is emitted
+    ) {
+        param($level)
+
+        $logPath = "$TestDrive/dsc_trace.log"
+        $null = '{}' | dsc -l $level resource get -r 'DoesNotExist' 2> $logPath
+        $log = Get-Content $logPath -Raw
+        $log | Should -BeLikeExactly "* $($level.ToUpper()) *"
+    }
+
+    It 'trace level error does not emit other levels' {
+        $logPath = "$TestDrive/dsc_trace.log"
+        $null = '{}' | dsc --trace-level error resource get -r 'DoesNotExist' 2> $logPath
+        $log = Get-Content $logPath -Raw
+        $log | Should -Not -BeLikeExactly "* WARNING *"
+        $log | Should -Not -BeLikeExactly "* INFO *"
+        $log | Should -Not -BeLikeExactly "* DEBUG *"
+        $log | Should -Not -BeLikeExactly "* TRACE *"
+    }
+
+    It 'trace format plaintext does not emit ANSI' {
+        $logPath = "$TestDrive/dsc_trace.log"
+        $null = '{}' | dsc --trace-format plaintext resource get -r 'DoesNotExist' 2> $logPath
+        $log = Get-Content $logPath -Raw
+        $log | Should -Not -BeLikeExactly "*``[0m*"
+    }
+
+    It 'trace format json emits json' {
+        $logPath = "$TestDrive/dsc_trace.log"
+        $null = '{}' | dsc --trace-format json resource get -r 'DoesNotExist' 2> $logPath
+        foreach ($line in (Get-Content $logPath)) {
+            $trace = $line | ConvertFrom-Json -Depth 10
+            $trace.timestamp | Should -Not -BeNullOrEmpty
+            $trace.level | Should -BeIn 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE'
+            $trace.fields.message | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -7,7 +7,7 @@ Describe 'tracing tests' {
         # @{ level = 'WARNING' } TODO: currently no warnings are emitted
         @{ level = 'info' }
         @{ level = 'debug' }
-        # @{ level = 'trace' } TODO:L currently no trace is emitted
+        # @{ level = 'trace' } TODO: currently no trace is emitted
     ) {
         param($level)
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Rename `logging` to `tracing` since we don't actually write to a log file currently.  Add support for `plaintext` and `json` tracing formats.

Note that previously `-f` was `--output-format`, but this was renamed to `-o` so that `-f` is now `--trace-format`

## PR Context

Fix https://github.com/PowerShell/DSC/issues/286