### PR TITLE
Refactor resource discovery code

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -161,6 +161,8 @@ if (!$SkipBuild) {
     # make sure dependencies are built first so clippy runs correctly
     $windows_projects = @("pal", "registry", "reboot_pending", "wmi-adapter")
 
+    $macOS_projects = @("resources/brew")
+
     # projects are in dependency order
     $projects = @(
         "tree-sitter-dscexpression",
@@ -170,7 +172,6 @@ if (!$SkipBuild) {
         "osinfo",
         "powershell-adapter",
         "process",
-        "resources/brew",
         "runcommandonset",
         "tools/dsctest",
         "tools/test_group_resource",
@@ -185,6 +186,10 @@ if (!$SkipBuild) {
         Save-Module -Path $target -Name 'PSDesiredStateConfiguration' -RequiredVersion '2.0.7' -Repository PSGallery -Force
         # Need to unhide all the files so that packaging works
         Get-ChildItem -Path $target -Recurse -Hidden | ForEach-Object { $_.Attributes = 'Normal' }
+    }
+
+    if ($IsMacOS) {
+        $projects += $macOS_projects
     }
 
     $failed = $false

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -27,7 +27,7 @@ pub fn get(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
         } else {
-            error!("Adapter {} not found", requires);
+            error!("Adapter '{}' not found", requires);
             return;
         };
     }
@@ -112,7 +112,7 @@ pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
         } else {
-            error!("Adapter {} not found", requires);
+            error!("Adapter '{}' not found", requires);
             return;
         };
     }
@@ -149,7 +149,7 @@ pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: &O
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
         } else {
-            error!("Adapter {} not found", requires);
+            error!("Adapter '{}' not found", requires);
             return;
         };
     }
@@ -186,7 +186,7 @@ pub fn delete(dsc: &DscManager, resource_type: &str, mut input: String) {
         if let Some(pr) = get_resource(dsc, requires) {
             resource = pr;
         } else {
-            error!("Adapter {} not found", requires);
+            error!("Adapter '{}' not found", requires);
             return;
         };
     }

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -337,7 +337,7 @@ pub fn validate_config(config: &str) -> Result<(), DscError> {
 
         resource_types.push(type_name.to_lowercase().to_string());
     }
-    dsc.discover_resources(&resource_types);
+    dsc.find_resources(&resource_types);
 
     for resource_block in resources {
         let Some(type_name) = resource_block["type"].as_str() else {
@@ -402,15 +402,15 @@ pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
             list_resources(&mut dsc, resource_name, adapter_name, description, tags, format);
         },
         ResourceSubCommand::Schema { resource , format } => {
-            dsc.discover_resources(&[resource.to_lowercase().to_string()]);
+            dsc.find_resources(&[resource.to_lowercase().to_string()]);
             resource_command::schema(&dsc, resource, format);
         },
         ResourceSubCommand::Export { resource, format } => {
-            dsc.discover_resources(&[resource.to_lowercase().to_string()]);
+            dsc.find_resources(&[resource.to_lowercase().to_string()]);
             resource_command::export(&mut dsc, resource, format);
         },
         ResourceSubCommand::Get { resource, input, path, all, format } => {
-            dsc.discover_resources(&[resource.to_lowercase().to_string()]);
+            dsc.find_resources(&[resource.to_lowercase().to_string()]);
             if *all { resource_command::get_all(&dsc, resource, format); }
             else {
                 let parsed_input = get_input(input, stdin, path);
@@ -418,17 +418,17 @@ pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
             }
         },
         ResourceSubCommand::Set { resource, input, path, format } => {
-            dsc.discover_resources(&[resource.to_lowercase().to_string()]);
+            dsc.find_resources(&[resource.to_lowercase().to_string()]);
             let parsed_input = get_input(input, stdin, path);
             resource_command::set(&dsc, resource, parsed_input, format);
         },
         ResourceSubCommand::Test { resource, input, path, format } => {
-            dsc.discover_resources(&[resource.to_lowercase().to_string()]);
+            dsc.find_resources(&[resource.to_lowercase().to_string()]);
             let parsed_input = get_input(input, stdin, path);
             resource_command::test(&dsc, resource, parsed_input, format);
         },
         ResourceSubCommand::Delete { resource, input, path } => {
-            dsc.discover_resources(&[resource.to_lowercase().to_string()]);
+            dsc.find_resources(&[resource.to_lowercase().to_string()]);
             let parsed_input = get_input(input, stdin, path);
             resource_command::delete(&dsc, resource, parsed_input);
         },

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -19,7 +19,7 @@ Describe 'tracing tests' {
 
     It 'trace level error does not emit other levels' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc --trace-level error resource get -r 'DoesNotExist' 2> $logPath
+        $null = '{}' | dsc --trace-level error resource list 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         $log | Should -Not -BeLikeExactly "* WARNING *"
         $log | Should -Not -BeLikeExactly "* INFO *"
@@ -29,18 +29,18 @@ Describe 'tracing tests' {
 
     It 'trace format plaintext does not emit ANSI' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc --trace-format plaintext resource get -r 'DoesNotExist' 2> $logPath
+        $null = '{}' | dsc --trace-format plaintext resource list 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         $log | Should -Not -BeLikeExactly "*``[0m*"
     }
 
     It 'trace format json emits json' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc --trace-format json resource get -r 'DoesNotExist' 2> $logPath
+        $null = '{}' | dsc --trace-format json resource list 'DoesNotExist' 2> $logPath
         foreach ($line in (Get-Content $logPath)) {
             $trace = $line | ConvertFrom-Json -Depth 10
             $trace.timestamp | Should -Not -BeNullOrEmpty
-            $trace.level | Should -BeIn 'ERROR', 'WARNING', 'INFO', 'DEBUG', 'TRACE'
+            $trace.level | Should -BeIn 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'
             $trace.fields.message | Should -Not -BeNullOrEmpty
         }
     }
@@ -55,12 +55,12 @@ Describe 'tracing tests' {
         param($level, $sourceExpected)
 
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc -l $level resource get -r 'DoesNotExist' 2> $logPath
+        $null = '{}' | dsc -l $level resource list 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         if ($sourceExpected) {
-            $log | Should -BeLike "*dsc*: *"
+            $log | Should -BeLike "*dsc_lib*: *"
         } else {
-            $log | Should -Not -BeLike "*dsc*: *"
+            $log | Should -Not -BeLike "*dsc_lib*: *"
         }
     }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -335,7 +335,7 @@ impl Configurator {
                     resource_type: resource.resource_type.clone(),
                     result: set_result,
                 };
-                result.results.push(resource_result);    
+                result.results.push(resource_result);
             } else if dsc_resource.capabilities.contains(&Capability::Delete) {
                 debug!("Resource implements delete and _exist is false");
                 let before_result = dsc_resource.get(&desired)?;
@@ -343,10 +343,10 @@ impl Configurator {
                 dsc_resource.delete(&desired)?;
                 let end_datetime = chrono::Local::now();
                 let after_result = dsc_resource.get(&desired)?;
-                // convert get result to set result                
+                // convert get result to set result
                 let set_result = match before_result {
                     GetResult::Resource(before_response) => {
-                        let GetResult::Resource(after_result) = after_result else { 
+                        let GetResult::Resource(after_result) = after_result else {
                             return Err(DscError::NotSupported("Group resources not supported for delete".to_string()))
                         };
                         let before_value = serde_json::to_value(&before_response.actual_state)?;
@@ -614,7 +614,7 @@ impl Configurator {
         let mut required_resources = config.resources.iter().map(|p| p.resource_type.to_lowercase()).collect::<Vec<String>>();
         required_resources.sort_unstable();
         required_resources.dedup();
-        self.discovery.discover_resources(&required_resources);
+        self.discovery.find_resources(&required_resources);
         Ok(config)
     }
 

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -138,7 +138,7 @@ impl ResourceDiscovery for CommandDiscovery {
                                         // resource that is requested by resource/config operation
                                         // if it is, then "ResouceNotFound" error will be issued later
                                         // and here we just record the error into debug stream.
-                                        debug!("{e}");
+                                        warn!("{e}");
                                         continue;
                                     },
                                 };

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -143,7 +143,7 @@ impl ResourceDiscovery for CommandDiscovery {
                                     },
                                 };
 
-                                if regex.is_match(filter) {
+                                if regex.is_match(&resource.type_name) {
                                     if let Some(ref manifest) = resource.manifest {
                                         let manifest = import_manifest(manifest.clone())?;
                                         if manifest.kind == Some(Kind::Adapter) {

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -203,7 +203,7 @@ impl ResourceDiscovery for CommandDiscovery {
 
         for (adapter_name, adapters) in &self.adapters {
             for adapter in adapters {
-                if !regex.is_match(&adapter_name) {
+                if !regex.is_match(adapter_name) {
                     continue;
                 }
 

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -261,6 +261,8 @@ impl ResourceDiscovery for CommandDiscovery {
 
         trace!("Listing resources with type_name_filter/adapter_name_filter: {type_name_filter}/{adapter_name_filter}");
 
+        self.discover_resources(type_name_filter)?;
+
         if !adapter_name_filter.is_empty() {
             self.discover_adapted_resources(adapter_name_filter)?;
         }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -148,10 +148,10 @@ impl ResourceDiscovery for CommandDiscovery {
                                         let manifest = import_manifest(manifest.clone())?;
                                         if manifest.kind == Some(Kind::Adapter) {
                                             trace!("Resource adapter {} found", resource.type_name);
-                                            insert_resource(&mut adapters, &resource)?;
+                                            insert_resource(&mut adapters, &resource);
                                         } else {
                                             trace!("Resource {} found", resource.type_name);
-                                            insert_resource(&mut resources, &resource)?;
+                                            insert_resource(&mut resources, &resource);
                                         }
                                     }
                                 }
@@ -253,7 +253,7 @@ impl ResourceDiscovery for CommandDiscovery {
                             }
 
                             if name_regex.is_match(&resource.type_name) {
-                                insert_resource(&mut adapted_resources, &resource)?;
+                                insert_resource(&mut adapted_resources, &resource);
                                 adapter_resources_count += 1;
                             }
                         },
@@ -340,11 +340,11 @@ impl ResourceDiscovery for CommandDiscovery {
 }
 
 // helper to insert a resource into a vector of resources in order of newest to oldest
-fn insert_resource(resources: &mut BTreeMap<String, Vec<DscResource>>, resource: &DscResource) -> Result<(), DscError> {
+fn insert_resource(resources: &mut BTreeMap<String, Vec<DscResource>>, resource: &DscResource) {
     if resources.contains_key(&resource.type_name) {
         let Some(resource_versions) = resources.get_mut(&resource.type_name) else {
             resources.insert(resource.type_name.clone(), vec![resource.clone()]);
-            return Ok(());
+            return;
         };
         // compare the resource versions and insert newest to oldest using semver
         let mut insert_index = resource_versions.len();
@@ -367,7 +367,7 @@ fn insert_resource(resources: &mut BTreeMap<String, Vec<DscResource>>, resource:
             };
             // if the version already exists, we skip
             if resource_instance_version == resource_version {
-                return Ok(());
+                return;
             }
 
             if resource_instance_version < resource_version {
@@ -379,7 +379,6 @@ fn insert_resource(resources: &mut BTreeMap<String, Vec<DscResource>>, resource:
     } else {
         resources.insert(resource.type_name.clone(), vec![resource.clone()]);
     }
-    Ok(())
 }
 
 fn load_manifest(path: &Path) -> Result<DscResource, DscError> {

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -190,14 +190,14 @@ impl ResourceDiscovery for CommandDiscovery {
 
         let mut adapted_resources = BTreeMap::<String, Vec<DscResource>>::new();
 
-        for (adapter_name, adapters) in self.adapters.iter() {
+        for (adapter_name, adapters) in &self.adapters {
             for adapter in adapters {
                 info!("Enumerating resources for adapter '{}'", adapter_name);
                 let pb_adapter_span = warn_span!("");
                 pb_adapter_span.pb_set_style(&ProgressStyle::with_template(
                     "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.white}"
                 )?);
-                pb_adapter_span.pb_set_message(format!("Enumerating resources for adapter '{}'", adapter_name).as_str());
+                pb_adapter_span.pb_set_message(format!("Enumerating resources for adapter '{adapter_name}'").as_str());
                 let _ = pb_adapter_span.enter();
                 let manifest = if let Some(manifest) = &adapter.manifest {
                     if let Ok(manifest) = import_manifest(manifest.clone()) {
@@ -282,7 +282,7 @@ impl ResourceDiscovery for CommandDiscovery {
         let mut found_resources = BTreeMap::<String, DscResource>::new();
         let mut remaining_required_resource_types = required_resource_types.to_owned();
 
-        for (resource_name, resources) in self.resources.iter() {
+        for (resource_name, resources) in &self.resources {
             let Some(resource ) = resources.first() else {
                 // skip if no resources
                 continue;
@@ -302,7 +302,7 @@ impl ResourceDiscovery for CommandDiscovery {
         debug!("Found {} matching non-adapter-based resources", found_resources.len());
 
         // now go through the adapter resources and add them to the list of resources
-        for (adapted_name, adapted_resource) in self.adapted_resources.iter() {
+        for (adapted_name, adapted_resource) in &self.adapted_resources {
             let Some(adapted_resource) = adapted_resource.first() else {
                 // skip if no resources
                 continue;

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -17,7 +17,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
-use tracing::{debug, error, info, trace, warn, warn_span, Span};
+use tracing::{debug, info, trace, warn, warn_span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 pub struct CommandDiscovery {
@@ -273,144 +273,52 @@ impl ResourceDiscovery for CommandDiscovery {
         Ok(resources)
     }
 
-    #[allow(clippy::too_many_lines)]
+    // TODO: handle version requirements
     fn find_resources(&mut self, required_resource_types: &[String]) -> Result<BTreeMap<String, DscResource>, DscError>
     {
         debug!("Searching for resources: {:?}", required_resource_types);
+        self.discover_resources("*")?;
 
-        let pb_span = warn_span!("");
-        pb_span.pb_set_style(&ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
-        )?);
-        pb_span.pb_set_message("Searching for resources");
-        let _ = pb_span.enter();
-
-        let mut resources: BTreeMap<String, DscResource> = BTreeMap::new();
-        let mut adapter_resources: BTreeMap<String, DscResource> = BTreeMap::new();
+        let mut found_resources = BTreeMap::<String, DscResource>::new();
         let mut remaining_required_resource_types = required_resource_types.to_owned();
 
-        if let Ok(paths) = CommandDiscovery::get_resource_paths() {
-            for path in paths {
-                debug!("Searching in {:?}", path);
-                if path.exists() && path.is_dir() {
-                    for entry in path.read_dir().unwrap() {
-                        let entry = entry.unwrap();
-                        let path = entry.path();
-                        if path.is_file() {
-                            let file_name = path.file_name().unwrap().to_str().unwrap();
-                            let file_name_lowercase = file_name.to_lowercase();
-                            if file_name_lowercase.ends_with(".dsc.resource.json") ||
-                            file_name_lowercase.ends_with(".dsc.resource.yaml") ||
-                            file_name_lowercase.ends_with(".dsc.resource.yml") {
-                                let resource = match load_manifest(&path)
-                                {
-                                    Ok(r) => r,
-                                    Err(e) => {
-                                        /*  In case of non-list resource/config operations:
-                                            At this point we can't determine whether or not the bad manifest contains resource that is requested by resource/config operation
-                                            if it is, then "ResouceNotFound" error will be issued later
-                                            and here we just record the error into debug stream.*/
-                                        debug!("{}", e);
-                                        continue;
-                                    },
-                                };
+        for (resource_name, resources) in self.resources.iter() {
+            let Some(resource ) = resources.first() else {
+                // skip if no resources
+                continue;
+            };
 
-                                if let Some(ref manifest) = resource.manifest {
-                                    let manifest = import_manifest(manifest.clone())?;
-                                    if manifest.kind == Some(Kind::Adapter) {
-                                        adapter_resources.insert(resource.type_name.to_lowercase(), resource.clone());
-                                        resources.insert(resource.type_name.to_lowercase(), resource.clone());
-                                    }
-                                }
-                                if remaining_required_resource_types.contains(&resource.type_name.to_lowercase())
-                                {
-                                    remaining_required_resource_types.retain(|x| *x != resource.type_name.to_lowercase());
-                                    debug!("Found {} in {}", &resource.type_name, path.display());
-                                    Span::current().pb_inc(1);
-                                    resources.insert(resource.type_name.to_lowercase(), resource);
-                                    if remaining_required_resource_types.is_empty()
-                                    {
-                                        return Ok(resources);
-                                    }
-                                }
-                            }
-                        }
-                    }
+            if remaining_required_resource_types.contains(&resource_name.to_lowercase())
+            {
+                // remove the resource from the list of required resources
+                remaining_required_resource_types.retain(|x| *x != resource_name.to_lowercase());
+                found_resources.insert(resource_name.to_lowercase(), resource.clone());
+                if remaining_required_resource_types.is_empty()
+                {
+                    return Ok(found_resources);
                 }
             }
         }
-        debug!("Found {} matching non-adapter-based resources", resources.len());
+        debug!("Found {} matching non-adapter-based resources", found_resources.len());
 
         // now go through the adapter resources and add them to the list of resources
-        for adapter in adapter_resources {
-            debug!("Enumerating resources for adapter '{}'", adapter.1.type_name);
-            let pb_adapter_span = warn_span!("");
-            pb_adapter_span.pb_set_style(&ProgressStyle::with_template(
-                "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.white}"
-            )?);
-            pb_adapter_span.pb_set_message(format!("Enumerating resources for adapter '{}'", adapter.1.type_name).as_str());
-            let _ = pb_adapter_span.enter();
-            let adapter_resource = adapter.1;
-            let adapter_type_name = adapter_resource.type_name.clone();
-            let manifest = if let Some(manifest) = adapter_resource.manifest {
-                if let Ok(manifest) = import_manifest(manifest) {
-                    manifest
-                } else {
-                    return Err(DscError::Operation(format!("Failed to import manifest for '{}'", adapter_resource.type_name.clone())));
-                }
-            } else {
-                return Err(DscError::MissingManifest(adapter_resource.type_name.clone()));
+        for (adapted_name, adapted_resource) in self.adapted_resources.iter() {
+            let Some(adapted_resource) = adapted_resource.first() else {
+                // skip if no resources
+                continue;
             };
-            let mut adapter_resources_count = 0;
-            // invoke the list command
-            let list_command = manifest.adapter.unwrap().list;
-            let (exit_code, stdout, stderr) = match invoke_command(&list_command.executable, list_command.args, None, Some(&adapter_resource.directory), None)
+
+            if remaining_required_resource_types.contains(&adapted_name.to_lowercase())
             {
-                Ok((exit_code, stdout, stderr)) => (exit_code, stdout, stderr),
-                Err(e) => {
-                    /* In case of non-list resource/config operations:
-                       print failure from adapter as error because this adapter was specifically requested by current resource/config operation*/
-                    error!("Could not start {}: {}", list_command.executable, e);
-                    continue;
-                },
-            };
-            log_resource_traces(&stderr);
-
-            if exit_code != 0 {
-                 /* In case of non-list resource/config operations:
-                    print failure from adapter as error because this adapter was specifically requested by current resource/config operation*/
-                error!("Adapter failed to list resources with exit code {exit_code}: {stderr}");
+                remaining_required_resource_types.retain(|x| *x != adapted_name.to_lowercase());
+                found_resources.insert(adapted_name.to_lowercase(), adapted_resource.clone());
+                if remaining_required_resource_types.is_empty()
+                {
+                    return Ok(found_resources);
+                }
             }
-
-            for line in stdout.lines() {
-                match serde_json::from_str::<DscResource>(line){
-                    Result::Ok(resource) => {
-                        if resource.require_adapter.is_none() {
-                            error!("{}", DscError::MissingRequires(adapter.0.clone(), resource.type_name.clone()).to_string());
-                            continue;
-                        }
-                        if remaining_required_resource_types.contains(&resource.type_name.to_lowercase())
-                        {
-                            remaining_required_resource_types.retain(|x| *x != resource.type_name.to_lowercase());
-                            debug!("Found {} in {}", &resource.type_name, &resource.path);
-                            resources.insert(resource.type_name.to_lowercase(), resource);
-                            adapter_resources_count += 1;
-                            if remaining_required_resource_types.is_empty()
-                            {
-                                return Ok(resources);
-                            }
-                        }
-                    },
-                    Result::Err(err) => {
-                        error!("Failed to parse resource: {line} -> {err}");
-                        continue;
-                    }
-                };
-            }
-
-            debug!("Adapter '{}' listed {} matching resources", adapter_type_name, adapter_resources_count);
         }
-        Ok(resources)
+        Ok(found_resources)
     }
 }
 
@@ -423,8 +331,15 @@ fn insert_resource(resources: &mut BTreeMap<String, Vec<DscResource>>, resource:
         };
         // compare the resource versions and insert newest to oldest using semver
         let mut insert_index = resource_versions.len();
-        for (index, resource_version) in resource_versions.iter().enumerate() {
-            if Version::parse(&resource_version.version)? < Version::parse(&resource.version)? {
+        for (index, resource_instance) in resource_versions.iter().enumerate() {
+            let resource_instance_version = Version::parse(&resource_instance.version)?;
+            let resource_version = Version::parse(&resource.version)?;
+            // if the version already exists, we skip
+            if resource_instance_version == resource_version {
+                return Ok(());
+            }
+
+            if resource_instance_version < resource_version {
                 insert_index = index;
                 break;
             }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -137,7 +137,7 @@ impl ResourceDiscovery for CommandDiscovery {
                                         // At this point we can't determine whether or not the bad manifest contains
                                         // resource that is requested by resource/config operation
                                         // if it is, then "ResouceNotFound" error will be issued later
-                                        // and here we just record the error into debug stream.
+                                        // and here we just write as warning
                                         warn!("{e}");
                                         continue;
                                     },

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -20,7 +20,7 @@ use tracing::{debug, info, trace, warn, warn_span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 pub struct CommandDiscovery {
-    // use BTreeMap so that the results are sorted
+    // use BTreeMap so that the results are sorted by the typename, the Vec is sorted by version
     resources: BTreeMap<String, Vec<DscResource>>,
     adapters: BTreeMap<String, Vec<DscResource>>,
     adapted_resources: BTreeMap<String, Vec<DscResource>>,

--- a/dsc_lib/src/discovery/discovery_trait.rs
+++ b/dsc_lib/src/discovery/discovery_trait.rs
@@ -5,6 +5,8 @@ use crate::{dscresources::dscresource::DscResource, dscerror::DscError};
 use std::collections::BTreeMap;
 
 pub trait ResourceDiscovery {
-    fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str) -> Result<BTreeMap<String, DscResource>, DscError>;
-    fn discover_resources(&mut self, required_resource_types: &[String]) -> Result<BTreeMap<String, DscResource>, DscError>;
+    fn discover_resources(&mut self, filter: &str) -> Result<(), DscError>;
+    fn discover_adapted_resources(&mut self, filter: &str) -> Result<(), DscError>;
+    fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str) -> Result<BTreeMap<String, Vec<DscResource>>, DscError>;
+    fn find_resources(&mut self, required_resource_types: &[String]) -> Result<BTreeMap<String, DscResource>, DscError>;
 }

--- a/dsc_lib/src/discovery/discovery_trait.rs
+++ b/dsc_lib/src/discovery/discovery_trait.rs
@@ -6,7 +6,7 @@ use std::collections::BTreeMap;
 
 pub trait ResourceDiscovery {
     fn discover_resources(&mut self, filter: &str) -> Result<(), DscError>;
-    fn discover_adapted_resources(&mut self, filter: &str) -> Result<(), DscError>;
+    fn discover_adapted_resources(&mut self, name_filter: &str, adapter_filter: &str) -> Result<(), DscError>;
     fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str) -> Result<BTreeMap<String, Vec<DscResource>>, DscError>;
     fn find_resources(&mut self, required_resource_types: &[String]) -> Result<BTreeMap<String, DscResource>, DscError>;
 }

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -27,7 +27,6 @@ impl Discovery {
     }
 
     /// List operation.
-    #[allow(clippy::missing_panics_doc)] // false positive in clippy; this function will never panic
     pub fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str) -> Vec<DscResource> {
         let discovery_types: Vec<Box<dyn ResourceDiscovery>> = vec![
             Box::new(command_discovery::CommandDiscovery::new()),
@@ -45,12 +44,10 @@ impl Discovery {
                 }
             };
 
-            for (_resource_name, resource) in discovered_resources {
-                let Some(resource) = resource.first() else {
-                    continue;
-                };
-
-                resources.push(resource.clone());
+            for (_resource_name, found_resources) in discovered_resources {
+                for resource in found_resources {
+                    resources.push(resource.clone());
+                }
             };
         }
 

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -45,8 +45,12 @@ impl Discovery {
                 }
             };
 
-            for resource in discovered_resources {
-                    resources.push(resource.1);
+            for (_resource_name, resource) in discovered_resources {
+                let Some(resource) = resource.first() else {
+                    continue;
+                };
+
+                resources.push(resource.clone());
             };
         }
 
@@ -58,7 +62,7 @@ impl Discovery {
         self.resources.get(type_name)
     }
 
-    pub fn discover_resources(&mut self, required_resource_types: &[String]) {
+    pub fn find_resources(&mut self, required_resource_types: &[String]) {
 
         let discovery_types: Vec<Box<dyn ResourceDiscovery>> = vec![
             Box::new(command_discovery::CommandDiscovery::new()),
@@ -67,7 +71,7 @@ impl Discovery {
         let mut remaining_required_resource_types = required_resource_types.to_owned();
         for mut discovery_type in discovery_types {
 
-            let discovered_resources = match discovery_type.discover_resources(&remaining_required_resource_types) {
+            let discovered_resources = match discovery_type.find_resources(&remaining_required_resource_types) {
                 Ok(value) => value,
                 Err(err) => {
                         error!("{err}");

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -26,7 +26,16 @@ impl Discovery {
         })
     }
 
-    /// List operation.
+    /// List operation for getting available resources based on the filters.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `type_name_filter` - The filter for the resource type name.
+    /// * `adapter_name_filter` - The filter for the adapter name.
+    /// 
+    /// # Returns
+    /// 
+    /// A vector of `DscResource` instances.
     pub fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str) -> Vec<DscResource> {
         let discovery_types: Vec<Box<dyn ResourceDiscovery>> = vec![
             Box::new(command_discovery::CommandDiscovery::new()),
@@ -59,22 +68,25 @@ impl Discovery {
         self.resources.get(type_name)
     }
 
+    /// Find resources based on the required resource types.
+    /// 
+    /// # Arguments
+    /// 
+    /// * `required_resource_types` - The required resource types.
     pub fn find_resources(&mut self, required_resource_types: &[String]) {
-
         let discovery_types: Vec<Box<dyn ResourceDiscovery>> = vec![
             Box::new(command_discovery::CommandDiscovery::new()),
         ];
-
         let mut remaining_required_resource_types = required_resource_types.to_owned();
         for mut discovery_type in discovery_types {
 
             let discovered_resources = match discovery_type.find_resources(&remaining_required_resource_types) {
                 Ok(value) => value,
                 Err(err) => {
-                        error!("{err}");
-                        continue;
-                    }
-                };
+                    error!("{err}");
+                    continue;
+                }
+            };
 
             for resource in discovered_resources {
                 self.resources.insert(resource.0.clone(), resource.1);

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -17,6 +17,9 @@ pub enum DscError {
     #[error("Command: Resource '{0}' [Exit code {1}] {2}")]
     Command(String, i32, String),
 
+    #[error("Command: Executable '{0}' [Exit code {1}] {2}")]
+    CommandExit(String, i32, String),
+
     #[error("CommandOperation: {0} for executable '{1}'")]
     CommandOperation(String, String),
 

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -98,9 +98,6 @@ pub enum DscError {
     #[error("Security context: {0}")]
     SecurityContext(String),
 
-    #[error("Semver: {0}")]
-    Semver(#[from] semver::Error),
-
     #[error("Utf-8 conversion error: {0}")]
     Utf8Conversion(#[from] Utf8Error),
 

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -98,6 +98,9 @@ pub enum DscError {
     #[error("Security context: {0}")]
     SecurityContext(String),
 
+    #[error("Semver: {0}")]
+    Semver(#[from] semver::Error),
+
     #[error("Utf-8 conversion error: {0}")]
     Utf8Conversion(#[from] Utf8Error),
 

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -12,22 +12,22 @@ use tracing::{error, warn, info, debug, trace};
 pub const EXIT_PROCESS_TERMINATED: i32 = 0x102;
 
 
-pub fn log_resource_traces(stderr: &str)
+pub fn log_resource_traces(process_name: &str, stderr: &str)
 {
     if !stderr.is_empty()
     {
         for trace_line in stderr.lines() {
             if let Result::Ok(json_obj) = serde_json::from_str::<Value>(trace_line) {
                 if let Some(msg) = json_obj.get("Error") {
-                    error!("{}", msg.as_str().unwrap_or_default());
+                    error!("Process {process_name}: {}", msg.as_str().unwrap_or_default());
                 } else if let Some(msg) = json_obj.get("Warning") {
-                    warn!("{}", msg.as_str().unwrap_or_default());
+                    warn!("Process {process_name}: {}", msg.as_str().unwrap_or_default());
                 } else if let Some(msg) = json_obj.get("Info") {
-                    info!("{}", msg.as_str().unwrap_or_default());
+                    info!("Process {process_name}: {}", msg.as_str().unwrap_or_default());
                 } else if let Some(msg) = json_obj.get("Debug") {
-                    debug!("{}", msg.as_str().unwrap_or_default());
+                    debug!("Process {process_name}: {}", msg.as_str().unwrap_or_default());
                 } else if let Some(msg) = json_obj.get("Trace") {
-                    trace!("{}", msg.as_str().unwrap_or_default());
+                    trace!("Process {process_name}: {}", msg.as_str().unwrap_or_default());
                 };
             };
         }
@@ -54,12 +54,7 @@ pub fn invoke_get(resource: &ResourceManifest, cwd: &str, filter: &str) -> Resul
     }
 
     info!("Invoking get '{}' using '{}'", &resource.resource_type, &resource.get.executable);
-    let (exit_code, stdout, stderr) = invoke_command(&resource.get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
-
+    let (_exit_code, stdout, stderr) = invoke_command(&resource.get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
     if resource.kind == Some(Kind::Resource) {
         debug!("Verifying output of get '{}' using '{}'", &resource.resource_type, &resource.get.executable);
         verify_json(resource, cwd, &stdout)?;
@@ -131,10 +126,6 @@ pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str, skip_te
 
     info!("Getting current state for set by invoking get {} using {}", &resource.resource_type, &resource.get.executable);
     let (exit_code, stdout, stderr) = invoke_command(&resource.get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
 
     if resource.kind == Some(Kind::Resource) {
         debug!("Verifying output of get '{}' using '{}'", &resource.resource_type, &resource.get.executable);
@@ -165,10 +156,6 @@ pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str, skip_te
 
     info!("Invoking set '{}' using '{}'", &resource.resource_type, &set.executable);
     let (exit_code, stdout, stderr) = invoke_command(&set.executable, args, input_desired, Some(cwd), env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
 
     match set.returns {
         Some(ReturnKind::State) => {
@@ -260,10 +247,6 @@ pub fn invoke_test(resource: &ResourceManifest, cwd: &str, expected: &str) -> Re
 
     info!("Invoking test '{}' using '{}'", &resource.resource_type, &test.executable);
     let (exit_code, stdout, stderr) = invoke_command(&test.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
 
     if resource.kind == Some(Kind::Resource) {
         debug!("Verifying output of test '{}' using '{}'", &resource.resource_type, &test.executable);
@@ -377,11 +360,7 @@ pub fn invoke_delete(resource: &ResourceManifest, cwd: &str, filter: &str) -> Re
     let command_input = get_command_input(&delete.input, filter)?;
 
     info!("Invoking delete '{}' using '{}'", &resource.resource_type, &delete.executable);
-    let (exit_code, _stdout, stderr) = invoke_command(&delete.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
+    let (_exit_code, _stdout, _stderr) = invoke_command(&delete.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
 
     Ok(())
 }
@@ -412,12 +391,7 @@ pub fn invoke_validate(resource: &ResourceManifest, cwd: &str, config: &str) -> 
     let command_input = get_command_input(&validate.input, config)?;
 
     info!("Invoking validate '{}' using '{}'", &resource.resource_type, &validate.executable);
-    let (exit_code, stdout, stderr) = invoke_command(&validate.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
-
+    let (_exit_code, stdout, _stderr) = invoke_command(&validate.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
     let result: ValidateResult = serde_json::from_str(&stdout)?;
     Ok(result)
 }
@@ -438,11 +412,7 @@ pub fn get_schema(resource: &ResourceManifest, cwd: &str) -> Result<String, DscE
 
     match schema_kind {
         SchemaKind::Command(ref command) => {
-            let (exit_code, stdout, stderr) = invoke_command(&command.executable, command.args.clone(), None, Some(cwd), None)?;
-            log_resource_traces(&stderr);
-            if exit_code != 0 {
-                return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-            }
+            let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, command.args.clone(), None, Some(cwd), None)?;
             Ok(stdout)
         },
         SchemaKind::Embedded(ref schema) => {
@@ -499,11 +469,7 @@ pub fn invoke_export(resource: &ResourceManifest, cwd: &str, input: Option<&str>
         args = process_args(&export.args, "");
     }
 
-    let (exit_code, stdout, stderr) = invoke_command(&export.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
-    log_resource_traces(&stderr);
-    if exit_code != 0 {
-        return Err(DscError::Command(resource.resource_type.clone(), exit_code, stderr));
-    }
+    let (_exit_code, stdout, stderr) = invoke_command(&export.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env)?;
     let mut instances: Vec<Value> = Vec::new();
     for line in stdout.lines()
     {
@@ -594,7 +560,13 @@ pub fn invoke_command(executable: &str, args: Option<Vec<String>>, input: Option
     }
     if !stderr.is_empty() {
         trace!("STDERR returned: {}", &stderr);
+        log_resource_traces(executable, &stderr);
     }
+
+    if exit_code != 0 {
+        return Err(DscError::Command(executable.to_string(), exit_code, stderr));
+    }
+
     Ok((exit_code, stdout, stderr))
 }
 

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -43,8 +43,8 @@ impl DscManager {
         self.discovery.list_available_resources(type_name_filter, adapter_name_filter)
     }
 
-    pub fn discover_resources(&mut self, required_resource_types: &[String]) {
-        self.discovery.discover_resources(required_resource_types);
+    pub fn find_resources(&mut self, required_resource_types: &[String]) {
+        self.discovery.find_resources(required_resource_types);
     }
     /// Invoke the get operation on a resource.
     ///


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In preparation to add support for handle multiple and finding specific versions of resource, needed to refactor the existing code.

- New helper to simply find all command based resources
- Another helper to enumerate adapter resources
- All the discovery is cached in memory
- Rename `discover_resources()` to be `find_resources()` as that's really what it does based on a filter
- Functions now return a vector of resources of the same type name, but different versions

Because the changes moves around lots of existing code, might be easier to review the file rather than the diff.