### PR TITLE
Added DSCConfigRoot env var in configs

### DIFF
--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -4,7 +4,7 @@
 use crate::args::{ConfigSubCommand, DscType, OutputFormat, ResourceSubCommand};
 use crate::resource_command::{get_resource, self};
 use crate::tablewriter::Table;
-use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_INPUT, EXIT_JSON_ERROR, EXIT_SUCCESS, EXIT_VALIDATION_FAILED, get_schema, write_output, get_input, process_macros};
+use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_INPUT, EXIT_JSON_ERROR, EXIT_SUCCESS, EXIT_VALIDATION_FAILED, get_schema, write_output, get_input, set_dscconfigroot};
 use tracing::error;
 
 use atty::Stream;
@@ -117,19 +117,17 @@ pub fn config_export(configurator: &mut Configurator, format: &Option<OutputForm
 }
 
 pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, stdin: &Option<String>) {
-    let config_path: String;
-    let mut json_string = match subcommand {
+    let json_string = match subcommand {
         ConfigSubCommand::Get { document, path, .. } |
         ConfigSubCommand::Set { document, path, .. } |
         ConfigSubCommand::Test { document, path, .. } |
         ConfigSubCommand::Validate { document, path, .. } |
         ConfigSubCommand::Export { document, path, .. } => {
-            config_path = path.clone().unwrap_or_default();
+            let config_path = path.clone().unwrap_or_default();
+            set_dscconfigroot(&config_path);
             get_input(document, stdin, path)
         }
     };
-
-    json_string = process_macros(&json_string, &config_path);
 
     let mut configurator = match Configurator::new(&json_string) {
         Ok(configurator) => configurator,

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -4,8 +4,8 @@
 use crate::args::{ConfigSubCommand, DscType, OutputFormat, ResourceSubCommand};
 use crate::resource_command::{get_resource, self};
 use crate::tablewriter::Table;
-use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_INPUT, EXIT_JSON_ERROR, EXIT_SUCCESS, EXIT_VALIDATION_FAILED, get_schema, write_output, get_input};
-use tracing::error;
+use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_INPUT, EXIT_JSON_ERROR, EXIT_SUCCESS, EXIT_VALIDATION_FAILED, get_schema, write_output, get_input, process_macros};
+use tracing::{error, debug};
 
 use atty::Stream;
 use dsc_lib::{
@@ -117,15 +117,20 @@ pub fn config_export(configurator: &mut Configurator, format: &Option<OutputForm
 }
 
 pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, stdin: &Option<String>) {
-    let json_string = match subcommand {
+    let config_path: String;
+    let mut json_string = match subcommand {
         ConfigSubCommand::Get { document, path, .. } |
         ConfigSubCommand::Set { document, path, .. } |
         ConfigSubCommand::Test { document, path, .. } |
         ConfigSubCommand::Validate { document, path, .. } |
         ConfigSubCommand::Export { document, path, .. } => {
+            config_path = path.clone().unwrap_or_default();
             get_input(document, stdin, path)
         }
     };
+
+    json_string = process_macros(&json_string, &config_path);
+    debug!("{json_string}");
 
     let mut configurator = match Configurator::new(&json_string) {
         Ok(configurator) => configurator,
@@ -161,9 +166,12 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, stdin:
         }
     };
 
-    if let Err(err) = configurator.set_parameters(&parameters) {
-        error!("Error: Parameter input failure: {err}");
-        exit(EXIT_INVALID_INPUT);
+    if parameters.is_some()
+    {
+        if let Err(err) = configurator.set_parameters(&parameters) {
+            error!("Error: Parameter input failure: {err}");
+            exit(EXIT_INVALID_INPUT);
+        }
     }
 
     match subcommand {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -5,7 +5,7 @@ use crate::args::{ConfigSubCommand, DscType, OutputFormat, ResourceSubCommand};
 use crate::resource_command::{get_resource, self};
 use crate::tablewriter::Table;
 use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_INPUT, EXIT_JSON_ERROR, EXIT_SUCCESS, EXIT_VALIDATION_FAILED, get_schema, write_output, get_input, process_macros};
-use tracing::{error, debug};
+use tracing::error;
 
 use atty::Stream;
 use dsc_lib::{
@@ -130,7 +130,6 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, stdin:
     };
 
     json_string = process_macros(&json_string, &config_path);
-    debug!("{json_string}");
 
     let mut configurator = match Configurator::new(&json_string) {
         Ok(configurator) => configurator,
@@ -166,12 +165,9 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, stdin:
         }
     };
 
-    if parameters.is_some()
-    {
-        if let Err(err) = configurator.set_parameters(&parameters) {
-            error!("Error: Parameter input failure: {err}");
-            exit(EXIT_INVALID_INPUT);
-        }
+    if let Err(err) = configurator.set_parameters(&parameters) {
+        error!("Error: Parameter input failure: {err}");
+        exit(EXIT_INVALID_INPUT);
     }
 
     match subcommand {

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -18,7 +18,6 @@ use dsc_lib::{
 };
 use schemars::{schema_for, schema::RootSchema};
 use serde_yaml::Value;
-use serde_json::json;
 use std::collections::HashMap;
 use std::env;
 use std::path::Path;
@@ -361,7 +360,7 @@ pub fn get_input(input: &Option<String>, stdin: &Option<String>, path: &Option<S
     parse_input_to_json(&value)
 }
 
-pub fn process_macros(json_string: &str, config_path: &str) -> String
+pub fn set_dscconfigroot(config_path: &str)
 {
     let path = Path::new(config_path);
     let config_root = match path.parent()
@@ -373,15 +372,4 @@ pub fn process_macros(json_string: &str, config_path: &str) -> String
     // Set env var so child processes (of resources) can use it
     debug!("Setting 'DSCConfigRoot' env var as '{}'", config_root);
     env::set_var("DSCConfigRoot", config_root.clone());
-
-    // we are replacing a substring in json, so the new substring must be properly escaped per json rules
-    let v = json!(config_root);
-    let mut json_escaped_config_root = v.to_string();
-    json_escaped_config_root.pop(); // remove last double quote
-    if !json_escaped_config_root.is_empty() {
-        json_escaped_config_root.remove(0); // remove first double quote
-    }
-
-    debug!("Escaped json 'DSCConfigRoot' is '{}'", json_escaped_config_root);
-    json_string.replace("_DSCConfigRoot_", &json_escaped_config_root)
 }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -378,7 +378,7 @@ pub fn process_macros(json_string: &str, config_path: &str) -> String
     let v = json!(config_root);
     let mut json_escaped_config_root = v.to_string();
     json_escaped_config_root.pop(); // remove last double quote
-    if json_escaped_config_root.len() > 0 {
+    if !json_escaped_config_root.is_empty() {
         json_escaped_config_root.remove(0); // remove first double quote
     }
 

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -18,7 +18,10 @@ use dsc_lib::{
 };
 use schemars::{schema_for, schema::RootSchema};
 use serde_yaml::Value;
+use serde_json::json;
 use std::collections::HashMap;
+use std::env;
+use std::path::Path;
 use std::process::exit;
 use syntect::{
     easy::HighlightLines,
@@ -356,4 +359,29 @@ pub fn get_input(input: &Option<String>, stdin: &Option<String>, path: &Option<S
     }
 
     parse_input_to_json(&value)
+}
+
+pub fn process_macros(json_string: &str, config_path: &str) -> String
+{
+    let path = Path::new(config_path);
+    let config_root = match path.parent()
+    {
+        Some(dir_path) => { dir_path.to_str().unwrap_or_default().to_string()},
+        _ => String::new()
+    };
+
+    // Set env var so child processes (of resources) can use it
+    debug!("Setting 'DSCConfigRoot' env var as '{}'", config_root);
+    env::set_var("DSCConfigRoot", config_root.clone());
+
+    // we are replacing a substring in json, so the new substring must be properly escaped per json rules
+    let v = json!(config_root);
+    let mut json_escaped_config_root = v.to_string();
+    json_escaped_config_root.pop(); // remove last double quote
+    if json_escaped_config_root.len() > 0 {
+        json_escaped_config_root.remove(0); // remove first double quote
+    }
+
+    debug!("Escaped json 'DSCConfigRoot' is '{}'", json_escaped_config_root);
+    json_string.replace("_DSCConfigRoot_", &json_escaped_config_root)
 }

--- a/dsc_lib/src/functions/envvar.rs
+++ b/dsc_lib/src/functions/envvar.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+use crate::configure::context::Context;
+use crate::parser::functions::{FunctionArg, FunctionResult};
+use super::{Function, AcceptedArgKind};
+use std::env;
+
+#[derive(Debug, Default)]
+pub struct Envvar {}
+
+impl Function for Envvar {
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::String]
+    }
+
+    fn min_args(&self) -> usize {
+        1
+    }
+
+    fn max_args(&self) -> usize {
+        1
+    }
+
+    fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
+        let FunctionArg::String(arg) = args.first().unwrap() else {
+            return Err(DscError::Parser("Invalid argument type".to_string()));
+        };
+
+        let val = env::var(arg).unwrap_or_default();
+        Ok(FunctionResult::String(val))
+    }
+}

--- a/dsc_lib/src/functions/mod.rs
+++ b/dsc_lib/src/functions/mod.rs
@@ -10,6 +10,7 @@ use crate::parser::functions::{FunctionArg, FunctionResult};
 
 pub mod base64;
 pub mod concat;
+pub mod envvar;
 pub mod parameters;
 pub mod resource_id;
 
@@ -53,6 +54,7 @@ impl FunctionDispatcher {
         let mut functions: HashMap<String, Box<dyn Function>> = HashMap::new();
         functions.insert("base64".to_string(), Box::new(base64::Base64{}));
         functions.insert("concat".to_string(), Box::new(concat::Concat{}));
+        functions.insert("envvar".to_string(), Box::new(envvar::Envvar{}));
         functions.insert("parameters".to_string(), Box::new(parameters::Parameters{}));
         functions.insert("resourceId".to_string(), Box::new(resource_id::ResourceId{}));
         Self {

--- a/powershellgroup/Tests/PSTestModule/TestClassResource.psm1
+++ b/powershellgroup/Tests/PSTestModule/TestClassResource.psm1
@@ -39,6 +39,10 @@ class TestClassResource
         {
             $this.Prop1 = "ValueForProp1"
         }
+        else
+        {
+            $this.Prop1 = $env:DSCConfigRoot
+        }
         $this.EnumProp = [EnumPropEnumeration]::Expected
         return $this
     }

--- a/powershellgroup/Tests/powershellgroup.config.tests.ps1
+++ b/powershellgroup/Tests/powershellgroup.config.tests.ps1
@@ -107,7 +107,7 @@ Describe 'PowerShellGroup resource tests' {
                 - name: Class-resource Info
                   type: PSTestModule/TestClassResource
                   properties:
-                    Name: _DSCConfigRoot_/TestClassResourceInstance
+                    Name: "[envvar('DSCConfigRoot')]"
 "@
 
         $config_path = "$TestDrive/test_config.dsc.yaml"
@@ -116,7 +116,7 @@ Describe 'PowerShellGroup resource tests' {
         $out = dsc config get --path $config_path
         $LASTEXITCODE | Should -Be 0
         $res = $out | ConvertFrom-Json
-        $res.results[0].result.actualState.Name | Should -Be "$TestDrive/TestClassResourceInstance"
+        $res.results[0].result.actualState.Name | Should -Be $TestDrive
         $res.results[0].result.actualState.Prop1 | Should -Be $TestDrive
     }
 
@@ -132,12 +132,12 @@ Describe 'PowerShellGroup resource tests' {
                 - name: Class-resource Info
                   type: PSTestModule/TestClassResource
                   properties:
-                    Name: _DSCConfigRoot_/TestClassResourceInstance
+                    Name: "[envvar('DSCConfigRoot')]"
 "@
         $out = $yaml | dsc config get
         $LASTEXITCODE | Should -Be 0
         $res = $out | ConvertFrom-Json
-        $res.results[0].result.actualState.Name | Should -Be "/TestClassResourceInstance"
+        $res.results[0].result.actualState.Name | Should -Be ""
         $res.results[0].result.actualState.Prop1 | Should -Be ""
     }
 }

--- a/powershellgroup/Tests/powershellgroup.config.tests.ps1
+++ b/powershellgroup/Tests/powershellgroup.config.tests.ps1
@@ -94,4 +94,50 @@ Describe 'PowerShellGroup resource tests' {
             $env:PSModulePath = $OldPSModulePath
         }
     }
+
+    It 'DSCConfigRoot macro is working when config is from a file' -Skip:(!$IsWindows){
+
+        $yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            resources:
+            - name: Working with class-based resources
+              type: DSC/PowerShellGroup
+              properties:
+                resources:
+                - name: Class-resource Info
+                  type: PSTestModule/TestClassResource
+                  properties:
+                    Name: _DSCConfigRoot_/TestClassResourceInstance
+"@
+
+        $config_path = "$TestDrive/test_config.dsc.yaml"
+        $yaml | Set-Content -Path $config_path
+
+        $out = dsc config get --path $config_path
+        $LASTEXITCODE | Should -Be 0
+        $res = $out | ConvertFrom-Json
+        $res.results[0].result.actualState.Name | Should -Be "$TestDrive/TestClassResourceInstance"
+        $res.results[0].result.actualState.Prop1 | Should -Be $TestDrive
+    }
+
+    It 'DSCConfigRoot macro is empty when config is piped from stdin' -Skip:(!$IsWindows){
+
+        $yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            resources:
+            - name: Working with class-based resources
+              type: DSC/PowerShellGroup
+              properties:
+                resources:
+                - name: Class-resource Info
+                  type: PSTestModule/TestClassResource
+                  properties:
+                    Name: _DSCConfigRoot_/TestClassResourceInstance
+"@
+        $out = $yaml | dsc config get
+        $LASTEXITCODE | Should -Be 0
+        $res = $out | ConvertFrom-Json
+        $res.results[0].result.actualState.Name | Should -Be "/TestClassResourceInstance"
+        $res.results[0].result.actualState.Prop1 | Should -Be ""
+    }
 }


### PR DESCRIPTION
# PR Summary

Fix #75 

For config operations, if `--path` dsc parameter is used, then:
1) `DSCConfigRoot` env var is defined and inherited by child resource processes that can be used to determine the location of the configuration file that is running;
2) `envvar` function can be used in the configuration text like so:
```
resources:
- name: Class-resource Info
  type: PSTestModule/TestClassResource
  properties:
    Name: Instance1
    ResourcePath: "[envvar('DSCConfigRoot')]"
```

Notes:
1) if configuration is piped using stdin or `-d`/`--document` parameter, then value of env var is empty string.
2) for non-config operations env var is not created.