### PR TITLE
Only emit source information for trace level `debug` and `trace`

### DIFF
--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -272,26 +272,30 @@ pub fn enable_tracing(trace_level: &TraceLevel, trace_format: &TraceFormat) {
         .add_directive(tracing_level.into());
     let indicatif_layer = IndicatifLayer::new();
     let layer = tracing_subscriber::fmt::Layer::default().with_writer(indicatif_layer.get_stderr_writer());
+    let with_source = tracing_level == Level::DEBUG || tracing_level == Level::TRACE;
     let fmt = match trace_format {
         TraceFormat::Default => {
             layer
                 .with_ansi(true)
                 .with_level(true)
-                .with_line_number(true)
+                .with_target(with_source)
+                .with_line_number(with_source)
                 .boxed()
         },
         TraceFormat::Plaintext => {
             layer
                 .with_ansi(false)
                 .with_level(true)
-                .with_line_number(false)
+                .with_target(with_source)
+                .with_line_number(with_source)
                 .boxed()
         },
         TraceFormat::Json => {
             layer
                 .with_ansi(false)
                 .with_level(true)
-                .with_line_number(true)
+                .with_target(with_source)
+                .with_line_number(with_source)
                 .json()
                 .boxed()
         }

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -7,7 +7,7 @@ Describe 'tracing tests' {
         # @{ level = 'WARNING' } TODO: currently no warnings are emitted
         @{ level = 'info' }
         @{ level = 'debug' }
-        # @{ level = 'trace' } TODO: currently no trace is emitted
+        @{ level = 'trace' }
     ) {
         param($level)
 
@@ -42,6 +42,25 @@ Describe 'tracing tests' {
             $trace.timestamp | Should -Not -BeNullOrEmpty
             $trace.level | Should -BeIn 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE'
             $trace.fields.message | Should -Not -BeNullOrEmpty
+        }
+    }
+
+    It 'trace level <level> emits source info: <sourceExpected>' -TestCases @(
+        @{ level = 'error'; sourceExpected = $false }
+        @{ level = 'warning'; sourceExpected = $false }
+        @{ level = 'info'; sourceExpected = $false }
+        @{ level = 'debug'; sourceExpected = $true }
+        @{ level = 'trace'; sourceExpected = $true }
+    ) {
+        param($level, $sourceExpected)
+
+        $logPath = "$TestDrive/dsc_trace.log"
+        $null = '{}' | dsc -l $level resource get -r 'DoesNotExist' 2> $logPath
+        $log = Get-Content $logPath -Raw
+        if ($sourceExpected) {
+            $log | Should -BeLike "*dsc*: *"
+        } else {
+            $log | Should -Not -BeLike "*dsc*: *"
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There's no reason to emit source code information unless trace level is `debug` or `trace` as the other levels are primarily used by end users and the source information takes up unnecessary space that isn't meaningful to them.
`with_target()` is the source file.