### PR TITLE
Update engine to call `delete` for resources that don't support `_exist` directly

### DIFF
--- a/dsc/tests/dsc_config_set.tests.ps1
+++ b/dsc/tests/dsc_config_set.tests.ps1
@@ -18,7 +18,6 @@ Describe 'dsc config get tests' {
         $out = $config_yaml | dsc config set | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].type | Should -BeExactly 'Test/Exist'
-        $out.results[0].result.beforeState.state | Should -BeExactly 'Absent'
         $out.results[0].result.beforeState._exist | Should -BeFalse
         $out.results[0].result.afterState.state | Should -BeExactly 'Absent'
         $out.results[0].result.afterState._exist | Should -BeFalse

--- a/dsc/tests/dsc_config_set.tests.ps1
+++ b/dsc/tests/dsc_config_set.tests.ps1
@@ -1,0 +1,31 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'dsc config get tests' {
+    It 'can use _exist with resources that support and do not support it' {
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json
+            resources:
+            - name: Exist
+              type: Test/Exist
+              properties:
+                _exist: false
+            - name: Delete
+              type: Test/Delete
+              properties:
+                _exist: false
+"@
+        $out = $config_yaml | dsc config set | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].type | Should -BeExactly 'Test/Exist'
+        $out.results[0].result.beforeState.state | Should -BeExactly 'Absent'
+        $out.results[0].result.beforeState._exist | Should -BeFalse
+        $out.results[0].result.afterState.state | Should -BeExactly 'Absent'
+        $out.results[0].result.afterState._exist | Should -BeFalse
+        $out.results[1].type | Should -BeExactly 'Test/Delete'
+        $out.results[1].result.beforeState.deleteCalled | Should -BeTrue
+        $out.results[1].result.beforeState._exist | Should -BeFalse
+        $out.results[1].result.afterState.deleteCalled | Should -BeTrue
+        $out.results[1].result.afterState._exist | Should -BeFalse
+    }
+}

--- a/dsc/tests/dsc_config_set.tests.ps1
+++ b/dsc/tests/dsc_config_set.tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'dsc config get tests' {
+Describe 'dsc config set tests' {
     It 'can use _exist with resources that support and do not support it' {
         $config_yaml = @"
             `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/10/config/document.json

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -316,9 +316,8 @@ impl Configurator {
                 // convert get result to set result                
                 let set_result = match before_result {
                     GetResult::Resource(before_response) => {
-                        let after_result = match after_result {
-                            GetResult::Resource(get_response) => get_response,
-                            _ => return Err(DscError::NotSupported("Group resources not supported for delete".to_string())),
+                        let GetResult::Resource(after_result) = after_result else { 
+                            return Err(DscError::NotSupported("Group resources not supported for delete".to_string()))
                         };
                         let before_value = serde_json::to_value(&before_response.actual_state)?;
                         let after_value = serde_json::to_value(&after_result.actual_state)?;

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -3,7 +3,9 @@
 
 use crate::configure::parameters::Input;
 use crate::dscerror::DscError;
-use crate::dscresources::dscresource::Invoke;
+use crate::dscresources::dscresource::get_diff;
+use crate::dscresources::invoke_result::GetResult;
+use crate::dscresources::{dscresource::{Capability, Invoke}, invoke_result::{SetResult, ResourceSetResponse}};
 use crate::dscresources::resource_manifest::Kind;
 use crate::DscResource;
 use crate::discovery::Discovery;
@@ -278,16 +280,68 @@ impl Configurator {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
             debug!("resource_type {}", &resource.resource_type);
+
+            // see if the properties contains `_exist` and is false
+            let exist = match &properties {
+                Some(property_map) => {
+                    if let Some(exist) = property_map.get("_exist") {
+                        !matches!(exist, Value::Bool(false))
+                    } else {
+                        true
+                    }
+                },
+                _ => {
+                    true
+                }
+            };
+
             let desired = add_metadata(&dsc_resource.kind, properties)?;
             trace!("desired: {desired}");
-            let set_result = dsc_resource.set(&desired, skip_test)?;
-            self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&set_result)?);
-            let resource_result = config_result::ResourceSetResult {
-                name: resource.name.clone(),
-                resource_type: resource.resource_type.clone(),
-                result: set_result,
-            };
-            result.results.push(resource_result);
+
+            if exist || dsc_resource.capabilities.contains(&Capability::SetHandlesExist) {
+                debug!("Resource handles _exist or _exist is true");
+                let set_result = dsc_resource.set(&desired, skip_test)?;
+                self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&set_result)?);
+                let resource_result = config_result::ResourceSetResult {
+                    name: resource.name.clone(),
+                    resource_type: resource.resource_type.clone(),
+                    result: set_result,
+                };
+                result.results.push(resource_result);    
+            } else if dsc_resource.capabilities.contains(&Capability::Delete) {
+                debug!("Resource implements delete and _exist is false");
+                let before_result = dsc_resource.get(&desired)?;
+                dsc_resource.delete(&desired)?;
+                let after_result = dsc_resource.get(&desired)?;
+                // convert get result to set result                
+                let set_result = match before_result {
+                    GetResult::Resource(before_response) => {
+                        let after_result = match after_result {
+                            GetResult::Resource(get_response) => get_response,
+                            _ => return Err(DscError::NotSupported("Group resources not supported for delete".to_string())),
+                        };
+                        let before_value = serde_json::to_value(&before_response.actual_state)?;
+                        let after_value = serde_json::to_value(&after_result.actual_state)?;
+                        ResourceSetResponse {
+                            before_state: before_response.actual_state,
+                            after_state: after_result.actual_state,
+                            changed_properties: Some(get_diff(&before_value, &after_value)),
+                        }
+                    },
+                    GetResult::Group(_) => {
+                        return Err(DscError::NotSupported("Group resources not supported for delete".to_string()));
+                    },
+                };
+                self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&set_result)?);
+                let resource_result = config_result::ResourceSetResult {
+                    name: resource.name.clone(),
+                    resource_type: resource.resource_type.clone(),
+                    result: SetResult::Resource(set_result),
+                };
+                result.results.push(resource_result);
+            } else {
+                return Err(DscError::NotImplemented(format!("Resource '{}' does not support `delete` and does not handle `_exist` as false", resource.resource_type)));
+            }
         }
 
         mem::drop(pb_span_enter);

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -71,6 +71,9 @@ pub enum DscError {
     #[error("Not implemented: {0}")]
     NotImplemented(String),
 
+    #[error("Not supported: {0}")]
+    NotSupported(String),
+
     #[error("Number conversion error: {0}")]
     NumberConversion(#[from] std::num::TryFromIntError),
 

--- a/registry/registry.dsc.resource.json
+++ b/registry/registry.dsc.resource.json
@@ -34,7 +34,7 @@
         "executable": "registry",
         "args": [
             "config",
-            "remove",
+            "delete",
             "--input",
             "{json}"
         ],

--- a/tools/dsctest/dscdelete.dsc.resource.json
+++ b/tools/dsctest/dscdelete.dsc.resource.json
@@ -1,11 +1,11 @@
 {
     "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/bundled/resource/manifest.json",
-    "type": "Test/Exist",
+    "type": "Test/Delete",
     "version": "0.1.0",
     "get": {
         "executable": "dsctest",
         "args": [
-            "exist",
+            "delete",
             "--input",
             "{json}"
         ],
@@ -13,19 +13,16 @@
             "arg": "{json}"
         }
     },
-    "set": {
+    "delete": {
         "executable": "dsctest",
         "args": [
-            "exist",
+            "delete",
             "--input",
             "{json}"
         ],
         "input": {
             "arg": "{json}"
-        },
-        "handlesExist": true,
-        "implementsPretest": true,
-        "return": "state"
+        }
     },
     "schema": {
         "command": {
@@ -33,7 +30,7 @@
             "args": [
                 "schema",
                 "-s",
-                "exist"
+                "delete"
             ]
         }
     }

--- a/tools/dsctest/dscexist.dsc.resource.json
+++ b/tools/dsctest/dscexist.dsc.resource.json
@@ -24,7 +24,6 @@
             "arg": "{json}"
         },
         "handlesExist": true,
-        "implementsPretest": true,
         "return": "state"
     },
     "schema": {

--- a/tools/dsctest/src/args.rs
+++ b/tools/dsctest/src/args.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum Schemas {
+    Delete,
     Echo,
     Exist,
     Sleep,
@@ -20,9 +21,21 @@ pub struct Args {
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]
 pub enum SubCommand {
+    #[clap(name = "delete", about = "delete operation")]
+    Delete {
+        #[clap(name = "input", short, long, help = "The input to the delete command as JSON")]
+        input: String,
+    },
+
     #[clap(name = "echo", about = "Return the input")]
     Echo {
         #[clap(name = "input", short, long, help = "The input to the echo command as JSON")]
+        input: String,
+    },
+
+    #[clap(name = "exist", about = "Check if a resource exists")]
+    Exist {
+        #[clap(name = "input", short, long, help = "The input to the exist command as JSON")]
         input: String,
     },
 
@@ -35,12 +48,6 @@ pub enum SubCommand {
     #[clap(name = "sleep", about = "Sleep for a specified number of seconds")]
     Sleep {
         #[clap(name = "input", short, long, help = "The input to the sleep command as JSON")]
-        input: String,
-    },
-
-    #[clap(name = "exist", about = "Check if a resource exists")]
-    Exist {
-        #[clap(name = "input", short, long, help = "The input to the exist command as JSON")]
         input: String,
     },
 }

--- a/tools/dsctest/src/delete.rs
+++ b/tools/dsctest/src/delete.rs
@@ -1,0 +1,14 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Delete {
+    #[serde(rename = "deleteCalled", skip_serializing_if = "Option::is_none")]
+    pub delete_called: Option<bool>,
+    #[serde(rename = "_exist")]
+    pub exist: bool,
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- A configuration set operation will now call `delete` on a resource (if it supports it) if `_exist = false` is one of the properties and the resource doesn't have the `SetHandlesExist` capability.
- If the resource has the `SetHandlesExist` capability, then it will get the raw properties
- Updated `Test/Exist` resource to better validate case that `_exist` is passed through
- Added `Test/Delete` resource to validate `delete` gets called
- Group/Adapter resources are not supported for the `delete` path as all resources would need to support `delete` (you'll get an error message if the resource returns a group response).
- Since `delete` is a synthetic `set` with `_exist`, had to write code to convert the `get` response into a `set` response
- Added synthetic `test` during configuration `set` operation if the resource doesn't directly implement it

## PR Context

Fix https://github.com/PowerShell/DSC/issues/290