### PR TITLE
Add metadata so adapter resource knows if input is configuration or for a resource

### DIFF
--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -71,9 +71,10 @@ pub struct Resource {
     #[serde(rename = "dependsOn", skip_serializing_if = "Option::is_none")]
     #[schemars(regex(pattern = r"^\[resourceId\(\s*'[a-zA-Z0-9\.]+/[a-zA-Z0-9]+'\s*,\s*'[a-zA-Z0-9 ]+'\s*\)]$"))]
     pub depends_on: Option<Vec<String>>,
-    // `identity` can be used for run-as
     #[serde(skip_serializing_if = "Option::is_none")]
     pub properties: Option<Map<String, Value>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<HashMap<String, Value>>,
 }
 
 // Defines the valid and recognized canonical URIs for the configuration schema
@@ -127,6 +128,7 @@ impl Resource {
             name: String::new(),
             depends_on: None,
             properties: None,
+            metadata: None,
         }
     }
 }

--- a/powershell-adapter/powershell.resource.ps1
+++ b/powershell-adapter/powershell.resource.ps1
@@ -33,6 +33,14 @@ function RefreshCache
     }
 }
 
+function IsConfiguration($obj) {
+    if ($null -ne $obj.metadata -and $null -ne $obj.metadata.'Microsoft.DSC' -and $obj.metadata.'Microsoft.DSC'.context -eq 'Configuration') {
+        return $true
+    }
+
+    return $false
+}
+
 if (($PSVersionTable.PSVersion.Major -eq 7) -and ($PSVersionTable.PSVersion.Minor -eq 4) `
    -and ($PSVersionTable.PSVersion.PreReleaseLabel.StartsWith("preview")))
 {
@@ -121,7 +129,7 @@ elseif ($Operation -eq 'Get')
 
     RefreshCache
 
-    if ($inputobj_pscustomobj.resources) # we are processing a config batch
+    if (IsConfiguration $inputobj_pscustomobj) # we are processing a config batch
     {
         foreach($r in $inputobj_pscustomobj.resources)
         {
@@ -191,7 +199,7 @@ elseif ($Operation -eq 'Set')
 
     RefreshCache
 
-    if ($inputobj_pscustomobj.resources) # we are processing a config batch
+    if (IsConfiguration $inputobj_pscustomobj) # we are processing a config batch
     {
         foreach($r in $inputobj_pscustomobj.resources)
         {
@@ -259,7 +267,7 @@ elseif ($Operation -eq 'Test')
 
     RefreshCache
 
-    if ($inputobj_pscustomobj.resources) # we are processing a config batch
+    if (IsConfiguration $inputobj_pscustomobj) # we are processing a config batch
     {
         foreach($r in $inputobj_pscustomobj.resources)
         {
@@ -327,7 +335,7 @@ elseif ($Operation -eq 'Export')
 
     RefreshCache
 
-    if ($inputobj_pscustomobj.resources) # we are processing a config batch
+    if (IsConfiguration $inputobj_pscustomobj) # we are processing a config batch
     {
         foreach($r in $inputobj_pscustomobj.resources)
         {

--- a/wmi-adapter/Tests/wmi.tests.ps1
+++ b/wmi-adapter/Tests/wmi.tests.ps1
@@ -11,7 +11,7 @@ Describe 'WMI adapter resource tests' {
 
             $configPath = Join-path $PSScriptRoot "test_wmi_config.dsc.yaml"
 
-            $dscPath = (get-command dsc -CommandType Application).Path
+            $dscPath = (get-command dsc -CommandType Application | Select-Object -First 1).Path
             $dscFolder = Split-Path -Path $dscPath
             $wmiGroupOptoutFile = Join-Path $dscFolder "wmi.dsc.resource.json.optout"
             $wmiGroupOptinFile = Join-Path $dscFolder "wmi.dsc.resource.json"

--- a/wmi-adapter/wmi.resource.ps1
+++ b/wmi-adapter/wmi.resource.ps1
@@ -13,6 +13,14 @@ $ProgressPreference = 'Ignore'
 $WarningPreference = 'Ignore'
 $VerbosePreference = 'Ignore'
 
+function IsConfiguration($obj) {
+    if ($null -ne $obj.metadata -and $null -ne $obj.metadata.'Microsoft.DSC' -and $obj.metadata.'Microsoft.DSC'.context -eq 'Configuration') {
+        return $true
+    }
+
+    return $false
+}
+
 if ($Operation -eq 'List')
 {
     $clases = Get-CimClass
@@ -62,7 +70,7 @@ elseif ($Operation -eq 'Get')
 
     $result = @()
 
-    if ($inputobj_pscustomobj.resources) # we are processing a config batch
+    if (IsConfiguration $inputobj_pscustomobj) # we are processing a config batch
     {
         foreach($r in $inputobj_pscustomobj.resources)
         {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As noted in the issue, adding `metadata` to the config indicating the input is a configuration, but only if the target resource is an adapter.  Also fix it so that export input will also execute any expressions.  Update powershell and wmi adapter resources to use this new metadata property.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/253