### PR TITLE
add better error if path is accidentally passed to `-d`

### DIFF
--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -367,11 +367,17 @@ pub fn parse_input_to_json(value: &str) -> String {
 pub fn get_input(input: &Option<String>, stdin: &Option<String>, path: &Option<String>) -> String {
     let value = match (input, stdin, path) {
         (Some(_), Some(_), None) | (None, Some(_), Some(_)) => {
-            error!("Error: Cannot specify both stdin and --input or --path");
+            error!("Error: Cannot specify both stdin and --document or --path");
             exit(EXIT_INVALID_ARGS);
         },
         (Some(input), None, None) => {
             debug!("Reading input from command line parameter");
+
+            // see if user accidentally passed in a file path
+            if Path::new(input).exists() {
+                error!("Error: Document provided is a file path, use --path instead");
+                exit(EXIT_INVALID_INPUT);
+            }
             input.clone()
         },
         (None, Some(stdin), None) => {
@@ -413,7 +419,7 @@ pub fn get_input(input: &Option<String>, stdin: &Option<String>, path: &Option<S
 ///
 /// # Arguments
 ///
-/// * `config_path` - Full path to the config file 
+/// * `config_path` - Full path to the config file
 ///
 /// # Returns
 ///
@@ -428,14 +434,14 @@ pub fn set_dscconfigroot(config_path: &str) -> String
             exit(EXIT_DSC_ERROR);
     };
 
-    let Some(config_root_path) = full_path.parent() else { 
+    let Some(config_root_path) = full_path.parent() else {
         // this should never happen because path was absolutized
         error!("Error reading config path parent");
         exit(EXIT_DSC_ERROR);
     };
 
     let env_var = "DSC_CONFIG_ROOT";
-    
+
     // warn if env var is already set/used
     if env::var(env_var).is_ok() {
         warn!("The current value of '{env_var}' env var will be overridden");

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -271,4 +271,10 @@ resources:
         $r.requireAdapter.StartsWith("Test") | Should -Be $true
         $r.kind | Should -Be "Resource"
     }
+
+    It 'passing filepath to document arg should error' {
+        $configFile = Resolve-Path $PSScriptRoot/../examples/osinfo.dsc.json
+        $stderr = dsc config get -d $configFile 2>&1
+        $stderr | Should -Match '.*?--path.*?'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Give a better specific error message if user accidentally uses filepath with `--document` parameter

## PR Context

Fix https://github.com/PowerShell/DSC/issues/297