### PR TITLE
Fix indicatif prog bar

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -17,6 +17,7 @@ clap_complete = { version = "4.4" }
 crossterm = { version = "0.27" }
 ctrlc = { version = "3.4.0" }
 dsc_lib = { path = "../dsc_lib" }
+indicatif = { version = "0.17" }
 jsonschema = "0.17"
 path-absolutize = { version = "3.1.1" }
 schemars = { version = "0.8.12" }
@@ -29,4 +30,3 @@ thiserror = "1.0.52"
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }
 tracing-indicatif = { version = "0.3.6" }
-indicatif = { version = "0.17" }

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -29,3 +29,4 @@ thiserror = "1.0.52"
 tracing = { version = "0.1.37" }
 tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }
 tracing-indicatif = { version = "0.3.6" }
+indicatif = { version = "0.17" }

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -398,6 +398,7 @@ pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
 
     match subcommand {
         ResourceSubCommand::List { resource_name, description, tags, format } => {
+
             let mut write_table = false;
             let mut table = Table::new(&["Type", "Kind", "Version", "Methods", "Requires", "Description"]);
             if format.is_none() && atty::is(Stream::Stdout) {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -19,7 +19,11 @@ use dsc_lib::{
 };
 use serde_yaml::Value;
 use std::process::exit;
-use tracing::{debug, error, trace};
+use tracing::{debug, error, info_span, trace};
+use indicatif::ProgressStyle;
+use std::time::Duration;
+use tracing::Span;
+use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 pub fn config_get(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool)
 {
@@ -398,7 +402,6 @@ pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
 
     match subcommand {
         ResourceSubCommand::List { resource_name, description, tags, format } => {
-
             let mut write_table = false;
             let mut table = Table::new(&["Type", "Kind", "Version", "Methods", "Requires", "Description"]);
             if format.is_none() && atty::is(Stream::Stdout) {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -19,11 +19,7 @@ use dsc_lib::{
 };
 use serde_yaml::Value;
 use std::process::exit;
-use tracing::{debug, error, info_span, trace};
-use indicatif::ProgressStyle;
-use std::time::Duration;
-use tracing::Span;
-use tracing_indicatif::span_ext::IndicatifSpanExt;
+use tracing::{debug, error, trace};
 
 pub fn config_get(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool)
 {

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "1.0"
 chrono = "0.4.26"
 security_context_lib = { path = "../security_context_lib" }
 tracing = "0.1.37"
+tracing-indicatif = { version = "0.3.6" }
 tree-sitter = "0.20"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
 

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -136,7 +136,7 @@ fn escape_property_values(properties: &Map<String, Value>) -> Result<Option<Map<
 }
 
 fn get_progress_bar_span(len: u64) -> Result<Span, DscError> {
-    let pb_span = warn_span!("progress bar");
+    let pb_span = warn_span!("");
     pb_span.pb_set_style(&ProgressStyle::with_template(
         "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
     )?);

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -16,9 +16,9 @@ use self::contraints::{check_length, check_number_limits, check_allowed_values};
 use indicatif::ProgressStyle;
 use security_context_lib::{SecurityContext, get_security_context};
 use serde_json::{Map, Value};
-use tracing_indicatif::span_ext::IndicatifSpanExt;
 use std::{collections::HashMap, mem};
 use tracing::{debug, trace, warn_span, Span};
+use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 pub mod context;
 pub mod config_doc;
@@ -270,7 +270,7 @@ impl Configurator {
         let pb_span_enter = pb_span.enter();
         for resource in resources {
             Span::current().pb_inc(1);
-            pb_span.pb_set_message(format!("Get '{}'", resource.name).as_str());
+            pb_span.pb_set_message(format!("Set '{}'", resource.name).as_str());
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -310,7 +310,7 @@ impl Configurator {
         let pb_span_enter = pb_span.enter();
         for resource in resources {
             Span::current().pb_inc(1);
-            pb_span.pb_set_message(format!("Get '{}'", resource.name).as_str());
+            pb_span.pb_set_message(format!("Test '{}'", resource.name).as_str());
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
@@ -356,7 +356,7 @@ impl Configurator {
         let pb_span_enter = pb_span.enter();
         for resource in config.resources {
             Span::current().pb_inc(1);
-            pb_span.pb_set_message(format!("Get '{}'", resource.name).as_str());
+            pb_span.pb_set_message(format!("Export '{}'", resource.name).as_str());
             let properties = self.invoke_property_expressions(&resource.properties)?;
             let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type.to_lowercase()) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type.clone()));

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -136,6 +136,7 @@ fn escape_property_values(properties: &Map<String, Value>) -> Result<Option<Map<
 }
 
 fn get_progress_bar_span(len: u64) -> Result<Span, DscError> {
+    // use warn_span since that is the default logging level but progress bars will be suppressed if error trace level is used
     let pb_span = warn_span!("");
     pb_span.pb_set_style(&ProgressStyle::with_template(
         "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
@@ -247,8 +248,8 @@ impl Configurator {
             result.results.push(resource_result);
         }
 
-        mem::drop(pb_span_enter);
-        mem::drop(pb_span);
+        std::mem::drop(pb_span_enter);
+        std::mem::drop(pb_span);
         Ok(result)
     }
 
@@ -327,8 +328,8 @@ impl Configurator {
             result.results.push(resource_result);
         }
 
-        mem::drop(pb_span_enter);
-        mem::drop(pb_span);
+        std::mem::drop(pb_span_enter);
+        std::mem::drop(pb_span);
         Ok(result)
     }
 
@@ -366,9 +367,9 @@ impl Configurator {
             add_resource_export_results_to_configuration(dsc_resource, Some(dsc_resource), &mut conf, input.as_str())?;
         }
 
+        std::mem::drop(pb_span_enter);
+        std::mem::drop(pb_span);
         result.result = Some(conf);
-        mem::drop(pb_span_enter);
-        mem::drop(pb_span);
         Ok(result)
     }
 

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -12,7 +12,6 @@ use std::env;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufReader;
-use std::mem;
 use std::path::Path;
 use tracing::{debug, error, trace, warn, warn_span, Span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
@@ -43,7 +42,7 @@ impl CommandDiscovery {
             )?);
         }
         pb_span.pb_set_message("Searching for resources");
-        let pb_span_enter = pb_span.enter();
+        let _ = pb_span.enter();
 
         let mut resources: BTreeMap<String, DscResource> = BTreeMap::new();
         let mut adapter_resources: Vec<String> = Vec::new();
@@ -144,7 +143,7 @@ impl CommandDiscovery {
                 "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.white}"
             )?);
             pb_adapter_span.pb_set_message(format!("Enumerating resources for adapter {adapter}").as_str());
-            let pb_adapter_enter = pb_adapter_span.enter();
+            let _ = pb_adapter_span.enter();
             let adapter_resource = resources.get(&adapter).unwrap();
             let adapter_type_name = adapter_resource.type_name.clone();
             let manifest = import_manifest(adapter_resource.manifest.clone().unwrap())?;
@@ -215,13 +214,9 @@ impl CommandDiscovery {
                     }
                 };
             }
-            mem::drop(pb_adapter_enter);
-            mem::drop(pb_adapter_span);
 
             debug!("Adapter '{}' listed {} matching resources", adapter_type_name, adapter_resources_count);
         }
-        mem::drop(pb_span_enter);
-        mem::drop(pb_span);
         Ok(resources)
     }
 }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -32,19 +32,18 @@ impl CommandDiscovery {
         debug!("Searching for resources: {:?}", required_resource_types);
         let return_all_resources = required_resource_types.len() == 1 && required_resource_types[0] == "*";
 
-        let header_span = warn_span!("header");
+        let pb_span = warn_span!("progress bar");
         if return_all_resources {
-            debug!("returning all resources");
-            header_span.pb_set_style(&ProgressStyle::with_template(
+            pb_span.pb_set_style(&ProgressStyle::with_template(
                 "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.yellow}"
             )?);
         } else {
-            header_span.pb_set_style(&ProgressStyle::with_template(
+            pb_span.pb_set_style(&ProgressStyle::with_template(
                 "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
             )?);
         }
-        header_span.pb_set_message("Searching for resources");
-        let header_span_enter = header_span.enter();
+        pb_span.pb_set_message("Searching for resources");
+        let pb_span_enter = pb_span.enter();
 
         let mut resources: BTreeMap<String, DscResource> = BTreeMap::new();
         let mut adapter_resources: Vec<String> = Vec::new();
@@ -221,8 +220,8 @@ impl CommandDiscovery {
 
             debug!("Adapter '{}' listed {} matching resources", adapter_type_name, adapter_resources_count);
         }
-        mem::drop(header_span_enter);
-        mem::drop(header_span);
+        mem::drop(pb_span_enter);
+        mem::drop(pb_span);
         Ok(resources)
     }
 }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -32,7 +32,7 @@ impl CommandDiscovery {
         debug!("Searching for resources: {:?}", required_resource_types);
         let return_all_resources = required_resource_types.len() == 1 && required_resource_types[0] == "*";
 
-        let pb_span = warn_span!("progress bar");
+        let pb_span = warn_span!("");
         if return_all_resources {
             pb_span.pb_set_style(&ProgressStyle::with_template(
                 "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.yellow}"
@@ -139,7 +139,7 @@ impl CommandDiscovery {
         // now go through the adapter resources and add them to the list of resources
         for adapter in adapter_resources {
             debug!("Enumerating resources for adapter {}", adapter);
-            let pb_adapter_span = warn_span!("adapter");
+            let pb_adapter_span = warn_span!("");
             pb_adapter_span.pb_set_style(&ProgressStyle::with_template(
                 "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.white}"
             )?);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- readdress #337 
- uses `warn_span` for progress bars since that is the default tracing level and can be turned off by specifying `error` trace level
- no longer displays progress bars once progress is completed, so `done` messages are removed
<!-- Summarize your PR between here and the checklist. -->

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
- `dsc resource list` demo:

https://github.com/PowerShell/DSC/assets/14894321/c98ad0d2-6581-4f88-a593-f3379132317b

- `dsc config get` demo:

https://github.com/PowerShell/DSC/assets/14894321/82948b41-dc58-45f8-aee5-798182ee04d2




