### PR TITLE
improve `no schema` error message

### DIFF
--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -89,7 +89,7 @@ pub enum DscError {
     #[error("Schema: {0}")]
     Schema(String),
 
-    #[error("No Schema: {0}")]
+    #[error("No Schema found and `validate` is not supported: {0}")]
     SchemaNotAvailable(String),
 
     #[error("Security context: {0}")]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

If a resource or adapter doesn't return JSON schema you get a pretty unhelpful error message for the resource author as `validate` could also be implemented if JSON schema validation isn't supported.  Added this to the error message.
