### PR TITLE
update expressions to error for non-ints

### DIFF
--- a/dsc_lib/src/functions/int.rs
+++ b/dsc_lib/src/functions/int.rs
@@ -75,6 +75,13 @@ mod tests {
     }
 
     #[test]
+    fn incomplete_float() {
+        let mut parser = Statement::new().unwrap();
+        let err = parser.parse_and_execute("[int(.2)]", &Context::new()).unwrap_err();
+        assert!(matches!(err, DscError::IntegerConversion(_)));
+    }
+
+    #[test]
     fn nested() {
         let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[int(int('-1'))]", &Context::new()).unwrap();
@@ -84,7 +91,7 @@ mod tests {
     #[test]
     fn error() {
         let mut parser = Statement::new().unwrap();
-        let err = parser.parse_and_execute("[int('foo')]", &Context::new()).unwrap_err();
+        let err = parser.parse_and_execute("[int('foo.1')]", &Context::new()).unwrap_err();
         assert!(matches!(err, DscError::FunctionArg(_, _)));
     }
 }

--- a/dsc_lib/src/functions/int.rs
+++ b/dsc_lib/src/functions/int.rs
@@ -68,6 +68,13 @@ mod tests {
     }
 
     #[test]
+    fn float() {
+        let mut parser = Statement::new().unwrap();
+        let err = parser.parse_and_execute("[int(1.2)]", &Context::new()).unwrap_err();
+        assert!(matches!(err, DscError::IntegerConversion(_)));
+    }
+
+    #[test]
     fn nested() {
         let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[int(int('-1'))]", &Context::new()).unwrap();

--- a/dsc_lib/src/functions/int.rs
+++ b/dsc_lib/src/functions/int.rs
@@ -75,9 +75,16 @@ mod tests {
     }
 
     #[test]
-    fn incomplete_float() {
+    fn incomplete_float_missing_digit() {
         let mut parser = Statement::new().unwrap();
         let err = parser.parse_and_execute("[int(.2)]", &Context::new()).unwrap_err();
+        assert!(matches!(err, DscError::Parser(_)));
+    }
+
+    #[test]
+    fn incomplete_float_missing_decimal() {
+        let mut parser = Statement::new().unwrap();
+        let err = parser.parse_and_execute("[int(2.)]", &Context::new()).unwrap_err();
         assert!(matches!(err, DscError::Parser(_)));
     }
 

--- a/dsc_lib/src/functions/int.rs
+++ b/dsc_lib/src/functions/int.rs
@@ -70,15 +70,15 @@ mod tests {
     #[test]
     fn float() {
         let mut parser = Statement::new().unwrap();
-        let err = parser.parse_and_execute("[int(1.2)]", &Context::new()).unwrap_err();
-        assert!(matches!(err, DscError::IntegerConversion(_)));
+        let err = parser.parse_and_execute("[int(1.0)]", &Context::new()).unwrap_err();
+        assert!(matches!(err, DscError::Parser(_)));
     }
 
     #[test]
     fn incomplete_float() {
         let mut parser = Statement::new().unwrap();
         let err = parser.parse_and_execute("[int(.2)]", &Context::new()).unwrap_err();
-        assert!(matches!(err, DscError::IntegerConversion(_)));
+        assert!(matches!(err, DscError::Parser(_)));
     }
 
     #[test]

--- a/tree-sitter-dscexpression/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/invalid_expressions.txt
@@ -124,3 +124,17 @@ Invalid float argument
           (ERROR
             (functionName)
             (memberName)))))
+
+=====
+Plus-sign number argument
+=====
+[myFunction(+1)]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (ERROR
+            (UNEXPECTED '+')
+            (memberName)))))

--- a/tree-sitter-dscexpression/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/invalid_expressions.txt
@@ -122,8 +122,9 @@ Invalid float argument
         (function
           (functionName)
           (ERROR
-            (functionName)
-            (memberName)))))
+            (functionName))
+          (arguments
+            (number)))))
 
 =====
 Plus-sign number argument
@@ -136,5 +137,35 @@ Plus-sign number argument
         (function
           (functionName)
           (ERROR
-            (UNEXPECTED '+')
-            (memberName)))))
+            (UNEXPECTED '+'))
+          (arguments
+            (number)))))
+
+=====
+Float input
+=====
+[myFunction(1234.5678)]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (ERROR
+            (number))
+          (arguments
+              (number)))))
+
+=====
+Float input starting with decimal
+=====
+[myFunction(.1)]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (ERROR)
+          (arguments
+              (number)))))

--- a/tree-sitter-dscexpression/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/invalid_expressions.txt
@@ -110,3 +110,17 @@ Incomplete expression
         (function
           (functionName)))
       (MISSING "]"))
+
+=====
+Invalid float argument
+=====
+[myFunction(a.1)]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (ERROR
+            (functionName)
+            (memberName)))))

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -127,3 +127,16 @@ Quotes float input
           (functionName)
           (arguments
               (string)))))
+
+=====
+Float input starting with decimal
+=====
+[myFunction(.1)]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (arguments
+              (number)))))

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -101,3 +101,29 @@ Nested dot-notation
                 (memberName)))))
         (memberAccess
           (memberName))))
+
+=====
+Float input
+=====
+[myFunction(1234.5678)]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (arguments
+              (number)))))
+
+=====
+Quotes float input
+=====
+[myFunction('1234.5678')]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (arguments
+              (string)))))

--- a/tree-sitter-dscexpression/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/corpus/valid_expressions.txt
@@ -103,19 +103,6 @@ Nested dot-notation
           (memberName))))
 
 =====
-Float input
-=====
-[myFunction(1234.5678)]
----
-
-    (statement
-      (expression
-        (function
-          (functionName)
-          (arguments
-              (number)))))
-
-=====
 Quotes float input
 =====
 [myFunction('1234.5678')]
@@ -127,16 +114,3 @@ Quotes float input
           (functionName)
           (arguments
               (string)))))
-
-=====
-Float input starting with decimal
-=====
-[myFunction(.1)]
----
-
-    (statement
-      (expression
-        (function
-          (functionName)
-          (arguments
-              (number)))))

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -29,7 +29,7 @@ module.exports = grammar({
     _quotedString: $ => seq('\'', $.string, '\''),
     // ARM strings do not allow to contain single-quote characters
     string: $ => /[^']*/,
-    number: $ => /-?(\d*[.])?\d+/,
+    number: $ => /-?\d+/,
     boolean: $ => choice('true', 'false'),
 
     memberAccess: $ => seq('.', $.memberName, repeat(seq('.', $.memberName))),

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -29,7 +29,7 @@ module.exports = grammar({
     _quotedString: $ => seq('\'', $.string, '\''),
     // ARM strings do not allow to contain single-quote characters
     string: $ => /[^']*/,
-    number: $ => /[+-]?([0-9]*[.])?[0-9]+/,
+    number: $ => /-?(\d*[.])?\d+/,
     boolean: $ => choice('true', 'false'),
 
     memberAccess: $ => seq('.', $.memberName, repeat(seq('.', $.memberName))),

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -29,7 +29,7 @@ module.exports = grammar({
     _quotedString: $ => seq('\'', $.string, '\''),
     // ARM strings do not allow to contain single-quote characters
     string: $ => /[^']*/,
-    number: $ => /-?\d+/,
+    number: $ => /[+-]?([0-9]*[.])?[0-9]+/,
     boolean: $ => choice('true', 'false'),
 
     memberAccess: $ => seq('.', $.memberName, repeat(seq('.', $.memberName))),


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary
- fix #390 
<!-- Summarize your PR between here and the checklist. -->

## PR Context
- existing grammar parses only the decimal digit(s) of floating point input as a number, resulting in incorrect handling by functions, like `int()`
- adds check for `ERROR` nodes in Rust parser for function name and args
<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
