### PR TITLE
(DOCS) Document fix to `int()` function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,7 +202,6 @@ the correct permissions to manage that resource instance.
 
   </details>
 
-
 ### Fixed
 
 - Fixed the JSON Schema for [exit codes][ur-fa] in the resource manifest to support negative
@@ -213,6 +212,19 @@ the correct permissions to manage that resource instance.
 
   - Issues: [#407][#407]
   - PRs: [#410][#410]
+
+  </details>
+
+- Fixed the behavior of the [int()][int()] configuration function to error when given an input
+  value other than a string or integer. Prior to this release, when you specified a number with
+  a fractional part as input for the function, it coerced the input value to an integer representing
+  the fractional part. Starting with this release, the `int()` function raises an invalid input
+  error when the input value isn't a string or an integer.
+
+  <details><summary>Related work items</summary>
+
+  - Issues: [#390][#390]
+  - PRs: [#438][#438]
 
   </details>
 
@@ -1481,6 +1493,7 @@ For the full list of changes in this release, see the [diff on GitHub][compare-v
 [#382]: https://github.com/PowerShell/DSC/issues/382
 [#385]: https://github.com/PowerShell/DSC/issues/385
 [#388]: https://github.com/PowerShell/DSC/issues/388
+[#390]: https://github.com/PowerShell/DSC/issues/390
 [#397]: https://github.com/PowerShell/DSC/issues/397
 [#400]: https://github.com/PowerShell/DSC/issues/400
 [#401]: https://github.com/PowerShell/DSC/issues/401
@@ -1491,6 +1504,7 @@ For the full list of changes in this release, see the [diff on GitHub][compare-v
 [#429]: https://github.com/PowerShell/DSC/issues/429
 [#432]: https://github.com/PowerShell/DSC/issues/432
 [#434]: https://github.com/PowerShell/DSC/issues/434
+[#438]: https://github.com/PowerShell/DSC/issues/438
 [#45]:  https://github.com/PowerShell/DSC/issues/45
 [#49]:  https://github.com/PowerShell/DSC/issues/49
 [#57]:  https://github.com/PowerShell/DSC/issues/57

--- a/docs/reference/schemas/config/functions/int.md
+++ b/docs/reference/schemas/config/functions/int.md
@@ -1,6 +1,6 @@
 ---
 description: Reference for the 'int' DSC configuration document function
-ms.date:     04/09/2024
+ms.date:     06/13/2024
 ms.topic:    reference
 title:       int
 ---
@@ -9,7 +9,7 @@ title:       int
 
 ## Synopsis
 
-Returns an integer from an input string or non-integer number.
+Returns an integer from an input string or integer.
 
 ## Syntax
 
@@ -19,8 +19,9 @@ int(<inputValue>)
 
 ## Description
 
-The `int()` function returns an integer, converting an input string or non-integer number into an
-integer. It truncates the fractional part of the input number, it doesn't round up.
+The `int()` function returns an integer, converting an input string into an integer. If you pass an
+integer, it returns the integer. If you pass any other value, including a non-integer number, the
+function raises an invalid input error.
 
 ## Examples
 
@@ -57,17 +58,12 @@ hadErrors: false
 
 ### inputValue
 
-The `int()` function expects input as either a string or a number. If the value is a string that
-can't be parsed as a number, DSC returns an error for the function.
-
-> [!NOTE]
-> There is an open bug (see [GitHub issue #390][#390]) for this function when operating on numbers.
-> The function correctly returns the expected value for string representations of numbers with
-> fractional parts, but returns the fractional part instead of the integer for actual numbers.
-> Specify the input value for this function as a string instead of a number.
+The `int()` function expects input as either a string or an integer. If the value is a string that
+can't be parsed as a number DSC returns an error for the function. If the value isn't a string or
+integer, DSC returns an invalid input error for the function.
 
 ```yaml
-Type:         [String, Number]
+Type:         [String, Integer]
 Required:     true
 MinimumCount: 1
 MaximumCount: 1
@@ -84,4 +80,3 @@ Type: integer
 ```
 
 <!-- Link reference definitions -->
-[#390]: https://github.com/PowerShell/DSC/issues/390


### PR DESCRIPTION
# PR Summary

In #438 we changed the `int()` function to error on input that isn't a string or an integer to align with the behavior of the ARM template function.

This change:

- Updates the documentation for the function to match the updated behavior and removing the note about the now-patched bug.
- Adds an entry for the fix to the changelog.

## PR Context

Document recent change.
