### PR TITLE
add metadata to configuration result output

### DIFF
--- a/dsc/examples/require_admin.yaml
+++ b/dsc/examples/require_admin.yaml
@@ -4,7 +4,7 @@
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   Microsoft.DSC:
-    requiredSecurityContext: Elevated
+    securityContext: Elevated
 resources:
 - name: os
   type: Microsoft/OSInfo

--- a/dsc/examples/require_nonadmin.yaml
+++ b/dsc/examples/require_nonadmin.yaml
@@ -3,7 +3,7 @@
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
 metadata:
   Microsoft.DSC:
-    requiredSecurityContext: Restricted
+    securityContext: Restricted
 resources:
 - name: os
   type: Microsoft/OSInfo

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -41,7 +41,19 @@ Describe 'dsc config get tests' {
               properties:
                 output: hello
 "@
-        $null = $config_yaml | dsc config get --format pretty-json | Out-String
+        $result = $config_yaml | dsc config get --format pretty-json | ConvertFrom-Json
+        $result.hadErrors | Should -BeFalse
+        $result.results.Count | Should -Be 1
+        $result.results[0].Name | Should -Be 'Echo'
+        $result.results[0].type | Should -BeExactly 'Test/Echo'
+        $result.results[0].result.actualState.output | Should -Be 'hello'
+        $result.metadata.'Microsoft.DSC'.version | Should -BeLike '3.*'
+        $result.metadata.'Microsoft.DSC'.operation | Should -BeExactly 'Get'
+        $result.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'Actual'
+        $result.metadata.'Microsoft.DSC'.startDatetime | Should -Not -BeNullOrEmpty
+        $result.metadata.'Microsoft.DSC'.endDatetime | Should -Not -BeNullOrEmpty
+        $result.metadata.'Microsoft.DSC'.duration | Should -Not -BeNullOrEmpty
+        $result.metadata.'Microsoft.DSC'.securityContext | Should -BeExactly 'Restricted'
         $LASTEXITCODE | Should -Be 0
     }
 }

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -53,7 +53,7 @@ Describe 'dsc config get tests' {
         $result.metadata.'Microsoft.DSC'.startDatetime | Should -Not -BeNullOrEmpty
         $result.metadata.'Microsoft.DSC'.endDatetime | Should -Not -BeNullOrEmpty
         $result.metadata.'Microsoft.DSC'.duration | Should -Not -BeNullOrEmpty
-        $result.metadata.'Microsoft.DSC'.securityContext | Should -BeExactly 'Restricted'
+        $result.metadata.'Microsoft.DSC'.securityContext | Should -Not -BeNullOrEmpty
         $LASTEXITCODE | Should -Be 0
     }
 }

--- a/dsc/tests/dsc_config_set.tests.ps1
+++ b/dsc/tests/dsc_config_set.tests.ps1
@@ -17,6 +17,8 @@ Describe 'dsc config set tests' {
 "@
         $out = $config_yaml | dsc config set | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
+        $out.hadErrors | Should -BeFalse
+        $out.results.Count | Should -Be 2
         $out.results[0].type | Should -BeExactly 'Test/Exist'
         $out.results[0].result.beforeState._exist | Should -BeFalse
         $out.results[0].result.afterState.state | Should -BeExactly 'Absent'
@@ -26,5 +28,13 @@ Describe 'dsc config set tests' {
         $out.results[1].result.beforeState._exist | Should -BeFalse
         $out.results[1].result.afterState.deleteCalled | Should -BeTrue
         $out.results[1].result.afterState._exist | Should -BeFalse
+        $out.metadata.'Microsoft.DSC'.version | Should -BeLike '3.*'
+        $out.metadata.'Microsoft.DSC'.operation | Should -BeExactly 'Set'
+        $out.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'Actual'
+        $out.metadata.'Microsoft.DSC'.startDatetime | Should -Not -BeNullOrEmpty
+        $out.metadata.'Microsoft.DSC'.endDatetime | Should -Not -BeNullOrEmpty
+        $out.metadata.'Microsoft.DSC'.duration | Should -Not -BeNullOrEmpty
+        $out.metadata.'Microsoft.DSC'.securityContext | Should -BeExactly 'Restricted'
+
     }
 }

--- a/dsc/tests/dsc_config_set.tests.ps1
+++ b/dsc/tests/dsc_config_set.tests.ps1
@@ -34,7 +34,7 @@ Describe 'dsc config set tests' {
         $out.metadata.'Microsoft.DSC'.startDatetime | Should -Not -BeNullOrEmpty
         $out.metadata.'Microsoft.DSC'.endDatetime | Should -Not -BeNullOrEmpty
         $out.metadata.'Microsoft.DSC'.duration | Should -Not -BeNullOrEmpty
-        $out.metadata.'Microsoft.DSC'.securityContext | Should -BeExactly 'Restricted'
+        $out.metadata.'Microsoft.DSC'.securityContext | Should -Not -BeNullOrEmpty
 
     }
 }

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -38,6 +38,7 @@ Describe 'resource export tests' {
         $config_with_process_list.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json'
         $config_with_process_list.'resources' | Should -Not -BeNullOrEmpty
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
+        $config_with_process_list.metadata.'Microsoft.DSC'.operation | Should -BeExactly 'Export'
     }
 
     It 'Configuration Export can be piped to configuration Set' -Skip:(!$IsWindows) {

--- a/dsc/tests/dsc_group.tests.ps1
+++ b/dsc/tests/dsc_group.tests.ps1
@@ -18,14 +18,12 @@ metadata:
 results:
 - metadata:
     Microsoft.DSC:
-      version: 0.1.0
       duration: *
   name: First Group
   type: Microsoft.DSC/Group
   result:
   - metadata:
       Microsoft.DSC:
-        version: 0.1.0
         duration: *
     name: First
     type: Test/Echo
@@ -34,14 +32,12 @@ results:
         output: First
   - metadata:
       Microsoft.DSC:
-        version: 0.1.0
         duration: *
     name: Nested Group
     type: Microsoft.DSC/Group
     result:
     - metadata:
         Microsoft.DSC:
-          version: 0.1.0
           duration: *
       name: Nested First
       type: Test/Echo
@@ -50,7 +46,6 @@ results:
           output: Nested First
     - metadata:
         Microsoft.DSC:
-          version: 0.1.0
           duration: *
       name: Nested Second
       type: Test/Echo
@@ -59,14 +54,12 @@ results:
           output: Nested Second
 - metadata:
     Microsoft.DSC:
-      version: 0.1.0
       duration: *
   name: Last Group
   type: Microsoft.DSC/Group
   result:
   - metadata:
       Microsoft.DSC:
-        version: 0.1.0
         duration: *
     name: Last
     type: Test/Echo

--- a/dsc/tests/dsc_group.tests.ps1
+++ b/dsc/tests/dsc_group.tests.ps1
@@ -14,7 +14,7 @@ metadata:
     startDatetime: *
     endDatetime: *
     duration: PT*S
-    securityContext: Restricted
+    securityContext: *
 results:
 - name: First Group
   type: Microsoft.DSC/Group

--- a/dsc/tests/dsc_group.tests.ps1
+++ b/dsc/tests/dsc_group.tests.ps1
@@ -5,7 +5,16 @@ Describe 'Group resource tests' {
     It 'Nested groups should work for get' {
         $out = (dsc config get -p $PSScriptRoot/../examples/groups.dsc.yaml -f yaml | Out-String).Trim()
         $LASTEXITCODE | Should -Be 0
-        $out | Should -BeExactly @'
+        $out | Should -BeLike @'
+metadata:
+  Microsoft.DSC:
+    version: 3*
+    operation: Get
+    executionType: Actual
+    startDatetime: *
+    endDatetime: *
+    duration: PT*S
+    securityContext: Restricted
 results:
 - name: First Group
   type: Microsoft.DSC/Group
@@ -36,7 +45,7 @@ results:
     result:
       actualState:
         output: Last
-messages: []
+messages: `[`]
 hadErrors: false
 '@
     }

--- a/dsc/tests/dsc_group.tests.ps1
+++ b/dsc/tests/dsc_group.tests.ps1
@@ -16,31 +16,59 @@ metadata:
     duration: PT*S
     securityContext: *
 results:
-- name: First Group
+- metadata:
+    Microsoft.DSC:
+      version: 0.1.0
+      duration: *
+  name: First Group
   type: Microsoft.DSC/Group
   result:
-  - name: First
+  - metadata:
+      Microsoft.DSC:
+        version: 0.1.0
+        duration: *
+    name: First
     type: Test/Echo
     result:
       actualState:
         output: First
-  - name: Nested Group
+  - metadata:
+      Microsoft.DSC:
+        version: 0.1.0
+        duration: *
+    name: Nested Group
     type: Microsoft.DSC/Group
     result:
-    - name: Nested First
+    - metadata:
+        Microsoft.DSC:
+          version: 0.1.0
+          duration: *
+      name: Nested First
       type: Test/Echo
       result:
         actualState:
           output: Nested First
-    - name: Nested Second
+    - metadata:
+        Microsoft.DSC:
+          version: 0.1.0
+          duration: *
+      name: Nested Second
       type: Test/Echo
       result:
         actualState:
           output: Nested Second
-- name: Last Group
+- metadata:
+    Microsoft.DSC:
+      version: 0.1.0
+      duration: *
+  name: Last Group
   type: Microsoft.DSC/Group
   result:
-  - name: Last
+  - metadata:
+      Microsoft.DSC:
+        version: 0.1.0
+        duration: *
+    name: Last
     type: Test/Echo
     result:
       actualState:

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 base64 = "0.22"
-chrono = "0.4.26"
+chrono = { version = "0.4.26" }
 derive_builder ="0.20"
 indicatif = { version = "0.17" }
 jsonschema = "0.17"

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -61,6 +61,21 @@ pub struct MicrosoftDscMetadata {
     pub context: Option<ContextKind>,
 }
 
+impl Default for MicrosoftDscMetadata {
+    fn default() -> Self {
+        Self {
+            version: None,
+            operation: None,
+            execution_type: None,
+            start_datetime: None,
+            end_datetime: None,
+            duration: None,
+            security_context: None,
+            context: None,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct Metadata {
     #[serde(rename = "Microsoft.DSC", skip_serializing_if = "Option::is_none")]

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -6,6 +6,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
+use super::config_result::ResultMetadata;
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum ContextKind {
     Configuration,
@@ -28,6 +30,13 @@ pub struct MicrosoftDscMetadata {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum MicrosoftMetadata {
+    DscInput(Metadata),
+    DscResult(ResultMetadata),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct Metadata {
     #[serde(rename = "Microsoft.DSC", skip_serializing_if = "Option::is_none")]
     pub microsoft: Option<MicrosoftDscMetadata>,
@@ -45,7 +54,7 @@ pub struct Configuration {
     pub variables: Option<HashMap<String, Value>>,
     pub resources: Vec<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<Metadata>,
+    pub metadata: Option<MicrosoftMetadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -33,7 +33,7 @@ pub enum ExecutionKind {
     WhatIf,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct MicrosoftDscMetadata {
     /// Version of DSC
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -59,21 +59,6 @@ pub struct MicrosoftDscMetadata {
     /// Identifies if the operation is part of a configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<ContextKind>,
-}
-
-impl Default for MicrosoftDscMetadata {
-    fn default() -> Self {
-        Self {
-            version: None,
-            operation: None,
-            execution_type: None,
-            start_datetime: None,
-            end_datetime: None,
-            duration: None,
-            security_context: None,
-            context: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -6,8 +6,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::collections::HashMap;
 
-use super::config_result::ResultMetadata;
-
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum ContextKind {
     Configuration,
@@ -22,18 +20,45 @@ pub enum SecurityContextKind {
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub struct MicrosoftDscMetadata {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub context: Option<ContextKind>,
-    #[serde(rename = "requiredSecurityContext", skip_serializing_if = "Option::is_none")]
-    pub required_security_context: Option<SecurityContextKind>,
+pub enum Operation {
+    Get,
+    Set,
+    Test,
+    Export,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-#[serde(untagged)]
-pub enum MicrosoftMetadata {
-    DscInput(Metadata),
-    DscResult(ResultMetadata),
+pub enum ExecutionKind {
+    Actual,
+    WhatIf,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct MicrosoftDscMetadata {
+    /// Version of DSC
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    /// The operation being performed
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operation: Option<Operation>,
+    /// The type of execution
+    #[serde(rename = "executionType", skip_serializing_if = "Option::is_none")]
+    pub execution_type: Option<ExecutionKind>,
+    /// The start time of the configuration operation
+    #[serde(rename = "startDatetime", skip_serializing_if = "Option::is_none")]
+    pub start_datetime: Option<String>,
+    /// The end time of the configuration operation
+    #[serde(rename = "endDatetime", skip_serializing_if = "Option::is_none")]
+    pub end_datetime: Option<String>,
+    /// The duration of the configuration operation
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<String>,
+    /// The security context of the configuration operation, can be specified to be required
+    #[serde(rename = "securityContext", skip_serializing_if = "Option::is_none")]
+    pub security_context: Option<SecurityContextKind>,
+    /// Identifies if the operation is part of a configuration
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<ContextKind>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -54,7 +79,7 @@ pub struct Configuration {
     pub variables: Option<HashMap<String, Value>>,
     pub resources: Vec<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub metadata: Option<MicrosoftMetadata>,
+    pub metadata: Option<Metadata>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -26,6 +26,8 @@ pub struct ResourceMessage {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ResourceGetResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
     pub name: String,
     #[serde(rename="type")]
     pub resource_type: String,
@@ -35,6 +37,7 @@ pub struct ResourceGetResult {
 impl From<ResourceTestResult> for ResourceGetResult {
     fn from(test_result: ResourceTestResult) -> Self {
         Self {
+            metadata: None,
             name: test_result.name,
             resource_type: test_result.resource_type,
             result: test_result.result.into(),
@@ -88,6 +91,8 @@ impl From<ConfigurationTestResult> for ConfigurationGetResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ResourceSetResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
     pub name: String,
     #[serde(rename="type")]
     pub resource_type: String,
@@ -146,6 +151,8 @@ impl Default for ConfigurationSetResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ResourceTestResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Metadata>,
     pub name: String,
     #[serde(rename="type")]
     pub resource_type: String,

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -4,7 +4,9 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult};
-use crate::configure::config_doc;
+use crate::configure::config_doc::Configuration;
+
+use super::config_doc::SecurityContextKind;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum MessageLevel {
@@ -21,6 +23,41 @@ pub struct ResourceMessage {
     pub resource_type: String,
     pub message: String,
     pub level: MessageLevel,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum Operation {
+    Get,
+    Set,
+    Test,
+    Export,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum ExecutionKind {
+    Actual,
+    WhatIf,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct ResultMetadata {
+    #[serde(rename = "Microsoft.DSC")]
+    pub microsoft: MicrosoftDscResultMetadata,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct MicrosoftDscResultMetadata {
+    pub version: String,
+    pub operation: Operation,
+    #[serde(rename = "executionType")]
+    pub execution_type: ExecutionKind,
+    #[serde(rename = "startDatetime")]
+    pub start_datetime: String,
+    #[serde(rename = "endDatetime")]
+    pub end_datetime: String,
+    pub duration: String,
+    #[serde(rename = "securityContext")]
+    pub security_context: SecurityContextKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -45,6 +82,7 @@ impl From<ResourceTestResult> for ResourceGetResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationGetResult {
+    pub metadata: Option<ResultMetadata>,
     pub results: Vec<ResourceGetResult>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
@@ -55,6 +93,7 @@ impl ConfigurationGetResult {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            metadata: None,
             results: Vec::new(),
             messages: Vec::new(),
             had_errors: false,
@@ -75,6 +114,7 @@ impl From<ConfigurationTestResult> for ConfigurationGetResult {
             results.push(result.into());
         }
         Self {
+            metadata: None,
             results,
             messages: test_result.messages,
             had_errors: test_result.had_errors,
@@ -115,6 +155,7 @@ impl Default for GroupResourceSetResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationSetResult {
+    pub metadata: Option<ResultMetadata>,
     pub results: Vec<ResourceSetResult>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
@@ -125,6 +166,7 @@ impl ConfigurationSetResult {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            metadata: None,
             results: Vec::new(),
             messages: Vec::new(),
             had_errors: false,
@@ -171,6 +213,7 @@ impl Default for GroupResourceTestResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationTestResult {
+    pub metadata: Option<ResultMetadata>,
     pub results: Vec<ResourceTestResult>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
@@ -181,6 +224,7 @@ impl ConfigurationTestResult {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            metadata: None,
             results: Vec::new(),
             messages: Vec::new(),
             had_errors: false,
@@ -197,7 +241,8 @@ impl Default for ConfigurationTestResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationExportResult {
-    pub result: Option<config_doc::Configuration>,
+    pub metadata: Option<ResultMetadata>,
+    pub result: Option<Configuration>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
     pub had_errors: bool,
@@ -207,6 +252,7 @@ impl ConfigurationExportResult {
     #[must_use]
     pub fn new() -> Self {
         Self {
+            metadata: None,
             result: None,
             messages: Vec::new(),
             had_errors: false,

--- a/dsc_lib/src/configure/config_result.rs
+++ b/dsc_lib/src/configure/config_result.rs
@@ -4,9 +4,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use crate::dscresources::invoke_result::{GetResult, SetResult, TestResult};
-use crate::configure::config_doc::Configuration;
-
-use super::config_doc::SecurityContextKind;
+use crate::configure::config_doc::{Configuration, Metadata};
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum MessageLevel {
@@ -23,41 +21,6 @@ pub struct ResourceMessage {
     pub resource_type: String,
     pub message: String,
     pub level: MessageLevel,
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub enum Operation {
-    Get,
-    Set,
-    Test,
-    Export,
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub enum ExecutionKind {
-    Actual,
-    WhatIf,
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub struct ResultMetadata {
-    #[serde(rename = "Microsoft.DSC")]
-    pub microsoft: MicrosoftDscResultMetadata,
-}
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub struct MicrosoftDscResultMetadata {
-    pub version: String,
-    pub operation: Operation,
-    #[serde(rename = "executionType")]
-    pub execution_type: ExecutionKind,
-    #[serde(rename = "startDatetime")]
-    pub start_datetime: String,
-    #[serde(rename = "endDatetime")]
-    pub end_datetime: String,
-    pub duration: String,
-    #[serde(rename = "securityContext")]
-    pub security_context: SecurityContextKind,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -82,7 +45,7 @@ impl From<ResourceTestResult> for ResourceGetResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationGetResult {
-    pub metadata: Option<ResultMetadata>,
+    pub metadata: Option<Metadata>,
     pub results: Vec<ResourceGetResult>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
@@ -155,7 +118,7 @@ impl Default for GroupResourceSetResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationSetResult {
-    pub metadata: Option<ResultMetadata>,
+    pub metadata: Option<Metadata>,
     pub results: Vec<ResourceSetResult>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
@@ -213,7 +176,7 @@ impl Default for GroupResourceTestResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationTestResult {
-    pub metadata: Option<ResultMetadata>,
+    pub metadata: Option<Metadata>,
     pub results: Vec<ResourceTestResult>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]
@@ -241,7 +204,7 @@ impl Default for ConfigurationTestResult {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct ConfigurationExportResult {
-    pub metadata: Option<ResultMetadata>,
+    pub metadata: Option<Metadata>,
     pub result: Option<Configuration>,
     pub messages: Vec<ResourceMessage>,
     #[serde(rename = "hadErrors")]

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use chrono::{DateTime, Local};
-use crate::configure::ExecutionKind;
+use crate::configure::config_doc::ExecutionKind;
 use security_context_lib::{get_security_context, SecurityContext};
 use serde_json::Value;
 use std::collections::HashMap;

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -1,24 +1,37 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use chrono::{DateTime, Local};
+use crate::configure::ExecutionKind;
+use security_context_lib::{get_security_context, SecurityContext};
 use serde_json::Value;
 use std::collections::HashMap;
 
-use super::config_doc::DataType;
+use super::config_doc::{DataType, SecurityContextKind};
 
 pub struct Context {
-    pub parameters: HashMap<String, (Value, DataType)>,
-    _variables: HashMap<String, Value>,
+    pub execution_type: ExecutionKind,
     pub outputs: HashMap<String, Value>, // this is used by the `reference()` function to retrieve output
+    pub parameters: HashMap<String, (Value, DataType)>,
+    pub security_context: SecurityContextKind,
+    _variables: HashMap<String, Value>,
+
+    pub start_datetime: DateTime<Local>,
 }
 
 impl Context {
     #[must_use]
     pub fn new() -> Self {
         Self {
-            parameters: HashMap::new(),
-            _variables: HashMap::new(),
+            execution_type: ExecutionKind::Actual,
             outputs: HashMap::new(),
+            parameters: HashMap::new(),
+            security_context: match get_security_context() {
+                SecurityContext::Admin => SecurityContextKind::Elevated,
+                SecurityContext::User => SecurityContextKind::Restricted,
+            },
+            _variables: HashMap::new(),
+            start_datetime: chrono::Local::now(),
         }
     }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -282,6 +282,7 @@ impl Configurator {
     /// # Errors
     ///
     /// This function will return an error if the underlying resource fails.
+    #[allow(clippy::too_many_lines)]
     pub fn invoke_set(&mut self, skip_test: bool, _error_action: ErrorAction, _progress_callback: impl Fn() + 'static) -> Result<ConfigurationSetResult, DscError> {
         let config = self.validate_config()?;
         let mut result = ConfigurationSetResult::new();

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -250,7 +250,6 @@ impl Configurator {
                     Metadata {
                         microsoft: Some(
                             MicrosoftDscMetadata {
-                                version: Some(dsc_resource.version.clone()),
                                 duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
                                 ..Default::default()
                             }
@@ -326,7 +325,6 @@ impl Configurator {
                         Metadata {
                             microsoft: Some(
                                 MicrosoftDscMetadata {
-                                    version: Some(dsc_resource.version.clone()),
                                     duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
                                     ..Default::default()
                                 }
@@ -369,7 +367,6 @@ impl Configurator {
                         Metadata {
                             microsoft: Some(
                                 MicrosoftDscMetadata {
-                                    version: Some(dsc_resource.version.clone()),
                                     duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
                                     ..Default::default()
                                 }
@@ -429,7 +426,6 @@ impl Configurator {
                     Metadata {
                         microsoft: Some(
                             MicrosoftDscMetadata {
-                                version: Some(dsc_resource.version.clone()),
                                 duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
                                 ..Default::default()
                             }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -241,9 +241,22 @@ impl Configurator {
             debug!("resource_type {}", &resource.resource_type);
             let filter = add_metadata(&dsc_resource.kind, properties)?;
             trace!("filter: {filter}");
+            let start_datetime = chrono::Local::now();
             let get_result = dsc_resource.get(&filter)?;
+            let end_datetime = chrono::Local::now();
             self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&get_result)?);
             let resource_result = config_result::ResourceGetResult {
+                metadata: Some(
+                    Metadata {
+                        microsoft: Some(
+                            MicrosoftDscMetadata {
+                                version: Some(dsc_resource.version.clone()),
+                                duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
+                                ..Default::default()
+                            }
+                        )
+                    }
+                ),
                 name: resource.name.clone(),
                 resource_type: resource.resource_type.clone(),
                 result: get_result,
@@ -303,9 +316,22 @@ impl Configurator {
 
             if exist || dsc_resource.capabilities.contains(&Capability::SetHandlesExist) {
                 debug!("Resource handles _exist or _exist is true");
+                let start_datetime = chrono::Local::now();
                 let set_result = dsc_resource.set(&desired, skip_test)?;
+                let end_datetime = chrono::Local::now();
                 self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&set_result)?);
                 let resource_result = config_result::ResourceSetResult {
+                    metadata: Some(
+                        Metadata {
+                            microsoft: Some(
+                                MicrosoftDscMetadata {
+                                    version: Some(dsc_resource.version.clone()),
+                                    duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
+                                    ..Default::default()
+                                }
+                            )
+                        }
+                    ),
                     name: resource.name.clone(),
                     resource_type: resource.resource_type.clone(),
                     result: set_result,
@@ -314,7 +340,9 @@ impl Configurator {
             } else if dsc_resource.capabilities.contains(&Capability::Delete) {
                 debug!("Resource implements delete and _exist is false");
                 let before_result = dsc_resource.get(&desired)?;
+                let start_datetime = chrono::Local::now();
                 dsc_resource.delete(&desired)?;
+                let end_datetime = chrono::Local::now();
                 let after_result = dsc_resource.get(&desired)?;
                 // convert get result to set result                
                 let set_result = match before_result {
@@ -336,6 +364,17 @@ impl Configurator {
                 };
                 self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&set_result)?);
                 let resource_result = config_result::ResourceSetResult {
+                    metadata: Some(
+                        Metadata {
+                            microsoft: Some(
+                                MicrosoftDscMetadata {
+                                    version: Some(dsc_resource.version.clone()),
+                                    duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
+                                    ..Default::default()
+                                }
+                            )
+                        }
+                    ),
                     name: resource.name.clone(),
                     resource_type: resource.resource_type.clone(),
                     result: SetResult::Resource(set_result),
@@ -380,9 +419,22 @@ impl Configurator {
             debug!("resource_type {}", &resource.resource_type);
             let expected = add_metadata(&dsc_resource.kind, properties)?;
             trace!("expected: {expected}");
+            let start_datetime = chrono::Local::now();
             let test_result = dsc_resource.test(&expected)?;
+            let end_datetime = chrono::Local::now();
             self.context.outputs.insert(format!("{}:{}", resource.resource_type, resource.name), serde_json::to_value(&test_result)?);
             let resource_result = config_result::ResourceTestResult {
+                metadata: Some(
+                    Metadata {
+                        microsoft: Some(
+                            MicrosoftDscMetadata {
+                                version: Some(dsc_resource.version.clone()),
+                                duration: Some(end_datetime.signed_duration_since(start_datetime).to_string()),
+                                ..Default::default()
+                            }
+                        )
+                    }
+                ),
                 name: resource.name.clone(),
                 resource_type: resource.resource_type.clone(),
                 result: test_result,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Use metadata to add execution information as part of result.  Resource execution now also includes the duration of execution.  Resource version will be a top level property in a separate PR.

![image](https://github.com/PowerShell/DSC/assets/11859881/215c56ce-3ef0-4900-bd2c-fa46f11b630a)

## PR Context

FIx https://github.com/PowerShell/DSC/issues/401