### PR TITLE
Fix `envvar()` function to error if env var doesn't exist

### DIFF
--- a/dsc_lib/src/functions/envvar.rs
+++ b/dsc_lib/src/functions/envvar.rs
@@ -41,8 +41,8 @@ mod tests {
     #[test]
     fn valid() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[envvar('PWD')]", &Context::new()).unwrap();
-        assert_eq!(result, std::env::var("PWD").unwrap());
+        let result = parser.parse_and_execute("[envvar('PATH')]", &Context::new()).unwrap();
+        assert_eq!(result, std::env::var("PATH").unwrap());
     }
 
     #[test]

--- a/powershell-adapter/Tests/powershellgroup.config.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.config.tests.ps1
@@ -120,7 +120,7 @@ Describe 'PowerShell adapter resource tests' {
         $res.results[0].result.actualState.Prop1 | Should -Be $TestDrive
     }
 
-    It 'DSCConfigRoot macro is empty when config is piped from stdin' -Skip:(!$IsWindows){
+    It 'DSC_CONFIG_ROOT env var does not exist when config is piped from stdin' -Skip:(!$IsWindows){
 
         $yaml = @"
             `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
@@ -134,10 +134,7 @@ Describe 'PowerShell adapter resource tests' {
                   properties:
                     Name: "[envvar('DSC_CONFIG_ROOT')]"
 "@
-        $out = $yaml | dsc config get
-        $LASTEXITCODE | Should -Be 0
-        $res = $out | ConvertFrom-Json
-        $res.results[0].result.actualState.Name | Should -Be ""
-        $res.results[0].result.actualState.Prop1 | Should -Be ""
+        $null = $yaml | dsc config get
+        $LASTEXITCODE | Should -Be 2
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix `envvar()` function to error if env var doesn't exist

## PR Context

Fix https://github.com/PowerShell/DSC/issues/336