### PR TITLE
Fix `concat()` function and add `createArray()` function

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -24,6 +24,6 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = { version = "0.9.3" }
 syntect = { version = "5.0", features = ["default-fancy"], default-features = false }
 sysinfo = { version = "0.29.10" }
-thiserror = "1.0"
+thiserror = "1.0.52"
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -38,7 +38,7 @@ Describe 'dsc config get tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: hello
+                output: hello
 "@
         $null = $config_yaml | dsc config get --format pretty-json | Out-String
         $LASTEXITCODE | Should -Be 0

--- a/dsc/tests/dsc_functions.tests.ps1
+++ b/dsc/tests/dsc_functions.tests.ps1
@@ -5,7 +5,7 @@ Describe 'tests for function expressions' {
     It 'function works: <text>' -TestCases @(
         @{ text = "[concat('a', 'b')]"; expected = 'ab' }
         @{ text = "[concat('a', 'b', 'c')]"; expected = 'abc' }
-        @{ text = "[concat('a', 1, concat(2, 'b'))]"; expected = 'a12b' }
+        @{ text = "[concat('a', concat('b', 'c'))]"; expected = 'abc' }
         @{ text = "[base64('ab')]"; expected = 'YWI=' }
         @{ text = "[base64(concat('a','b'))]"; expected = 'YWI=' }
         @{ text = "[base64(base64(concat('a','b')))]"; expected = 'WVdJPQ==' }

--- a/dsc/tests/dsc_functions.tests.ps1
+++ b/dsc/tests/dsc_functions.tests.ps1
@@ -19,9 +19,9 @@ Describe 'tests for function expressions' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '$escapedText'
+                output: '$escapedText'
 "@
         $out = $config_yaml | dsc config get | ConvertFrom-Json
-        $out.results[0].result.actualState.text | Should -Be $expected
+        $out.results[0].result.actualState.output | Should -Be $expected
     }
 }

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -17,7 +17,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = 'hello' }} | ConvertTo-Json
 
@@ -31,7 +31,7 @@ Describe 'Parameters tests' {
         }
 
         $LASTEXITCODE | Should -Be 0
-        $out.results[0].result.actualState.text | Should -BeExactly 'hello'
+        $out.results[0].result.actualState.output | Should -BeExactly 'hello'
     }
 
     It 'Input is <type>' -TestCases @(
@@ -51,13 +51,13 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
         $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out.results[0].result.actualState.text | Should -BeExactly $expected
+        $out.results[0].result.actualState.output | Should -BeExactly $expected
     }
 
     It 'Input is incorrect type <type>' -TestCases @(
@@ -77,7 +77,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
@@ -104,7 +104,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
@@ -130,7 +130,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
@@ -154,7 +154,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
@@ -180,7 +180,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[parameters(''param1'')]'
+                output: '[parameters(''param1'')]'
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
@@ -208,7 +208,7 @@ Describe 'Parameters tests' {
             - name: Echo
               type: Test/Echo
               properties:
-                text: '[concat(parameters(''param1''),'','',parameters(''param2''),'','',parameters(''param3''),'','',parameters(''param4''))]'
+                output: '[concat(parameters(''param1''),'','',parameters(''param2''),'','',parameters(''param3''),'','',parameters(''param4''))]'
 "@
 
         $out = $config_yaml | dsc config get | ConvertFrom-Json

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -35,12 +35,12 @@ Describe 'Parameters tests' {
     }
 
     It 'Input is <type>' -TestCases @(
-        @{ type = 'string'; value = 'hello'; expected = 'hello' }
-        @{ type = 'int'; value = 42; expected = 42 }
-        @{ type = 'bool'; value = $true; expected = $true }
-        @{ type = 'array'; value = @('hello', 'world'); expected = '["hello","world"]' }
+        @{ type = 'string'; value = 'hello' }
+        @{ type = 'int'; value = 42}
+        @{ type = 'bool'; value = $true}
+        @{ type = 'array'; value = @('hello', 'world')}
     ) {
-        param($type, $value, $expected)
+        param($type, $value)
 
         $config_yaml = @"
             `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
@@ -57,7 +57,7 @@ Describe 'Parameters tests' {
 
         $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out.results[0].result.actualState.output | Should -BeExactly $expected
+        $out.results[0].result.actualState.output | Should -BeExactly $value
     }
 
     It 'Input is incorrect type <type>' -TestCases @(
@@ -192,28 +192,43 @@ Describe 'Parameters tests' {
         $config_yaml = @"
             `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
             parameters:
-              param1:
+              paramString:
                 type: string
                 defaultValue: 'hello'
-              param2:
+              paramInt:
                 type: int
                 defaultValue: 7
-              param3:
+              paramBool:
                 type: bool
                 defaultValue: false
-              param4:
+              paramArray:
                 type: array
                 defaultValue: ['hello', 'world']
             resources:
-            - name: Echo
+            - name: String
               type: Test/Echo
               properties:
-                output: '[concat(parameters(''param1''),'','',parameters(''param2''),'','',parameters(''param3''),'','',parameters(''param4''))]'
+                output: '[parameters(''paramString'')]'
+            - name: Int
+              type: Test/Echo
+              properties:
+                output: '[parameters(''paramInt'')]'
+            - name: Bool
+              type: Test/Echo
+              properties:
+                output: '[parameters(''paramBool'')]'
+            - name: Array
+              type: Test/Echo
+              properties:
+                output: '[parameters(''paramArray'')]'
 "@
 
         $out = $config_yaml | dsc config get | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out.results[0].result.actualState.text | Should -BeExactly 'hello,7,false,["hello","world"]'
+        $out.results[0].result.actualState.output | Should -BeExactly 'hello'
+        $out.results[1].result.actualState.output | Should -BeExactly 7
+        $out.results[2].result.actualState.output | Should -BeExactly $false
+        $out.results[3].result.actualState.output | Should -BeExactly @('hello', 'world')
     }
 
     It 'property value uses parameter value' {

--- a/dsc/tests/dsc_test.tests.ps1
+++ b/dsc/tests/dsc_test.tests.ps1
@@ -56,7 +56,7 @@ Describe 'config test tests' {
     }
 
     It 'can accept the use of --format as a subcommand' {
-        $null = "text: hello" | dsc resource test -r Test/Echo --format pretty-json
+        $null = "output: hello" | dsc resource test -r Test/Echo --format pretty-json
         $LASTEXITCODE | Should -Be 0
     }
 }

--- a/dsc_lib/src/configure/depends_on.rs
+++ b/dsc_lib/src/configure/depends_on.rs
@@ -33,7 +33,10 @@ pub fn get_resource_invocation_order(config: &Configuration, parser: &mut Statem
         if let Some(depends_on) = resource.depends_on.clone() {
             for dependency in depends_on {
                 let statement = parser.parse_and_execute(&dependency, context)?;
-                let (resource_type, resource_name) = get_type_and_name(&statement)?;
+                let Some(string_result) = statement.as_str() else {
+                    return Err(DscError::Validation(format!("'dependsOn' syntax is incorrect: {dependency}")));
+                };
+                let (resource_type, resource_name) = get_type_and_name(string_result)?;
 
                 // find the resource by name
                 let Some(dependency_resource) = config.resources.iter().find(|r| r.name.eq(resource_name)) else {
@@ -64,7 +67,10 @@ pub fn get_resource_invocation_order(config: &Configuration, parser: &mut Statem
                 let resource_index = order.iter().position(|r| r.name == resource.name && r.resource_type == resource.resource_type).ok_or(DscError::Validation("Resource not found in order".to_string()))?;
                 for dependency in depends_on {
                   let statement = parser.parse_and_execute(dependency, context)?;
-                  let (resource_type, resource_name) = get_type_and_name(&statement)?;
+                  let Some(string_result) = statement.as_str() else {
+                      return Err(DscError::Validation(format!("'dependsOn' syntax is incorrect: {dependency}")));
+                  };
+                  let (resource_type, resource_name) = get_type_and_name(string_result)?;
                   let dependency_index = order.iter().position(|r| r.name == resource_name && r.resource_type == resource_type).ok_or(DscError::Validation("Dependency not found in order".to_string()))?;
                   if resource_index < dependency_index {
                       return Err(DscError::Validation(format!("Circular dependency detected for resource named '{0}'", resource.name)));

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -452,10 +452,11 @@ impl Configurator {
                             return Err(DscError::Parser(format!("Property value '{value}' could not be transformed as string")));
                         };
                         let statement_result = self.statement_parser.parse_and_execute(statement, &self.context)?;
-                        let Some(string_result) = statement_result.as_str() else {
-                            return Err(DscError::Parser(format!("Property value '{value}' could not be transformed as string")));
+                        if let Some(string_result) = statement_result.as_str() {
+                            result.insert(name.clone(), Value::String(string_result.to_string()));
+                        } else {
+                            result.insert(name.clone(), statement_result);
                         };
-                        result.insert(name.clone(), Value::String(string_result.to_string()));
                     },
                     _ => {
                         result.insert(name.clone(), value.clone());

--- a/dsc_lib/src/functions/base64.rs
+++ b/dsc_lib/src/functions/base64.rs
@@ -5,8 +5,9 @@ use base64::{Engine as _, engine::general_purpose};
 
 use crate::DscError;
 use crate::configure::context::Context;
-use crate::parser::functions::{FunctionArg, FunctionResult};
-use super::{Function, AcceptedArgKind};
+use crate::functions::AcceptedArgKind;
+use serde_json::Value;
+use super::Function;
 
 #[derive(Debug, Default)]
 pub struct Base64 {}
@@ -24,11 +25,8 @@ impl Function for Base64 {
         1
     }
 
-    fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
-        let FunctionArg::String(arg) = args.first().unwrap() else {
-            return Err(DscError::Parser("Invalid argument type".to_string()));
-        };
-        Ok(FunctionResult::String(general_purpose::STANDARD.encode(arg)))
+    fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
+        Ok(Value::String(general_purpose::STANDARD.encode(args[0].as_str().unwrap_or_default())))
     }
 }
 

--- a/dsc_lib/src/functions/create_array.rs
+++ b/dsc_lib/src/functions/create_array.rs
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+use crate::configure::context::Context;
+use crate::functions::{AcceptedArgKind, Function};
+use serde_json::Value;
+use tracing::debug;
+
+#[derive(Debug, Default)]
+pub struct CreateArray {}
+
+impl Function for CreateArray {
+    fn min_args(&self) -> usize {
+        0
+    }
+
+    fn max_args(&self) -> usize {
+        usize::MAX
+    }
+
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::String, AcceptedArgKind::Number, AcceptedArgKind::Object, AcceptedArgKind::Array]
+    }
+
+    fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
+        debug!("createArray function");
+        let mut array_result = Vec::<Value>::new();
+        let mut input_type : Option<AcceptedArgKind> = None;
+        for value in args {
+            if value.is_array() {
+                if input_type.is_none() {
+                    input_type = Some(AcceptedArgKind::Array);
+                } else if input_type != Some(AcceptedArgKind::Array) {
+                    return Err(DscError::Parser("Arguments must all be arrays".to_string()));
+                }
+            } else if value.is_number() {
+                if input_type.is_none() {
+                    input_type = Some(AcceptedArgKind::Number);
+                } else if input_type != Some(AcceptedArgKind::Number) {
+                    return Err(DscError::Parser("Arguments must all be integers".to_string()));
+                }
+            } else if value.is_object() {
+                if input_type.is_none() {
+                    input_type = Some(AcceptedArgKind::Object);
+                } else if input_type != Some(AcceptedArgKind::Object) {
+                    return Err(DscError::Parser("Arguments must all be objects".to_string()));
+                }
+            } else if value.is_string() {
+                if input_type.is_none() {
+                    input_type = Some(AcceptedArgKind::String);
+                } else if input_type != Some(AcceptedArgKind::String) {
+                    return Err(DscError::Parser("Arguments must all be strings".to_string()));
+                }
+            } else {
+                return Err(DscError::Parser("Invalid argument type".to_string()));
+            }
+            array_result.push(value.clone());
+        }
+
+        Ok(Value::Array(array_result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configure::context::Context;
+    use crate::parser::Statement;
+
+    #[test]
+    fn strings() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[createArray('a', 'b')]", &Context::new()).unwrap();
+        assert_eq!(result.to_string(), r#"["a","b"]"#);
+    }
+
+    #[test]
+    fn integers() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[createArray(1,2,3)]", &Context::new()).unwrap();
+        assert_eq!(result.to_string(), "[1,2,3]");
+    }
+
+    #[test]
+    fn arrays() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[createArray(createArray('a','b'), createArray('c','d'))]", &Context::new()).unwrap();
+        assert_eq!(result.to_string(), r#"[["a","b"],["c","d"]]"#);
+    }
+
+    #[test]
+    fn objects() {
+        // TODO
+    }
+
+    #[test]
+    fn mixed_types() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[createArray(1,'a')]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn empty() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[createArray()]", &Context::new()).unwrap();
+        assert_eq!(result.to_string(), "[]");
+    }
+}

--- a/dsc_lib/src/functions/envvar.rs
+++ b/dsc_lib/src/functions/envvar.rs
@@ -3,8 +3,9 @@
 
 use crate::DscError;
 use crate::configure::context::Context;
-use crate::parser::functions::{FunctionArg, FunctionResult};
-use super::{Function, AcceptedArgKind};
+use crate::functions::AcceptedArgKind;
+use super::Function;
+use serde_json::Value;
 use std::env;
 
 #[derive(Debug, Default)]
@@ -23,12 +24,8 @@ impl Function for Envvar {
         1
     }
 
-    fn invoke(&self, args: &[FunctionArg], _context: &Context) -> Result<FunctionResult, DscError> {
-        let FunctionArg::String(arg) = args.first().unwrap() else {
-            return Err(DscError::Parser("Invalid argument type".to_string()));
-        };
-
-        let val = env::var(arg).unwrap_or_default();
-        Ok(FunctionResult::String(val))
+    fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
+        let val = env::var(args[0].as_str().unwrap_or_default()).unwrap_or_default();
+        Ok(Value::String(val))
     }
 }

--- a/dsc_lib/src/functions/parameters.rs
+++ b/dsc_lib/src/functions/parameters.rs
@@ -5,7 +5,7 @@ use crate::DscError;
 use crate::configure::context::Context;
 use crate::functions::{AcceptedArgKind, Function};
 use serde_json::Value;
-use tracing::trace;
+use tracing::{debug, trace};
 
 #[derive(Debug, Default)]
 pub struct Parameters {}
@@ -24,6 +24,7 @@ impl Function for Parameters {
     }
 
     fn invoke(&self, args: &[Value], context: &Context) -> Result<Value, DscError> {
+        debug!("Invoke parameters function");
         if let Some(key) = args[0].as_str() {
             trace!("parameters key: {key}");
             if context.parameters.contains_key(key) {

--- a/dsc_lib/src/functions/parameters.rs
+++ b/dsc_lib/src/functions/parameters.rs
@@ -3,8 +3,9 @@
 
 use crate::DscError;
 use crate::configure::context::Context;
-use crate::functions::{Function, FunctionArg, FunctionResult, AcceptedArgKind};
-use tracing::debug;
+use crate::functions::{AcceptedArgKind, Function};
+use serde_json::Value;
+use tracing::trace;
 
 #[derive(Debug, Default)]
 pub struct Parameters {}
@@ -22,24 +23,17 @@ impl Function for Parameters {
         vec![AcceptedArgKind::String]
     }
 
-    fn invoke(&self, args: &[FunctionArg], context: &Context) -> Result<FunctionResult, DscError> {
-        let FunctionArg::String(key) = &args[0] else {
-            return Err(DscError::Parser("Invalid argument type".to_string()));
-        };
-        debug!("parameters key: {key}");
-        if context.parameters.contains_key(key) {
-            let value = &context.parameters[key];
-            // we have to check if it's a string as a to_string() will put the string in quotes as part of the value
-            if value.is_string() {
-                if let Some(value) = value.as_str() {
-                    return Ok(FunctionResult::String(value.to_string()));
-                }
+    fn invoke(&self, args: &[Value], context: &Context) -> Result<Value, DscError> {
+        if let Some(key) = args[0].as_str() {
+            trace!("parameters key: {key}");
+            if context.parameters.contains_key(key) {
+                Ok(context.parameters[key].clone())
             }
-
-            Ok(FunctionResult::Object(context.parameters[key].clone()))
-        }
-        else {
-            Err(DscError::Parser(format!("Parameter '{key}' not found in context")))
+            else {
+                Err(DscError::Parser(format!("Parameter '{key}' not found in context")))
+            }
+        } else {
+            Err(DscError::Parser("Invalid argument type".to_string()))
         }
     }
 }

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use serde_json::Value;
-use tracing::debug;
+use tracing::{debug, trace};
 use tree_sitter::Node;
 
 use crate::configure::context::Context;
@@ -64,6 +64,7 @@ impl Expression {
     /// This function will return an error if the expression fails to execute.
     pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<Value, DscError> {
         let result = self.function.invoke(function_dispatcher, context)?;
+        trace!("Function result: '{:?}'", result);
         if let Some(member_access) = &self.member_access {
             debug!("Evaluating member access '{:?}'", member_access);
             if !result.is_object() {

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -1,12 +1,14 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use serde_json::Value;
+use tracing::debug;
 use tree_sitter::Node;
 
 use crate::configure::context::Context;
 use crate::dscerror::DscError;
 use crate::functions::FunctionDispatcher;
-use crate::parser::functions::{Function, FunctionResult};
+use crate::parser::functions::Function;
 
 #[derive(Clone)]
 pub struct Expression {
@@ -60,30 +62,33 @@ impl Expression {
     /// # Errors
     ///
     /// This function will return an error if the expression fails to execute.
-    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<String, DscError> {
+    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<Value, DscError> {
         let result = self.function.invoke(function_dispatcher, context)?;
         if let Some(member_access) = &self.member_access {
-            match result {
-                FunctionResult::String(_) => {
-                    Err(DscError::Parser("Member access on string not supported".to_string()))
-                },
-                FunctionResult::Object(object) => {
-                    let mut value = object;
-                    if !value.is_object() {
-                        return Err(DscError::Parser(format!("Member access on non-object value '{value}'")));
+            debug!("Evaluating member access '{:?}'", member_access);
+            if !result.is_object() {
+                return Err(DscError::Parser("Member access on non-object value".to_string()));
+            }
+
+            let mut value = result;
+            for member in member_access {
+                if !value.is_object() {
+                    return Err(DscError::Parser(format!("Member access '{member}' on non-object value")));
+                }
+
+                if let Some(object) = value.as_object() {
+                    if !object.contains_key(member) {
+                        return Err(DscError::Parser(format!("Member '{member}' not found")));
                     }
-                    for member in member_access {
-                        value = value[member].clone();
-                    }
-                    Ok(value.to_string())
+
+                    value = object[member].clone();
                 }
             }
+
+            Ok(value)
         }
         else {
-            match result {
-                FunctionResult::String(value) => Ok(value),
-                FunctionResult::Object(object) => Ok(object.to_string()),
-            }
+            Ok(result)
         }
     }
 }

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use serde_json::Value;
+use serde_json::{Number, Value};
 use tree_sitter::Node;
 
 use crate::DscError;
@@ -19,16 +19,8 @@ pub struct Function {
 
 #[derive(Clone)]
 pub enum FunctionArg {
-    String(String),
-    Integer(i32),
-    Boolean(bool),
+    Value(Value),
     Expression(Expression),
-}
-
-#[derive(Debug, PartialEq)]
-pub enum FunctionResult {
-    String(String),
-    Object(Value),
 }
 
 impl Function {
@@ -59,18 +51,18 @@ impl Function {
     /// # Errors
     ///
     /// This function will return an error if the function fails to execute.
-    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<FunctionResult, DscError> {
+    pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<Value, DscError> {
         // if any args are expressions, we need to invoke those first
-        let mut resolved_args: Vec<FunctionArg> = vec![];
+        let mut resolved_args: Vec<Value> = vec![];
         if let Some(args) = &self.args {
             for arg in args {
                 match arg {
                     FunctionArg::Expression(expression) => {
                         let value = expression.invoke(function_dispatcher, context)?;
-                        resolved_args.push(FunctionArg::String(value));
+                        resolved_args.push(value.clone());
                     },
-                    _ => {
-                        resolved_args.push(arg.clone());
+                    FunctionArg::Value(value) => {
+                        resolved_args.push(value.clone());
                     }
                 }
             }
@@ -90,15 +82,15 @@ fn convert_args_node(statement_bytes: &[u8], args: &Option<Node>) -> Result<Opti
         match arg.kind() {
             "string" => {
                 let value = arg.utf8_text(statement_bytes)?;
-                result.push(FunctionArg::String(value.to_string()));
+                result.push(FunctionArg::Value(Value::String(value.to_string())));
             },
             "number" => {
                 let value = arg.utf8_text(statement_bytes)?;
-                result.push(FunctionArg::Integer(value.parse::<i32>()?));
+                result.push(FunctionArg::Value(Value::Number(Number::from(value.parse::<i32>()?))));
             },
             "boolean" => {
                 let value = arg.utf8_text(statement_bytes)?;
-                result.push(FunctionArg::Boolean(value.parse::<bool>()?));
+                result.push(FunctionArg::Value(Value::Bool(value.parse::<bool>()?)));
             },
             "expression" => {
                 // TODO: this is recursive, we may want to stop at a specific depth

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use expressions::Expression;
+use serde_json::Value;
 use tree_sitter::Parser;
 
 use crate::configure::context::Context;
@@ -41,7 +42,7 @@ impl Statement {
     /// # Errors
     ///
     /// This function will return an error if the statement fails to parse or execute.
-    pub fn parse_and_execute(&mut self, statement: &str, context: &Context) -> Result<String, DscError> {
+    pub fn parse_and_execute(&mut self, statement: &str, context: &Context) -> Result<Value, DscError> {
         let Some(tree) = &mut self.parser.parse(statement, None) else {
             return Err(DscError::Parser(format!("Error parsing statement: {statement}")));
         };
@@ -66,14 +67,14 @@ impl Statement {
                 let Ok(value) = child_node.utf8_text(statement_bytes) else {
                     return Err(DscError::Parser("Error parsing string literal".to_string()));
                 };
-                Ok(value.to_string())
+                Ok(Value::String(value.to_string()))
             },
             "escapedStringLiteral" => {
                 // need to remove the first character: [[ => [
                 let Ok(value) = child_node.utf8_text(statement_bytes) else {
                     return Err(DscError::Parser("Error parsing escaped string literal".to_string()));
                 };
-                Ok(value[1..].to_string())
+                Ok(Value::String(value[1..].to_string()))
             },
             "expression" => {
                 let expression = Expression::new(statement_bytes, &child_node)?;

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -3,6 +3,7 @@
 
 use expressions::Expression;
 use serde_json::Value;
+use tracing::debug;
 use tree_sitter::Parser;
 
 use crate::configure::context::Context;
@@ -43,6 +44,7 @@ impl Statement {
     ///
     /// This function will return an error if the statement fails to parse or execute.
     pub fn parse_and_execute(&mut self, statement: &str, context: &Context) -> Result<Value, DscError> {
+        debug!("Parsing statement: {0}", statement);
         let Some(tree) = &mut self.parser.parse(statement, None) else {
             return Err(DscError::Parser(format!("Error parsing statement: {statement}")));
         };

--- a/tools/dsctest/src/echo.rs
+++ b/tools/dsctest/src/echo.rs
@@ -3,9 +3,23 @@
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum Output {
+    #[serde(rename = "array")]
+    Array(Vec<Value>),
+    #[serde(rename = "bool")]
+    Bool(bool),
+    #[serde(rename = "number")]
+    Number(i64),
+    #[serde(rename = "string")]
+    String(String),
+}
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Echo {
-    pub text: String,
+    pub output: Output,
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Fix `concat()` to align with ARM: only accept string and arrays, error if mixed types.  This required changing a bunch of tests that used numbers.
- Add `createArray()` to test with `concat()`
- Change functions to accept and return `Value` directly thus removing some unnecessary structs used previously
- `Echo` resource now supports int, bool, string, and arrays so changed property to `output` instead of `text` and updated tests

## PR Context

Fix https://github.com/PowerShell/DSC/issues/271