### PR TITLE
Enable `set` and `test` for Import resources

### DIFF
--- a/dsc/examples/osinfo_parameters.dsc.yaml
+++ b/dsc/examples/osinfo_parameters.dsc.yaml
@@ -13,3 +13,7 @@ resources:
   type: Microsoft/OSInfo
   properties:
     family: "[parameters('osFamily')]"
+- name: another os instance
+  type: Microsoft/OSInfo
+  properties:
+    family: macOS

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -4,10 +4,11 @@
 use crate::configure::config_doc::{ExecutionKind, Metadata};
 use crate::configure::parameters::Input;
 use crate::dscerror::DscError;
-use crate::dscresources::dscresource::get_diff;
-use crate::dscresources::invoke_result::GetResult;
-use crate::dscresources::{dscresource::{Capability, Invoke}, invoke_result::{SetResult, ResourceSetResponse}};
-use crate::dscresources::resource_manifest::Kind;
+use crate::dscresources::{
+    {dscresource::{Capability, Invoke, get_diff}, invoke_result::{SetResult, ResourceSetResponse}},
+    invoke_result::GetResult,
+    resource_manifest::Kind,
+};
 use crate::DscResource;
 use crate::discovery::Discovery;
 use crate::parser::Statement;

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -95,6 +95,9 @@ pub enum DscError {
     #[error("Resource not found: {0}")]
     ResourceNotFound(String),
 
+    #[error("Resource manifest not found: {0}")]
+    ResourceManifestNotFound(String),
+
     #[error("Schema: {0}")]
     Schema(String),
 

--- a/dsc_lib/src/dscresources/invoke_result.rs
+++ b/dsc_lib/src/dscresources/invoke_result.rs
@@ -90,10 +90,11 @@ pub enum TestResult {
     Group(Vec<ResourceTestResult>),
 }
 
+#[must_use]
 pub fn get_in_desired_state(test_result: &TestResult) -> bool {
     match test_result {
         TestResult::Resource(ref resource_test_result) => {
-            return resource_test_result.in_desired_state;
+            resource_test_result.in_desired_state
         },
         TestResult::Group(ref group_test_result) => {
             for result in group_test_result {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This follows the PR to support `Import` kind resources by enabling `set` and `test`.  As part of this change, the output for group resources should also address #266.  Note that `test` is not complete yet as the engine currently just uses the input config as the desired state, but even after initial resolving of the include, that config still needs to have expressions invoked and parameters resolved for a valid comparison.  That work will be addressed later.

As part of this change, the `set` group result and `test` group result now align with `get` which changes the schema.

A helper function was added for `test` to recursively determine if in desired state by looking for `inDesiredState` property and if any are false than not in desired state (I think this might address https://github.com/PowerShell/DSC/issues/284)

## PR Context

Fix https://github.com/PowerShell/DSC/issues/266
