### PR TITLE
Allow PowerShellGroup to override psmodulepath

### DIFF
--- a/powershellgroup/Tests/powershellgroup.config.tests.ps1
+++ b/powershellgroup/Tests/powershellgroup.config.tests.ps1
@@ -61,4 +61,37 @@ Describe 'PowerShellGroup resource tests' {
         $res.resources[0].properties.Name | Should -Be "Object1"
         $res.resources[0].properties.Prop1 | Should -Be "Property of object1"
     }
+
+    It 'Custom psmodulepath in config works' -Skip:(!$IsWindows){
+
+        $OldPSModulePath  = $env:PSModulePath
+        Copy-Item -Recurse -Force -Path "$PSScriptRoot/PSTestModule" -Destination $TestDrive
+        Rename-Item -Path "$PSScriptRoot/PSTestModule" -NewName "_PSTestModule"
+        
+        try {
+            $yaml = @"
+                `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+                resources:
+                - name: Working with class-based resources
+                  type: DSC/PowerShellGroup
+                  properties:
+                    psmodulepath: `$env:PSModulePath;$TestDrive
+                    resources:
+                    - name: Class-resource Info
+                      type: PSTestModule/TestClassResource
+"@
+            $out = $yaml | dsc config export
+            $LASTEXITCODE | Should -Be 0
+            $res = $out | ConvertFrom-Json
+            $res.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json'
+            $res.'resources' | Should -Not -BeNullOrEmpty
+            $res.resources.count | Should -Be 5
+            $res.resources[0].properties.Name | Should -Be "Object1"
+            $res.resources[0].properties.Prop1 | Should -Be "Property of object1"
+        }
+        finally {
+            Rename-Item -Path "$PSScriptRoot/_PSTestModule" -NewName "PSTestModule"
+            $env:PSModulePath = $OldPSModulePath
+        }
+    }
 }

--- a/powershellgroup/powershellgroup.resource.ps1
+++ b/powershellgroup/powershellgroup.resource.ps1
@@ -39,6 +39,17 @@ if (($PSVersionTable.PSVersion.Major -eq 7) -and ($PSVersionTable.PSVersion.Mino
     throw "PowerShell 7.4-previews are not supported by PowerShellGroup resource; please use PS 7.4.0-rc.1 or newer."
 }
 
+$inputobj_pscustomobj = $null
+if ($stdinput)
+{
+    $inputobj_pscustomobj = $stdinput | ConvertFrom-Json
+    $new_psmodulepath = $inputobj_pscustomobj.psmodulepath
+    if ($new_psmodulepath)
+    {
+        $env:PSModulePath = $ExecutionContext.InvokeCommand.ExpandString($new_psmodulepath)
+    }
+}
+
 $DscModule = Get-Module -Name PSDesiredStateConfiguration -ListAvailable |
     Sort-Object -Property Version -Descending |
     Select-Object -First 1
@@ -105,12 +116,6 @@ if ($Operation -eq 'List')
 }
 elseif ($Operation -eq 'Get')
 {
-    $inputobj_pscustomobj = $null
-    if ($stdinput)
-    {
-        $inputobj_pscustomobj = $stdinput | ConvertFrom-Json
-    }
-
     $result = @()
 
     RefreshCache
@@ -181,12 +186,6 @@ elseif ($Operation -eq 'Get')
 }
 elseif ($Operation -eq 'Set')
 {
-    $inputobj_pscustomobj = $null
-    if ($stdinput)
-    {
-        $inputobj_pscustomobj = $stdinput | ConvertFrom-Json
-    }
-
     $result = @()
 
     RefreshCache
@@ -255,12 +254,6 @@ elseif ($Operation -eq 'Set')
 }
 elseif ($Operation -eq 'Test')
 {
-    $inputobj_pscustomobj = $null
-    if ($stdinput)
-    {
-        $inputobj_pscustomobj = $stdinput | ConvertFrom-Json
-    }
-
     $result = @()
 
     RefreshCache
@@ -329,12 +322,6 @@ elseif ($Operation -eq 'Test')
 }
 elseif ($Operation -eq 'Export')
 {
-    $inputobj_pscustomobj = $null
-    if ($stdinput)
-    {
-        $inputobj_pscustomobj = $stdinput | ConvertFrom-Json
-    }
-
     $result = @()
 
     RefreshCache


### PR DESCRIPTION
# PR Summary

Fix #285 

## PR Context

The PSModulePath env var is clobbered within the group resource (thus PSDSC is still found by the default env var). The string value would be PS syntax and expanded within the group resource.

```
properties:
  psmodulepath: $env:PSModulePath;$env:LOCALAPPDATA\Microsoft\WinGet\Configuration\Modules
  resources: ...
```
