### PR TITLE
Rename `requires` in DscResource schema to `requireAdapter`

### DIFF
--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -22,7 +22,7 @@ pub fn get(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
-    if let Some(requires) = &resource.requires {
+    if let Some(requires) = &resource.require_adapter {
         input = add_type_name_to_json(input, resource.type_name.clone());
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
@@ -59,7 +59,7 @@ pub fn get_all(dsc: &DscManager, resource_type: &str, format: &Option<OutputForm
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
-    if let Some(requires) = &resource.requires {
+    if let Some(requires) = &resource.require_adapter {
         input = add_type_name_to_json(input, resource.type_name.clone());
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
@@ -113,7 +113,7 @@ pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
 
-    if let Some(requires) = &resource.requires {
+    if let Some(requires) = &resource.require_adapter {
         input = add_type_name_to_json(input, resource.type_name.clone());
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
@@ -156,7 +156,7 @@ pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: &O
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
 
-    if let Some(requires) = &resource.requires {
+    if let Some(requires) = &resource.require_adapter {
         input = add_type_name_to_json(input, resource.type_name.clone());
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
@@ -217,7 +217,7 @@ pub fn export(dsc: &mut DscManager, resource_type: &str, format: &Option<OutputF
     };
 
     let mut adapter_resource: Option<&DscResource> = None;
-    if let Some(requires) = &dsc_resource.requires {
+    if let Some(requires) = &dsc_resource.require_adapter {
         input = add_type_name_to_json(input, dsc_resource.type_name.clone());
         if let Some(pr) = get_resource(dsc, requires) {
             adapter_resource = Some(pr);

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -455,7 +455,7 @@ pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
                         format!("{:?}", resource.kind),
                         resource.version,
                         capabilities,
-                        resource.requires.unwrap_or_default(),
+                        resource.require_adapter.unwrap_or_default(),
                         resource.description.unwrap_or_default()
                     ]);
                 }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -182,7 +182,7 @@ impl CommandDiscovery {
             for line in stdout.lines() {
                 match serde_json::from_str::<DscResource>(line){
                     Result::Ok(resource) => {
-                        if resource.requires.is_none() {
+                        if resource.require_adapter.is_none() {
                             if return_all_resources {
                                 warn!("{}", DscError::MissingRequires(adapter.clone(), resource.type_name.clone()).to_string());
                             } else {

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -36,7 +36,8 @@ pub struct DscResource {
     /// The properties of the resource.
     pub properties: Vec<String>,
     /// The required resource adapter for the resource.
-    pub requires: Option<String>,
+    #[serde(rename="requireAdapter")]
+    pub require_adapter: Option<String>,
     /// The manifest of the resource.
     pub manifest: Option<Value>,
 }
@@ -72,7 +73,7 @@ impl DscResource {
             implemented_as: ImplementedAs::Command,
             author: None,
             properties: Vec::new(),
-            requires: None,
+            require_adapter: None,
             manifest: None,
         }
     }

--- a/powershell-adapter/powershell.resource.ps1
+++ b/powershell-adapter/powershell.resource.ps1
@@ -136,7 +136,7 @@ if ($Operation -eq 'List')
             implementedAs = $r.ImplementationDetail;
             author = $author_string;
             properties = $propertyList;
-            requires = $requiresString
+            requireAdapter = $requiresString
         }
 
         $z | ConvertTo-Json -Compress

--- a/tools/test_group_resource/src/main.rs
+++ b/tools/test_group_resource/src/main.rs
@@ -23,7 +23,7 @@ fn main() {
                 directory: "test_directory".to_string(),
                 author: Some("Microsoft".to_string()),
                 properties: vec!["Property1".to_string(), "Property2".to_string()],
-                requires: Some("Test/TestGroup".to_string()),
+                require_adapter: Some("Test/TestGroup".to_string()),
                 manifest: Some(serde_json::to_value(ResourceManifest {
                     description: Some("This is a test resource.".to_string()),
                     schema_version: dsc_lib::dscresources::resource_manifest::ManifestSchemaUri::Version2023_10,
@@ -56,7 +56,7 @@ fn main() {
                 directory: "test_directory".to_string(),
                 author: Some("Microsoft".to_string()),
                 properties: vec!["Property1".to_string(), "Property2".to_string()],
-                requires: Some("Test/TestGroup".to_string()),
+                require_adapter: Some("Test/TestGroup".to_string()),
                 manifest: Some(serde_json::to_value(ResourceManifest {
                     description: Some("This is a test resource.".to_string()),
                     schema_version: dsc_lib::dscresources::resource_manifest::ManifestSchemaUri::Version2023_10,
@@ -93,7 +93,7 @@ fn main() {
                 directory: "test_directory".to_string(),
                 author: Some("Microsoft".to_string()),
                 properties: vec!["Property1".to_string(), "Property2".to_string()],
-                requires: None,
+                require_adapter: None,
                 manifest: None,
             };
             println!("{}", serde_json::to_string(&resource1).unwrap());

--- a/tools/test_group_resource/tests/provider.tests.ps1
+++ b/tools/test_group_resource/tests/provider.tests.ps1
@@ -11,15 +11,15 @@ Describe 'Resource adapter tests' {
         $out[0].version | Should -Be '1.0.0'
         $out[0].path | Should -BeExactly 'test_resource1'
         $out[0].implementedas | Should -BeExactly 'TestResource'
-        $out[0].requires | Should -BeExactly 'Test/TestGroup'
+        $out[0].requireAdapter | Should -BeExactly 'Test/TestGroup'
         $out[1].type | Should -BeExactly 'Test/TestResource2'
         $out[1].version | Should -Be '1.0.1'
         $out[1].path | Should -BeExactly 'test_resource2'
         $out[1].implementedas | Should -BeExactly 'TestResource'
-        $out[1].requires | Should -BeExactly 'Test/TestGroup'
+        $out[1].requireAdapter | Should -BeExactly 'Test/TestGroup'
     }
 
-    It 'Error if adapter resource is missing "requires" member' {
+    It 'Error if adapter resource is missing "requireAdapter" member' {
         $invalid_manifest = @'
         {
             "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",

--- a/wmi-adapter/wmi.resource.ps1
+++ b/wmi-adapter/wmi.resource.ps1
@@ -55,7 +55,7 @@ if ($Operation -eq 'List')
             implementedAs = "";
             author = $author_string;
             properties = $propertyList;
-            requires = $requiresString
+            requireAdapter = $requiresString
         }
 
         $z | ConvertTo-Json -Compress


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Rename the `requires` member in DscResource to `requireAdapter` to align with naming and making it more clear

## PR Context

Fix https://github.com/PowerShell/DSC/issues/100