### PR TITLE
remove support to retrieve schema from URL

### DIFF
--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -11,7 +11,6 @@ indicatif = { version = "0.17" }
 jsonschema = "0.17"
 num-traits = "0.2"
 regex = "1.7"
-reqwest = { version = "0.12", features = ["blocking"] }
 schemars = { version = "0.8.12", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -4,7 +4,6 @@
 use std::str::Utf8Error;
 
 use indicatif::style::TemplateError;
-use reqwest::StatusCode;
 use thiserror::Error;
 use tracing::error;
 use tree_sitter::LanguageError;
@@ -28,12 +27,6 @@ pub enum DscError {
 
     #[error("Function '{0}' error: {1}")]
     FunctionArg(String, String),
-
-    #[error("HTTP: {0}")]
-    Http(#[from] reqwest::Error),
-
-    #[error("HTTP status: {0}")]
-    HttpStatus(StatusCode),
 
     #[error("Function integer argument conversion error: {0}")]
     IntegerConversion(#[from] std::num::ParseIntError),

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -453,17 +453,6 @@ pub fn get_schema(resource: &ResourceManifest, cwd: &str) -> Result<String, DscE
             let json = serde_json::to_string(schema)?;
             Ok(json)
         },
-        SchemaKind::Url(ref url) => {
-            // TODO: cache downloaded schemas so we don't have to download them every time
-            let mut response = reqwest::blocking::get(url)?;
-            if !response.status().is_success() {
-                return Err(DscError::HttpStatus(response.status()));
-            }
-
-            let mut body = String::new();
-            response.read_to_string(&mut body)?;
-            Ok(body)
-        },
     }
 }
 

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -126,9 +126,6 @@ pub enum SchemaKind {
     /// The schema is embedded in the manifest.
     #[serde(rename = "embedded")]
     Embedded(Value),
-    /// The schema is retrieved from a URL.  Required for intellisense support.
-    #[serde(rename = "url")]
-    Url(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The support for schema URL was initially intended for intellisense support.  However, we can still resolve resources for intellisense using existing other means to get the json schema.  We should not allow reaching out to internet during configuration deployment.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
