### PR TITLE
Separated WinPS adapter and tests

### DIFF
--- a/powershell-adapter/Tests/class_ps_resources.dsc.yaml
+++ b/powershell-adapter/Tests/class_ps_resources.dsc.yaml
@@ -7,10 +7,6 @@ resources:
   type: Microsoft.DSC/PowerShell
   properties:
     resources:
-    - name: Repository Info
-      type: PSTestModule/TestPSRepository
-      properties:
-        Name: TestPSRepository1
     - name: Class-resource Info
       type: TestClassResource/TestClassResource
       properties:

--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -4,9 +4,6 @@
 Describe 'PowerShell adapter resource tests' {
 
     BeforeAll {
-        if ($isWindows) {
-            winrm quickconfig -quiet -force
-        }    
         $OldPSModulePath  = $env:PSModulePath
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $PSScriptRoot
 
@@ -16,7 +13,6 @@ Describe 'PowerShell adapter resource tests' {
         else
         {
             $cacheFilePath = Join-Path $env:LocalAppData "dsc" "PSAdapterCache.json"
-            $cacheFilePath_v5 = Join-Path $env:LocalAppData "dsc" "WindowsPSAdapterCache.json"
         }
     }
     AfterAll {
@@ -25,7 +21,6 @@ Describe 'PowerShell adapter resource tests' {
 
     BeforeEach {
         Remove-Item -Force -ea SilentlyContinue -Path $cacheFilePath
-        Remove-Item -Force -ea SilentlyContinue -Path $cacheFilePath_v5
     }
 
     It 'Discovery includes class-based and script-based resources ' -Skip:(!$IsWindows){
@@ -37,48 +32,12 @@ Describe 'PowerShell adapter resource tests' {
         ($resources | ? {$_.Type -eq 'PSTestModule/TestPSRepository'}).Count | Should -Be 1
     }
 
-    It 'Windows PowerShell adapter supports File resource' -Skip:(!$IsWindows){
-
-        $r = dsc resource list --adapter Microsoft.Windows/WindowsPowerShell
-        $LASTEXITCODE | Should -Be 0
-        $resources = $r | ConvertFrom-Json
-        ($resources | ? {$_.Type -eq 'PSDesiredStateConfiguration/File'}).Count | Should -Be 1
-    }
-
-    It 'Get works on Binary "File" resource' -Skip:(!$IsWindows){
-
-        $testFile = "$testdrive\test.txt"
-        'test' | Set-Content -Path $testFile -Force
-        $r = '{"DestinationPath":"' + $testFile.replace('\','\\') + '"}' | dsc resource get -r 'PSDesiredStateConfiguration/File'
-        $LASTEXITCODE | Should -Be 0
-        $res = $r | ConvertFrom-Json
-        $res.actualState.result.properties.DestinationPath | Should -Be "$testFile"
-    }
-
-    It 'Get works on traditional "Script" resource' -Skip:(!$IsWindows){
-
-        $testFile = "$testdrive\test.txt"
-        'test' | Set-Content -Path $testFile -Force
-        $r = '{"GetScript": "@{result = $(Get-Content ' + $testFile.replace('\','\\') + ')}", "SetScript": "throw", "TestScript": "throw"}' | dsc resource get -r 'PSDesiredStateConfiguration/Script'
-        $LASTEXITCODE | Should -Be 0
-        $res = $r | ConvertFrom-Json
-        $res.actualState.result.properties.result | Should -Be 'test'
-    }
-
     It 'Get works on class-based resource' -Skip:(!$IsWindows){
 
         $r = "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource'
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.Prop1 | Should -BeExactly 'ValueForProp1'
-    }
-
-    It 'Get works on script-based resource' -Skip:(!$IsWindows){
-
-        $r = "{'Name':'TestPSRepository1'}" | dsc resource get -r 'PSTestModule/TestPSRepository'
-        $LASTEXITCODE | Should -Be 0
-        $res = $r | ConvertFrom-Json
-        $res.actualState.result.properties.PublishLocation | Should -BeExactly 'https://www.powershellgallery.com/api/v2/package/'
     }
 
     It 'Get uses enum names on class-based resource' -Skip:(!$IsWindows){
@@ -89,25 +48,9 @@ Describe 'PowerShell adapter resource tests' {
         $res.actualState.result.properties.EnumProp | Should -BeExactly 'Expected'
     }
 
-    It 'Get uses enum names on script-based resource' -Skip:(!$IsWindows){
-
-        $r = "{'Name':'TestPSRepository1'}" | dsc resource get -r 'PSTestModule/TestPSRepository'
-        $LASTEXITCODE | Should -Be 0
-        $res = $r | ConvertFrom-Json
-        $res.actualState.result.properties.Ensure | Should -BeExactly 'Present'
-    }
-
     It 'Test works on class-based resource' -Skip:(!$IsWindows){
 
         $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource test -r 'TestClassResource/TestClassResource'
-        $LASTEXITCODE | Should -Be 0
-        $res = $r | ConvertFrom-Json
-        $res.actualState.result.properties.InDesiredState | Should -Be $True
-    }
-
-    It 'Test works on script-based resource' -Skip:(!$IsWindows){
-
-        $r = "{'Name':'TestPSRepository1','PackageManagementProvider':'NuGet'}" | dsc resource test -r 'PSTestModule/TestPSRepository'
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.InDesiredState | Should -Be $True
@@ -119,14 +62,6 @@ Describe 'PowerShell adapter resource tests' {
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.afterState.result | Should -Not -BeNull
-    }
-
-    It 'Set works on script-based resource' -Skip:(!$IsWindows){
-
-        $r = "{'Name':'TestPSRepository1'}" | dsc resource set -r 'PSTestModule/TestPSRepository'
-        $LASTEXITCODE | Should -Be 0
-        $res = $r | ConvertFrom-Json
-        $res.afterState.result.properties.RebootRequired | Should -Not -BeNull
     }
 
     It 'Export works on PS class-based resource' -Skip:(!$IsWindows){

--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'PowerShell adapter resource tests' {
+Describe 'WindowsPowerShell adapter resource tests' {
 
     BeforeAll {
         if ($isWindows) {

--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -11,14 +11,18 @@ Describe 'PowerShell adapter resource tests' {
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $PSScriptRoot
 
         $winpsConfigPath = Join-path $PSScriptRoot "winps_resource.dsc.yaml"
-        $cacheFilePath_v5 = Join-Path $env:LocalAppData "dsc" "WindowsPSAdapterCache.json"
+        if ($isWindows) {
+            $cacheFilePath_v5 = Join-Path $env:LocalAppData "dsc" "WindowsPSAdapterCache.json"
+        }
     }
     AfterAll {
         $env:PSModulePath = $OldPSModulePath
     }
 
     BeforeEach {
-        Remove-Item -Force -ea SilentlyContinue -Path $cacheFilePath_v5
+        if ($isWindows) {
+            Remove-Item -Force -ea SilentlyContinue -Path $cacheFilePath_v5
+        }
     }
 
     It 'Windows PowerShell adapter supports File resource' -Skip:(!$IsWindows){

--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -1,0 +1,61 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'PowerShell adapter resource tests' {
+
+    BeforeAll {
+        if ($isWindows) {
+            winrm quickconfig -quiet -force
+        }    
+        $OldPSModulePath  = $env:PSModulePath
+        $env:PSModulePath += [System.IO.Path]::PathSeparator + $PSScriptRoot
+
+        $winpsConfigPath = Join-path $PSScriptRoot "winps_resource.dsc.yaml"
+        $cacheFilePath_v5 = Join-Path $env:LocalAppData "dsc" "WindowsPSAdapterCache.json"
+    }
+    AfterAll {
+        $env:PSModulePath = $OldPSModulePath
+    }
+
+    BeforeEach {
+        Remove-Item -Force -ea SilentlyContinue -Path $cacheFilePath_v5
+    }
+
+    It 'Windows PowerShell adapter supports File resource' -Skip:(!$IsWindows){
+
+        $r = dsc resource list --adapter Microsoft.Windows/WindowsPowerShell
+        $LASTEXITCODE | Should -Be 0
+        $resources = $r | ConvertFrom-Json
+        ($resources | ? {$_.Type -eq 'PSDesiredStateConfiguration/File'}).Count | Should -Be 1
+    }
+
+    It 'Get works on Binary "File" resource' -Skip:(!$IsWindows){
+
+        $testFile = "$testdrive\test.txt"
+        'test' | Set-Content -Path $testFile -Force
+        $r = '{"DestinationPath":"' + $testFile.replace('\','\\') + '"}' | dsc resource get -r 'PSDesiredStateConfiguration/File'
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.actualState.result.properties.DestinationPath | Should -Be "$testFile"
+    }
+
+    It 'Get works on traditional "Script" resource' -Skip:(!$IsWindows){
+
+        $testFile = "$testdrive\test.txt"
+        'test' | Set-Content -Path $testFile -Force
+        $r = '{"GetScript": "@{result = $(Get-Content ' + $testFile.replace('\','\\') + ')}", "SetScript": "throw", "TestScript": "throw"}' | dsc resource get -r 'PSDesiredStateConfiguration/Script'
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.actualState.result.properties.result | Should -Be 'test'
+    }
+
+    It 'Get works on config with File resource for WinPS' -Skip:(!$IsWindows){
+
+      $testFile = "$testdrive\test.txt"
+      'test' | Set-Content -Path $testFile -Force
+      $r = (Get-Content -Raw $winpsConfigPath).Replace('c:\test.txt',"$testFile") | dsc config get
+      $LASTEXITCODE | Should -Be 0
+      $res = $r | ConvertFrom-Json
+      $res.results[0].result.actualState.result[0].properties.DestinationPath | Should -Be "$testFile"
+    }
+}

--- a/powershell-adapter/copy_files.txt
+++ b/powershell-adapter/copy_files.txt
@@ -1,3 +1,5 @@
 ./psDscAdapter/powershell.resource.ps1
 ./psDscAdapter/psDscAdapter.psd1
 ./psDscAdapter/psDscAdapter.psm1
+./psDscAdapter/win_psDscAdapter.psd1
+./psDscAdapter/win_psDscAdapter.psm1

--- a/powershell-adapter/psDscAdapter/powershell.resource.ps1
+++ b/powershell-adapter/psDscAdapter/powershell.resource.ps1
@@ -15,7 +15,13 @@ if ('Validate' -ne $Operation) {
     $host.ui.WriteErrorLine($trace)
 
     # load private functions of psDscAdapter stub module
-    $psDscAdapter = Import-Module "$PSScriptRoot/psDscAdapter.psd1" -Force -PassThru
+    if ($PSVersionTable.PSVersion.Major -le 5) {
+        $psDscAdapter = Import-Module "$PSScriptRoot/win_psDscAdapter.psd1" -Force -PassThru
+    }
+    else {
+        $psDscAdapter = Import-Module "$PSScriptRoot/psDscAdapter.psd1" -Force -PassThru
+    }
+    
 
     # initialize OUTPUT as array
     $result = [System.Collections.Generic.List[Object]]::new()

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psd1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psd1
@@ -1,0 +1,48 @@
+﻿# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+@{
+
+# Script module or binary module file associated with this manifest.
+RootModule = 'win_psDscAdapter.psm1'
+
+# Version number of this module.
+moduleVersion = '0.0.1'
+
+# ID used to uniquely identify this module
+GUID = 'e0dd561d-c47f-4132-aac9-cd9dc8739bb1'
+
+# Author of this module
+Author = 'Microsoft Corporation'
+
+# Company or vendor of this module
+CompanyName = 'Microsoft Corporation'
+
+# Copyright statement for this module
+Copyright = '(c) Microsoft Corporation. All rights reserved.'
+
+# Description of the functionality provided by this module
+Description = 'PowerShell Desired State Configuration Module for DSC PowerShell Adapter'
+
+# Functions to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no functions to export.
+FunctionsToExport = @(
+        'Get-DscResource'
+        'Invoke-DscResource'
+        'Invoke-DscCacheRefresh'
+    )
+
+# Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
+CmdletsToExport = @()
+
+# Variables to export from this module
+VariablesToExport = @()
+
+# Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
+AliasesToExport = @()
+
+PrivateData = @{
+    PSData = @{
+        ProjectUri   = 'https://github.com/PowerShell/dsc'
+    }
+}
+}


### PR DESCRIPTION
# PR Summary

Having code for both PS6+ and WinPS adapters in same files is becoming too branchy and hard to maintain;
This PR:
1) moves all WinPS adapter code into a separate files: `win_psDscAdapter.psd1`, `win_psDscAdapter.psm1`.
2) WinPS adapter tests are moved out to `win_powershellgroup.tests.ps1`.
3) PS6+ adapter code is cleaned, e.g. only class-based resources support is left
4) Perf optimizations in PS6+ adapter:
   - only load PSDSC module when actually needed (happens only during cache refresh)
   - remove unnecessary `Get-Module -ListAvailable` call

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
