### PR TITLE
Add `reference()` function to get output from a resource

### DIFF
--- a/dsc/examples/reference.dsc.yaml
+++ b/dsc/examples/reference.dsc.yaml
@@ -1,0 +1,12 @@
+# Simple example showing how to reference output from a resource to use in another
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+resources:
+- name: os
+  type: Microsoft/OSInfo
+  properties: {}
+- name: Echo
+  type: Test/Echo
+  properties:
+    output: "[concat('The OS is ', reference(resourceId('Microsoft/OSInfo','os')).actualState.family)]"
+  dependsOn:
+  - "[resourceId('Microsoft/OSInfo','os')]"

--- a/dsc/tests/dsc_reference.tests.ps1
+++ b/dsc/tests/dsc_reference.tests.ps1
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Tests for config using reference function' {
+    It 'Reference works' {
+        $out = dsc config get -p $PSScriptRoot/../examples/reference.dsc.yaml | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $os = if ($IsWindows) {
+            'Windows'
+        }
+        elseif ($IsLinux) {
+            'Linux'
+        }
+        else {
+            'macOS'
+        }
+
+        $out.results[1].result.actualState.Output | Should -BeExactly "The OS is $os"
+    }
+}

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 pub struct Context {
     pub parameters: HashMap<String, Value>,
     pub _variables: HashMap<String, Value>,
-    pub _outputs: HashMap<String, Value>, // This is eventually for References function to get output from resources
+    pub outputs: HashMap<String, Value>, // this is used by the `reference()` function to retrieve output
 }
 
 impl Context {
@@ -16,7 +16,7 @@ impl Context {
         Self {
             parameters: HashMap::new(),
             _variables: HashMap::new(),
-            _outputs: HashMap::new(),
+            outputs: HashMap::new(),
         }
     }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -238,6 +238,7 @@ impl Configurator {
             let filter = add_metadata(&dsc_resource.kind, properties)?;
             trace!("filter: {filter}");
             let get_result = dsc_resource.get(&filter)?;
+            self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&get_result)?);
             let resource_result = config_result::ResourceGetResult {
                 name: resource.name.clone(),
                 resource_type: resource.resource_type.clone(),
@@ -276,6 +277,7 @@ impl Configurator {
             let desired = add_metadata(&dsc_resource.kind, properties)?;
             trace!("desired: {desired}");
             let set_result = dsc_resource.set(&desired, skip_test)?;
+            self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&set_result)?);
             let resource_result = config_result::ResourceSetResult {
                 name: resource.name.clone(),
                 resource_type: resource.resource_type.clone(),
@@ -314,6 +316,7 @@ impl Configurator {
             let expected = add_metadata(&dsc_resource.kind, properties)?;
             trace!("expected: {expected}");
             let test_result = dsc_resource.test(&expected)?;
+            self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&test_result)?);
             let resource_result = config_result::ResourceTestResult {
                 name: resource.name.clone(),
                 resource_type: resource.resource_type.clone(),

--- a/dsc_lib/src/functions/mod.rs
+++ b/dsc_lib/src/functions/mod.rs
@@ -15,6 +15,7 @@ pub mod div;
 pub mod envvar;
 pub mod mul;
 pub mod parameters;
+pub mod reference;
 pub mod resource_id;
 pub mod sub;
 
@@ -66,6 +67,7 @@ impl FunctionDispatcher {
         functions.insert("envvar".to_string(), Box::new(envvar::Envvar{}));
         functions.insert("mul".to_string(), Box::new(mul::Mul{}));
         functions.insert("parameters".to_string(), Box::new(parameters::Parameters{}));
+        functions.insert("reference".to_string(), Box::new(reference::Reference{}));
         functions.insert("resourceId".to_string(), Box::new(resource_id::ResourceId{}));
         functions.insert("sub".to_string(), Box::new(sub::Sub{}));
         Self {

--- a/dsc_lib/src/functions/reference.rs
+++ b/dsc_lib/src/functions/reference.rs
@@ -47,14 +47,14 @@ mod tests {
         let mut parser = Statement::new().unwrap();
         let mut context = Context::new();
         context.outputs.insert("foo:bar".to_string(), "baz".into());
-        let result = parser.parse_and_execute("[referene('foo:bar')]", &context).unwrap();
+        let result = parser.parse_and_execute("[reference('foo:bar')]", &context).unwrap();
         assert_eq!(result, "baz");
     }
 
     #[test]
     fn invalid_resourceid() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[referene('foo:bar')]", &Context::new());
+        let result = parser.parse_and_execute("[reference('foo:bar')]", &Context::new());
         assert!(result.is_err());
     }
 }

--- a/dsc_lib/src/functions/reference.rs
+++ b/dsc_lib/src/functions/reference.rs
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+use crate::configure::context::Context;
+use crate::functions::{AcceptedArgKind, Function};
+use serde_json::Value;
+use tracing::debug;
+
+#[derive(Debug, Default)]
+pub struct Reference {}
+
+impl Function for Reference {
+    fn min_args(&self) -> usize {
+        1
+    }
+
+    fn max_args(&self) -> usize {
+        1
+    }
+
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::String]
+    }
+
+    fn invoke(&self, args: &[Value], context: &Context) -> Result<Value, DscError> {
+        debug!("reference function");
+        if let Some(key) = args[0].as_str() {
+            if context.outputs.contains_key(key) {
+                Ok(context.outputs[key].clone())
+            } else {
+                Err(DscError::Parser(format!(
+                    "Invalid resourceId or resource has not executed yet: {}",
+                    key
+                )))
+            }
+        } else {
+            Err(DscError::Parser("Invalid argument".to_string()))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configure::context::Context;
+    use crate::parser::Statement;
+
+    #[test]
+    fn valid_resourceid() {
+        let mut parser = Statement::new().unwrap();
+        let mut context = Context::new();
+        context.outputs.insert("foo:bar".to_string(), "baz".into());
+        let result = parser.parse_and_execute("[referene('foo:bar')]", &context).unwrap();
+        assert_eq!(result, "baz");
+    }
+
+    #[test]
+    fn invalid_resourceid() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[referene('foo:bar')]", &Context::new());
+        assert!(result.is_err());
+    }
+}

--- a/dsc_lib/src/functions/reference.rs
+++ b/dsc_lib/src/functions/reference.rs
@@ -29,10 +29,7 @@ impl Function for Reference {
             if context.outputs.contains_key(key) {
                 Ok(context.outputs[key].clone())
             } else {
-                Err(DscError::Parser(format!(
-                    "Invalid resourceId or resource has not executed yet: {}",
-                    key
-                )))
+                Err(DscError::Parser(format!("Invalid resourceId or resource has not executed yet: {key}")))
             }
         } else {
             Err(DscError::Parser("Invalid argument".to_string()))

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -39,7 +39,7 @@ impl Expression {
             }
             let mut result = vec![];
             let mut cursor = members.walk();
-            for member in members.children(&mut cursor) {
+            for member in members.named_children(&mut cursor) {
                 if member.is_error() {
                     return Err(DscError::Parser("Error parsing dot-notation member".to_string()));
                 }
@@ -73,10 +73,6 @@ impl Expression {
 
             let mut value = result;
             for member in member_access {
-                if member == "." {
-                    continue;
-                }
-
                 if !value.is_object() {
                     return Err(DscError::Parser(format!("Member access '{member}' on non-object value")));
                 }

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -73,6 +73,10 @@ impl Expression {
 
             let mut value = result;
             for member in member_access {
+                if member == "." {
+                    continue;
+                }
+
                 if !value.is_object() {
                     return Err(DscError::Parser(format!("Member access '{member}' on non-object value")));
                 }

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -32,8 +32,7 @@ module.exports = grammar({
     number: $ => /-?\d+/,
     boolean: $ => choice('true', 'false'),
 
-    memberAccess: $ => repeat1($._member),
-    _member: $ => seq('.', $.memberName),
+    memberAccess: $ => seq('.', $.memberName, repeat(seq('.', $.memberName))),
     memberName: $ => /[a-zA-Z0-9_-]+/,
   }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add `reference()` function to get output from an executed resource.  Note that this differs from https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/template-functions-resource#reference in that it only takes a single argument which is a `resourceId`.  The other two parameters don't apply to DSC.  Also note that the output is the same as if you executed the resource from `dsc` so it's wrapped as a GetResult, SetResult, TestResult.

## PR Context

Part of https://github.com/PowerShell/DSC/issues/57