### PR TITLE
add tests for osinfo parameters examples

### DIFF
--- a/dsc/tests/dsc_osinfo.tests.ps1
+++ b/dsc/tests/dsc_osinfo.tests.ps1
@@ -1,0 +1,21 @@
+Describe 'Tests for osinfo examples' {
+    It 'Config with default parameters and get works' {
+        $out = dsc config get -p $PSScriptRoot/../examples/osinfo_parameters.dsc.yaml | ConvertFrom-Json -Depth 10
+        $LASTEXITCODE | Should -Be 0
+        $expected = if ($IsWindows) {
+            'Windows'
+        } elseif ($IsLinux) {
+            'Linux'
+        } else {
+            'macOS'
+        }
+
+        $out.results[0].result.actualState.family | Should -BeExactly $expected
+    }
+
+    It 'Config test works' {
+        $out = dsc config -f $PSScriptRoot/../examples/osinfo.parameters.yaml test -p $PSScriptRoot/../examples/osinfo_parameters.dsc.yaml | ConvertFrom-Json -Depth 10
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].result.inDesiredState | Should -Be $IsMacOS
+    }
+}

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -45,7 +45,7 @@ pub enum ErrorAction {
 ///
 /// # Panics
 ///
-/// Doesn't panic because there is a match/Some check before unwrap(); false positive.
+/// Doesn't panic because there is a match/Some check before `unwrap()`; false positive.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Adding tests for osinfo parameters example config

## PR Context

Need to have tests for all example configs in case some changes break them