### PR TITLE
Enable metadata in config to declare if admin is required or not

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -111,6 +111,7 @@ if (!$SkipBuild) {
 # projects are in dependency order
 $projects = @(
     "tree-sitter-dscexpression",
+    "security_context_lib",
     "dsc_lib",
     "file_lib",
     "dsc",

--- a/dsc/examples/groups.dsc.yaml
+++ b/dsc/examples/groups.dsc.yaml
@@ -1,5 +1,8 @@
 # Example for grouping and groups in groups
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  Microsoft.DSC:
+    requiredSecurityContext: Current # this is the default and just used as an example indicating this config works for admins and non-admins
 resources:
 - name: Last Group
   type: Microsoft.DSC/Group

--- a/dsc/examples/require_admin.yaml
+++ b/dsc/examples/require_admin.yaml
@@ -1,0 +1,11 @@
+# example showing use of specific metadata to indicate this config requires admin to run
+# note that the resource doesn't require admin, but this will fail to even try to run the
+# config if the user is not root or elevated as administrator
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  Microsoft.DSC:
+    requiredSecurityContext: Elevated
+resources:
+- name: os
+  type: Microsoft/OSInfo
+  properties: {}

--- a/dsc/examples/require_nonadmin.yaml
+++ b/dsc/examples/require_nonadmin.yaml
@@ -1,0 +1,10 @@
+# example showing use of specific metadata to indicate this config requires admin to run
+# this will fail to even try to run the config if the user is root or elevated as administrator
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+metadata:
+  Microsoft.DSC:
+    requiredSecurityContext: Restricted
+resources:
+- name: os
+  type: Microsoft/OSInfo
+  properties: {}

--- a/dsc/tests/dsc_securitycontext.tests.ps1
+++ b/dsc/tests/dsc_securitycontext.tests.ps1
@@ -4,7 +4,8 @@
 Describe 'Tests for configuration security context metadata' {
     BeforeAll {
         $isAdmin = if ($IsWindows) {
-            [System.Security.Principal.WindowsIdentity]::GetCurrent().Owner.IsWellKnown('Builtin\Administrators')
+            $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+            [System.Security.Principal.WindowsPrincipal]::new($identity).IsInRole([System.Security.Principal.WindowsBuiltInRole]::Administrator)
         }
         else {
             [System.Environment]::UserName -eq 'root'

--- a/dsc/tests/dsc_securitycontext.tests.ps1
+++ b/dsc/tests/dsc_securitycontext.tests.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Tests for configuration security context metadata' {
+    BeforeAll {
+        $isAdmin = if ($IsWindows) {
+            [System.Security.Principal.WindowsIdentity]::GetCurrent().Owner.IsWellKnown('Builtin\Administrators')
+        }
+        else {
+            [System.Environment]::UserName -eq 'root'
+        }
+    }
+
+    It 'Require admin' {
+        $out = dsc config get -p $PSScriptRoot/../examples/require_admin.yaml
+        if ($isAdmin) {
+            $LASTEXITCODE | Should -Be 0
+            $out | Should -Not -BeNullOrEmpty
+        }
+        else {
+            $LASTEXITCODE | Should -Be 2
+        }
+    }
+
+    It 'Require non-admin' {
+        $out = dsc config get -p $PSScriptRoot/../examples/require_nonadmin.yaml
+        if ($isAdmin) {
+            $LASTEXITCODE | Should -Be 2
+        }
+        else {
+            $LASTEXITCODE | Should -Be 0
+            $out | Should -Not -BeNullOrEmpty
+        }
+    }
+}

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -16,6 +16,7 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 serde_yaml = { version = "0.9.3" }
 thiserror = "1.0"
 chrono = "0.4.26"
+security_context_lib = { path = "../security_context_lib" }
 tracing = "0.1.37"
 tree-sitter = "0.20"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -45,7 +45,7 @@ pub struct Configuration {
     pub variables: Option<HashMap<String, Value>>,
     pub resources: Vec<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<HashMap<String, Value>>,
+    pub metadata: Option<Metadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -7,6 +7,33 @@ use serde_json::{Map, Value};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum ContextKind {
+    Configuration,
+    Resource,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum SecurityContextKind {
+    Current,
+    Elevated,
+    Restricted,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct MicrosoftDscMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<ContextKind>,
+    #[serde(rename = "requiredSecurityContext", skip_serializing_if = "Option::is_none")]
+    pub required_security_context: Option<SecurityContextKind>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct Metadata {
+    #[serde(rename = "Microsoft.DSC", skip_serializing_if = "Option::is_none")]
+    pub microsoft: Option<MicrosoftDscMetadata>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct Configuration {
     #[serde(rename = "$schema")]

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -9,11 +9,12 @@ use crate::DscResource;
 use crate::discovery::Discovery;
 use crate::parser::Statement;
 use self::context::Context;
-use self::config_doc::{Configuration, DataType};
+use self::config_doc::{Configuration, DataType, SecurityContextKind};
 use self::depends_on::get_resource_invocation_order;
 use self::config_result::{ConfigurationGetResult, ConfigurationSetResult, ConfigurationTestResult, ConfigurationExportResult};
 use self::contraints::{check_length, check_number_limits, check_allowed_values};
 use indicatif::{ProgressBar, ProgressStyle};
+use security_context_lib::{SecurityContext, get_security_context};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -159,6 +160,36 @@ fn add_metadata(kind: &Kind, mut properties: Option<Map<String, Value>> ) -> Res
     }
 
     Ok(serde_json::to_string(&properties)?)
+}
+
+fn check_security_context(config: &Configuration) -> Result<(), DscError> {
+    if config.metadata.is_none() {
+        return Ok(());
+    }
+
+    if let Some(metadata) = &config.metadata {
+        if let Some(microsoft_dsc) = &metadata.microsoft {
+            if let Some(required_security_context) = &microsoft_dsc.required_security_context {
+                match required_security_context {
+                    SecurityContextKind::Current => {
+                        // no check needed
+                    },
+                    SecurityContextKind::Elevated => {
+                        if get_security_context() != SecurityContext::Admin {
+                            return Err(DscError::SecurityContext("Elevated security context required".to_string()));
+                        }
+                    },
+                    SecurityContextKind::Restricted => {
+                        if get_security_context() != SecurityContext::User {
+                            return Err(DscError::SecurityContext("Restricted security context required".to_string()));
+                        }
+                    },
+                }
+            }
+        }
+    }
+
+    Ok(())
 }
 
 impl Configurator {
@@ -415,6 +446,7 @@ impl Configurator {
 
     fn validate_config(&mut self) -> Result<Configuration, DscError> {
         let config: Configuration = serde_json::from_str(self.config.as_str())?;
+        check_security_context(&config)?;
 
         // Perform discovery of resources used in config
         let mut required_resources = config.resources.iter().map(|p| p.resource_type.to_lowercase()).collect::<Vec<String>>();

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -89,6 +89,9 @@ pub enum DscError {
     #[error("No Schema: {0}")]
     SchemaNotAvailable(String),
 
+    #[error("Security context: {0}")]
+    SecurityContext(String),
+
     #[error("Utf-8 conversion error: {0}")]
     Utf8Conversion(#[from] Utf8Error),
 

--- a/ntstatuserror/src/lib.rs
+++ b/ntstatuserror/src/lib.rs
@@ -15,7 +15,7 @@ pub struct NtStatusError {
 
 impl NtStatusError {
     /// Create a new `NtStatusError` from an NTSTATUS error code and a message.
-    /// 
+    ///
     /// # Arguments
     ///
     /// * `status` - The NTSTATUS error code

--- a/security_context_lib/Cargo.toml
+++ b/security_context_lib/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 is_elevated = "0.1.0"
+
+[target.'cfg(not(target_os = "windows"))'.dependencies]
+nix = { version = "0.28.0", features = ["user"] }

--- a/security_context_lib/Cargo.toml
+++ b/security_context_lib/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "security_context_lib"
+version = "0.1.0"
+edition = "2021"
+
+[target.'cfg(target_os = "windows")'.dependencies]
+is_elevated = "0.1.0"

--- a/security_context_lib/src/lib.rs
+++ b/security_context_lib/src/lib.rs
@@ -1,10 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SecurityContext {
     Admin,
     User,
 }
 
 #[cfg(target_os = "windows")]
-pub function get_security_context() -> SecurityContext {
+pub fn get_security_context() -> SecurityContext {
     use is_elevated::is_elevated;
     if is_elevated() {
         return SecurityContext::Admin;
@@ -14,7 +18,7 @@ pub function get_security_context() -> SecurityContext {
 }
 
 #[cfg(not(target_os = "windows"))]
-pub function get_security_context() -> SecurityContext {
+pub fn get_security_context() -> SecurityContext {
     use nix::unistd::Uid;
 
     if Uid::effective().is_root() {

--- a/security_context_lib/src/lib.rs
+++ b/security_context_lib/src/lib.rs
@@ -8,22 +8,22 @@ pub enum SecurityContext {
 }
 
 #[cfg(target_os = "windows")]
+#[must_use]
 pub fn get_security_context() -> SecurityContext {
     use is_elevated::is_elevated;
     if is_elevated() {
         return SecurityContext::Admin;
-    } else {
-        return SecurityContext::User;
     }
+    SecurityContext::User
 }
 
 #[cfg(not(target_os = "windows"))]
+#[must_use]
 pub fn get_security_context() -> SecurityContext {
     use nix::unistd::Uid;
 
     if Uid::effective().is_root() {
         return SecurityContext::Admin;
-    } else {
-        return SecurityContext::User;
     }
+    SecurityContext::User
 }

--- a/security_context_lib/src/lib.rs
+++ b/security_context_lib/src/lib.rs
@@ -1,0 +1,25 @@
+pub enum SecurityContext {
+    Admin,
+    User,
+}
+
+#[cfg(target_os = "windows")]
+pub function get_security_context() -> SecurityContext {
+    use is_elevated::is_elevated;
+    if is_elevated() {
+        return SecurityContext::Admin;
+    } else {
+        return SecurityContext::User;
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub function get_security_context() -> SecurityContext {
+    use nix::unistd::Uid;
+
+    if Uid::effective().is_root() {
+        return SecurityContext::Admin;
+    } else {
+        return SecurityContext::User;
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enable using metadata to declare if a config requires admin or non-admin.  A helper function library added using different methods depending on Windows and non-Windows.  This can be used later with RunAsGroup resource.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/258