### PR TITLE
update version to preview.8

### DIFF
--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsc"
-version = "3.0.0-preview.7"
+version = "3.0.0-preview.8"
 edition = "2021"
 
 [profile.release]

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsc_lib"
-version = "3.0.0-preview.7"
+version = "3.0.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Update version to preview.8
- dsc_lib will stay at 3.0.0 since it's not exposed as part of the binary