### PR TITLE
(MAINT) Skip builds on docs-only PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,10 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+    paths-ignore:
+      - "docs/**"
+      - "*.md"
+      - ".vscode/*.json"
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
# PR Summary

This change uses the [`paths-ignore`][01] property for the GitHub workflow pull requests trigger to skip the lengthy build process for PRs that only modify documentation or VS Code configuration, neither of which affect the code-building.

## PR Context

This should enable faster feedback cycles for pull requests that don't affect the build, as the build workflow can take 15-20m each time.