### PR TITLE
add progress bar

### DIFF
--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -56,7 +56,7 @@ Describe 'resource export tests' {
         $set_results.results.count | Should -BeGreaterThan 1
     }
 
-    It 'Duplicate resource types in Configuration Export should result in error' {
+    It 'Duplicate resource types in Configuration Export should not result in error' {
 
         $yaml = @'
             $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
@@ -71,8 +71,7 @@ Describe 'resource export tests' {
                 pid: 0
 '@
         $out = $yaml | dsc config export 2>&1
-        $LASTEXITCODE | Should -Be 2
-        $out | out-string | Should -BeLike '*specified multiple times*'
+        $LASTEXITCODE | Should -Be 0
     }
 
     It 'Export can be called on individual resource with the use of --format as a subcommand' {

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.21"
-derive_builder ="0.12"
+derive_builder ="0.20"
+indicatif = { version = "0.17" }
 jsonschema = "0.17"
 regex = "1.7"
 reqwest = { version = "0.11", features = ["blocking"] }
@@ -16,7 +17,7 @@ serde_yaml = { version = "0.9.3" }
 thiserror = "1.0"
 chrono = "0.4.26"
 tracing = "0.1.37"
-tree-sitter = "~0.20.10"
+tree-sitter = "0.21"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
 
 [dev-dependencies]

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -17,7 +17,7 @@ serde_yaml = { version = "0.9.3" }
 thiserror = "1.0"
 chrono = "0.4.26"
 tracing = "0.1.37"
-tree-sitter = "0.21"
+tree-sitter = "0.20"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
 
 [dev-dependencies]

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -14,7 +14,7 @@ use self::config_result::{ConfigurationGetResult, ConfigurationSetResult, Config
 use self::contraints::{check_length, check_number_limits, check_allowed_values};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde_json::{Map, Value};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use tracing::{debug, trace};
 
 pub mod context;

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -137,7 +137,7 @@ fn get_progress_bar(len: u64) -> Result<ProgressBar, DscError> {
     let pb = ProgressBar::new(len);
     pb.enable_steady_tick(Duration::from_millis(120));
     pb.set_style(ProgressStyle::with_template(
-        "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}"
+        "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
     )?);
    Ok(pb)
 }
@@ -179,7 +179,7 @@ impl Configurator {
         let pb = get_progress_bar(resources.len() as u64)?;
         for resource in resources {
             pb.inc(1);
-            pb.set_message(format!("Get {}", resource.name));
+            pb.set_message(format!("Get '{}'", resource.name));
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -195,7 +195,7 @@ impl Configurator {
             result.results.push(resource_result);
         }
 
-        pb.finish_and_clear();
+        pb.finish_with_message("Get configuration completed");
         Ok(result)
     }
 
@@ -216,7 +216,7 @@ impl Configurator {
         let pb = get_progress_bar(resources.len() as u64)?;
         for resource in resources {
             pb.inc(1);
-            pb.set_message(format!("Set {}", resource.name));
+            pb.set_message(format!("Set '{}'", resource.name));
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -232,7 +232,7 @@ impl Configurator {
             result.results.push(resource_result);
         }
 
-        pb.finish_and_clear();
+        pb.finish_with_message("Set configuration completed");
         Ok(result)
     }
 
@@ -253,7 +253,7 @@ impl Configurator {
         let pb = get_progress_bar(resources.len() as u64)?;
         for resource in resources {
             pb.inc(1);
-            pb.set_message(format!("Test {}", resource.name));
+            pb.set_message(format!("Test '{}'", resource.name));
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -269,7 +269,7 @@ impl Configurator {
             result.results.push(resource_result);
         }
 
-        pb.finish_and_clear();
+        pb.finish_with_message("Test configuration completed");
         Ok(result)
     }
 
@@ -296,7 +296,7 @@ impl Configurator {
         let pb = get_progress_bar(config.resources.len() as u64)?;
         for resource in &config.resources {
             pb.inc(1);
-            pb.set_message(format!("Export {}", resource.name));
+            pb.set_message(format!("Export '{}'", resource.name));
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type.clone()));
             };
@@ -306,7 +306,7 @@ impl Configurator {
         }
 
         result.result = Some(conf);
-        pb.finish_and_clear();
+        pb.finish_with_message("Export configuration completed");
         Ok(result)
     }
 

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -15,6 +15,7 @@ use self::contraints::{check_length, check_number_limits, check_allowed_values};
 use indicatif::{ProgressBar, ProgressStyle};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
+use std::time::Duration;
 use tracing::{debug, trace};
 
 pub mod context;
@@ -134,6 +135,7 @@ fn escape_property_values(properties: &Map<String, Value>) -> Result<Option<Map<
 
 fn get_progress_bar(len: u64) -> Result<ProgressBar, DscError> {
     let pb = ProgressBar::new(len);
+    pb.enable_steady_tick(Duration::from_millis(120));
     pb.set_style(ProgressStyle::with_template(
         "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}"
     )?);

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -33,17 +33,17 @@ impl CommandDiscovery {
         let multi_progress_bar = MultiProgress::new();
         let pb = multi_progress_bar.add(
         if return_all_resources {
-                let pb = ProgressBar::new_spinner();
+                let pb = ProgressBar::new(1);
                 pb.enable_steady_tick(Duration::from_millis(120));
                 pb.set_style(ProgressStyle::with_template(
-                    "{spinner:.green} [{elapsed_precise}] {msg}"
+                    "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.yellow}"
                 )?);
                 pb
             } else {
                 let pb = ProgressBar::new(required_resource_types.len() as u64);
                 pb.enable_steady_tick(Duration::from_millis(120));
                 pb.set_style(ProgressStyle::with_template(
-                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}"
+                    "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
                 )?);
                 pb
             }
@@ -128,11 +128,11 @@ impl CommandDiscovery {
         // now go through the provider resources and add them to the list of resources
         for provider in provider_resources {
             debug!("Enumerating resources for provider {}", provider);
-            let pb_adapter = multi_progress_bar.add(ProgressBar::new_spinner());
+            let pb_adapter = multi_progress_bar.add(ProgressBar::new(1));
             pb_adapter.enable_steady_tick(Duration::from_millis(120));
-            pb_adapter.set_style(ProgressStyle::default_spinner().tick_strings(&[
-                "◷", "◶", "◵", "◴"
-            ]));
+            pb_adapter.set_style(ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.white}"
+            )?);
             pb_adapter.set_message(format!("Enumerating resources for adapter {provider}"));
             let provider_resource = resources.get(&provider).unwrap();
             let provider_type_name = provider_resource.type_name.clone();
@@ -204,13 +204,12 @@ impl CommandDiscovery {
                     }
                 };
             }
-            pb_adapter.finish_and_clear();
+            pb_adapter.finish_with_message(format!("Done with {provider}"));
 
             debug!("Provider {} listed {} matching resources", provider_type_name, provider_resources_count);
         }
 
-        pb.finish_and_clear();
-        multi_progress_bar.clear()?;
+        pb.finish_with_message("Discovery complete");
         Ok(resources)
     }
 }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -32,23 +32,20 @@ impl CommandDiscovery {
 
         let multi_progress_bar = MultiProgress::new();
         let pb = multi_progress_bar.add(
-            match return_all_resources {
-                true => {
-                    let pb = ProgressBar::new_spinner();
-                    pb.enable_steady_tick(Duration::from_millis(120));
-                    pb.set_style(ProgressStyle::with_template(
-                        "{spinner:.green} [{elapsed_precise}] {msg}"
-                    )?);
-                    pb
-                },
-                false => {
-                    let pb = ProgressBar::new(required_resource_types.len() as u64);
-                    pb.enable_steady_tick(Duration::from_millis(120));
-                    pb.set_style(ProgressStyle::with_template(
-                    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}"
-                    )?);
-                    pb
-                }
+        if return_all_resources {
+                let pb = ProgressBar::new_spinner();
+                pb.enable_steady_tick(Duration::from_millis(120));
+                pb.set_style(ProgressStyle::with_template(
+                    "{spinner:.green} [{elapsed_precise}] {msg}"
+                )?);
+                pb
+            } else {
+                let pb = ProgressBar::new(required_resource_types.len() as u64);
+                pb.enable_steady_tick(Duration::from_millis(120));
+                pb.set_style(ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}"
+                )?);
+                pb
             }
         );
         pb.set_message("Searching for resources");
@@ -136,7 +133,7 @@ impl CommandDiscovery {
             pb_adapter.set_style(ProgressStyle::default_spinner().tick_strings(&[
                 "◷", "◶", "◵", "◴"
             ]));
-            pb_adapter.set_message(format!("Enumerating resources for adapter {}", provider));
+            pb_adapter.set_message(format!("Enumerating resources for adapter {provider}"));
             let provider_resource = resources.get(&provider).unwrap();
             let provider_type_name = provider_resource.type_name.clone();
             let manifest = import_manifest(provider_resource.manifest.clone().unwrap())?;

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -36,7 +36,7 @@ impl Discovery {
 
         let mut regex: Option<Box<Regex>> = None;
         let mut resources: Vec<DscResource> = Vec::new();
-        if !type_name_filter.is_empty() 
+        if !type_name_filter.is_empty()
         {
             let regex_str = convert_wildcard_to_regex(type_name_filter);
             let mut regex_builder = RegexBuilder::new(regex_str.as_str());

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -3,6 +3,7 @@
 
 use std::str::Utf8Error;
 
+use indicatif::style::TemplateError;
 use reqwest::StatusCode;
 use thiserror::Error;
 use tracing::error;
@@ -75,6 +76,9 @@ pub enum DscError {
 
     #[error("Parser: {0}")]
     Parser(String),
+
+    #[error("Progress: {0}")]
+    Progress(#[from] TemplateError),
 
     #[error("Resource not found: {0}")]
     ResourceNotFound(String),

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -26,7 +26,7 @@ impl Statement {
     /// This function will return an error if the underlying parser fails to initialize.
     pub fn new() -> Result<Self, DscError> {
         let mut parser = Parser::new();
-        parser.set_language(tree_sitter_dscexpression::language())?;
+        parser.set_language(&tree_sitter_dscexpression::language())?;
         let function_dispatcher = FunctionDispatcher::new();
         Ok(Self {
             parser,

--- a/dsc_lib/src/parser/mod.rs
+++ b/dsc_lib/src/parser/mod.rs
@@ -26,7 +26,7 @@ impl Statement {
     /// This function will return an error if the underlying parser fails to initialize.
     pub fn new() -> Result<Self, DscError> {
         let mut parser = Parser::new();
-        parser.set_language(&tree_sitter_dscexpression::language())?;
+        parser.set_language(tree_sitter_dscexpression::language())?;
         let function_dispatcher = FunctionDispatcher::new();
         Ok(Self {
             parser,

--- a/tree-sitter-dscexpression/Cargo.toml
+++ b/tree-sitter-dscexpression/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "~0.20.10"
+tree-sitter = "0.21"
 
 [build-dependencies]
 cc = "1.0"

--- a/tree-sitter-dscexpression/Cargo.toml
+++ b/tree-sitter-dscexpression/Cargo.toml
@@ -20,7 +20,7 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = "0.21"
+tree-sitter = "0.20"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Add multi-line progress for resource discovery, one for commands and one for adapters
- Add a progress bar for config operations
- Update some out of date dependencies
- Removed check for duplicate resources used in export as we need to allow it and updated test

Current design leaves the progress bars on screen so you can see the elapsed time but also avoids the situation where it runs fast and you see something flash in the terminal and disappear not knowing what it was

## PR Context

Note that this is just progress of `dsc` itself, we still need to enable messages from resources to report their own progress particularly for group resources and adapters.

Example:

![Screen Recording 2024-02-27 at 7 32 53 PM](https://github.com/PowerShell/DSC/assets/11859881/ea295af1-0761-43cd-a435-b5aa00e65e67)
