### PR TITLE
pre-allocate string for table writer

### DIFF
--- a/dsc/src/tablewriter.rs
+++ b/dsc/src/tablewriter.rs
@@ -49,7 +49,7 @@ impl Table {
         let (width, _) = size().unwrap_or((80, 25));
         // make header bright green
         println!("\x1b[1;32m");
-        let mut header_row = String::new();
+        let mut header_row = String::with_capacity(width as usize);
         let last_column = self.header.len() - 1;
         for (i, column) in self.header.iter().enumerate() {
             header_row.push_str(&format!("{:<width$}", column, width = self.column_widths[i]));
@@ -67,7 +67,7 @@ impl Table {
 
         // TODO: make this smarter by splitting long text to multiple lines
         for row in &self.rows {
-            let mut row_str = String::new();
+            let mut row_str = String::with_capacity(header_row.len());
             for (i, column) in row.iter().enumerate() {
                 row_str.push_str(&format!("{:<width$}", column, width = self.column_widths[i]));
                 if i != last_column {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Pre-allocate the size of the string if we know the length to avoid unnecessary re-allocations as the string gets built.