### PR TITLE
PSAdapter cache updates

### DIFF
--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -84,19 +84,19 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Verify that ClearCache works in PSAdapter' {
         # generate the cache
-        $null = dsc resource list * -a Microsoft.DSC/PowerShell
+        $null = dsc resource list '*' -a Microsoft.DSC/PowerShell
         # call the ClearCache operation
         $scriptPath = Join-Path $PSScriptRoot '..' 'psDscAdapter' 'powershell.resource.ps1'
-        $null = & $scriptPath -Operation ClearCache 2
+        $null = & $scriptPath -Operation ClearCache
         # verify that PSAdapter does not find the cache
-        dsc -l debug resource list * -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
+        dsc -l debug resource list '*' -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
         $LASTEXITCODE | Should -Be 0
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Cache file not found'
     }
 
     It 'Verify that a new PS Cache version results in cache rebuid' {
         # generate the cache
-        $null = dsc resource list * -a Microsoft.DSC/PowerShell
+        $null = dsc resource list '*' -a Microsoft.DSC/PowerShell
         # update the version in the cache file
         $cacheFilePath = if ($IsWindows) {
             # PS 6+ on Windows
@@ -115,7 +115,7 @@ Describe 'PowerShell adapter resource tests' {
         New-Item -Force -Path $cacheFilePath -Value $jsonCache -Type File | Out-Null
 
         # verify that a new PS Cache version results in cache rebuid
-        dsc -l debug resource list * -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
+        dsc -l debug resource list '*' -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
         $LASTEXITCODE | Should -Be 0
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Incompartible version of cache in file'
     }

--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -81,4 +81,42 @@ Describe 'PowerShell adapter resource tests' {
         $res.actualState.result.count | Should -Be 5
         $res.actualState.result| % {$_.Name | Should -Not -BeNullOrEmpty}
     }
+
+    It 'Verify that ClearCache works in PSAdapter' {
+        # generate the cache
+        $null = dsc resource list * -a Microsoft.DSC/PowerShell
+        # call the ClearCache operation
+        $scriptPath = Join-Path $PSScriptRoot '..' 'psDscAdapter' 'powershell.resource.ps1'
+        $null = & $scriptPath -Operation ClearCache 2
+        # verify that PSAdapter does not find the cache
+        dsc -l debug resource list * -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
+        $LASTEXITCODE | Should -Be 0
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Cache file not found'
+    }
+
+    It 'Verify that a new PS Cache version results in cache rebuid' {
+        # generate the cache
+        $null = dsc resource list * -a Microsoft.DSC/PowerShell
+        # update the version in the cache file
+        $cacheFilePath = if ($IsWindows) {
+            # PS 6+ on Windows
+            Join-Path $env:LocalAppData "dsc\PSAdapterCache.json"
+        } else {
+            # either WinPS or PS 6+ on Linux/Mac
+            if ($PSVersionTable.PSVersion.Major -le 5) {
+                Join-Path $env:LocalAppData "dsc\WindowsPSAdapterCache.json"
+            } else {
+                Join-Path $env:HOME ".dsc" "PSAdapterCache.json"
+            }
+        }
+        $cache = Get-Content -Raw $cacheFilePath | ConvertFrom-Json
+        $cache.CacheSchemaVersion = 0
+        $jsonCache = $cache | ConvertTo-Json -Depth 90
+        New-Item -Force -Path $cacheFilePath -Value $jsonCache -Type File | Out-Null
+
+        # verify that a new PS Cache version results in cache rebuid
+        dsc -l debug resource list * -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
+        $LASTEXITCODE | Should -Be 0
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Incompartible version of cache in file'
+    }
 }

--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -117,6 +117,6 @@ Describe 'PowerShell adapter resource tests' {
         # verify that a new PS Cache version results in cache rebuid
         dsc -l debug resource list '*' -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
         $LASTEXITCODE | Should -Be 0
-        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Incompartible version of cache in file'
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Incompatible version of cache in file'
     }
 }

--- a/powershell-adapter/psDscAdapter/psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/psDscAdapter.psm1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$script:CurrentCacheSchemaVersion = 1
+
 function Write-DscTrace {
     param(
         [Parameter(Mandatory = $false)]
@@ -230,47 +232,53 @@ function Invoke-DscCacheRefresh {
         "Reading from Get-DscResource cache file $cacheFilePath" | Write-DscTrace
 
         $cache = Get-Content -Raw $cacheFilePath | ConvertFrom-Json
-        $dscResourceCacheEntries = $cache.ResourceCache
 
-        if ($dscResourceCacheEntries.Count -eq 0) {
-            # if there is nothing in the cache file - refresh cache
+        if ($cache.CacheSchemaVersion -ne $script:CurrentCacheSchemaVersion) {
             $refreshCache = $true
+            "Incompartible version of cache in file '"+$cache.CacheSchemaVersion+"' (expected '"+$script:CurrentCacheSchemaVersion+"')" | Write-DscTrace
+        } else {
+            $dscResourceCacheEntries = $cache.ResourceCache
 
-            "Filtered DscResourceCache cache is empty" | Write-DscTrace
-        }
-        else
-        {
-            "Checking cache for stale entries" | Write-DscTrace
+            if ($dscResourceCacheEntries.Count -eq 0) {
+                # if there is nothing in the cache file - refresh cache
+                $refreshCache = $true
 
-            foreach ($cacheEntry in $dscResourceCacheEntries) {
-                "Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
+                "Filtered DscResourceCache cache is empty" | Write-DscTrace
+            }
+            else
+            {
+                "Checking cache for stale entries" | Write-DscTrace
 
-                $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
-                
-                    if (-not ((Get-Item $_.Name).LastWriteTime.Equals([DateTime]$_.Value)))
-                    {
-                        "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
-                        $refreshCache = $true
-                        break
+                foreach ($cacheEntry in $dscResourceCacheEntries) {
+                    "Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
+
+                    $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
+                    
+                        if (-not ((Get-Item $_.Name).LastWriteTime.Equals([DateTime]$_.Value)))
+                        {
+                            "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
+                            $refreshCache = $true
+                            break
+                        }
                     }
+
+                    if ($refreshCache) {break}
                 }
 
-                if ($refreshCache) {break}
-            }
+                "Checking cache for stale PSModulePath" | Write-DscTrace
 
-            "Checking cache for stale PSModulePath" | Write-DscTrace
+                $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
 
-            $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
+                $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
+                $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
+                $hs_cache.SymmetricExceptWith($hs_live)
+                $diff = $hs_cache
 
-            $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
-            $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
-            $hs_cache.SymmetricExceptWith($hs_live)
-            $diff = $hs_cache
+                "PSModulePath diff '$diff'" | Write-DscTrace
 
-            "PSModulePath diff '$diff'" | Write-DscTrace
-
-            if ($diff.Count -gt 0) {
-                $refreshCache = $true
+                if ($diff.Count -gt 0) {
+                    $refreshCache = $true
+                }
             }
         }
     }
@@ -318,6 +326,7 @@ function Invoke-DscCacheRefresh {
         $cache.ResourceCache = $dscResourceCacheEntries
         $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
         $cache.PSModulePaths = $m.FullName
+        $cache.CacheSchemaVersion = $script:CurrentCacheSchemaVersion
 
         # save cache for future use
         # TODO: replace this with a high-performance serializer
@@ -482,6 +491,7 @@ class dscResourceCacheEntry {
 }
 
 class dscResourceCache {
+    [int] $CacheSchemaVersion
     [string[]] $PSModulePaths
     [dscResourceCacheEntry[]] $ResourceCache
 }

--- a/powershell-adapter/psDscAdapter/psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/psDscAdapter.psm1
@@ -235,7 +235,7 @@ function Invoke-DscCacheRefresh {
 
         if ($cache.CacheSchemaVersion -ne $script:CurrentCacheSchemaVersion) {
             $refreshCache = $true
-            "Incompartible version of cache in file '"+$cache.CacheSchemaVersion+"' (expected '"+$script:CurrentCacheSchemaVersion+"')" | Write-DscTrace
+            "Incompatible version of cache in file '"+$cache.CacheSchemaVersion+"' (expected '"+$script:CurrentCacheSchemaVersion+"')" | Write-DscTrace
         } else {
             $dscResourceCacheEntries = $cache.ResourceCache
 

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+$script:CurrentCacheSchemaVersion = 1
+
 function Write-DscTrace {
     param(
         [Parameter(Mandatory = $false)]
@@ -68,47 +70,52 @@ function Invoke-DscCacheRefresh {
         "Reading from Get-DscResource cache file $cacheFilePath" | Write-DscTrace
 
         $cache = Get-Content -Raw $cacheFilePath | ConvertFrom-Json
-        $dscResourceCacheEntries = $cache.ResourceCache
-
-        if ($dscResourceCacheEntries.Count -eq 0) {
-            # if there is nothing in the cache file - refresh cache
+        if ($cache.CacheSchemaVersion -ne $script:CurrentCacheSchemaVersion) {
             $refreshCache = $true
+            "Incompartible version of cache in file '"+$cache.CacheSchemaVersion+"' (expected '"+$script:CurrentCacheSchemaVersion+"')" | Write-DscTrace
+        } else {
+            $dscResourceCacheEntries = $cache.ResourceCache
 
-            "Filtered DscResourceCache cache is empty" | Write-DscTrace
-        }
-        else
-        {
-            "Checking cache for stale entries" | Write-DscTrace
+            if ($dscResourceCacheEntries.Count -eq 0) {
+                # if there is nothing in the cache file - refresh cache
+                $refreshCache = $true
 
-            foreach ($cacheEntry in $dscResourceCacheEntries) {
-                "Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
+                "Filtered DscResourceCache cache is empty" | Write-DscTrace
+            }
+            else
+            {
+                "Checking cache for stale entries" | Write-DscTrace
 
-                $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
-                
-                    if (-not ((Get-Item $_.Name).LastWriteTime.Equals([DateTime]$_.Value)))
-                    {
-                        "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
-                        $refreshCache = $true
-                        break
+                foreach ($cacheEntry in $dscResourceCacheEntries) {
+                    "Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
+
+                    $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
+                    
+                        if (-not ((Get-Item $_.Name).LastWriteTime.Equals([DateTime]$_.Value)))
+                        {
+                            "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
+                            $refreshCache = $true
+                            break
+                        }
                     }
+
+                    if ($refreshCache) {break}
                 }
 
-                if ($refreshCache) {break}
-            }
+                "Checking cache for stale PSModulePath" | Write-DscTrace
 
-            "Checking cache for stale PSModulePath" | Write-DscTrace
+                $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
 
-            $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
+                $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
+                $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
+                $hs_cache.SymmetricExceptWith($hs_live)
+                $diff = $hs_cache
 
-            $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
-            $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
-            $hs_cache.SymmetricExceptWith($hs_live)
-            $diff = $hs_cache
+                "PSModulePath diff '$diff'" | Write-DscTrace
 
-            "PSModulePath diff '$diff'" | Write-DscTrace
-
-            if ($diff.Count -gt 0) {
-                $refreshCache = $true
+                if ($diff.Count -gt 0) {
+                    $refreshCache = $true
+                }
             }
         }
     }
@@ -223,6 +230,7 @@ function Invoke-DscCacheRefresh {
         $cache.ResourceCache = $dscResourceCacheEntries
         $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
         $cache.PSModulePaths = $m.FullName
+        $cache.CacheSchemaVersion = $script:CurrentCacheSchemaVersion
 
         # save cache for future use
         # TODO: replace this with a high-performance serializer
@@ -472,6 +480,7 @@ class dscResourceCacheEntry {
 }
 
 class dscResourceCache {
+    [int] $CacheSchemaVersion
     [string[]] $PSModulePaths
     [dscResourceCacheEntry[]] $ResourceCache
 }


### PR DESCRIPTION
# PR Summary

1) Adding a parameter that users can use to clear PSAdapter cache:
`.\psDscAdapter\powershell.resource.ps1 -Operation ClearCache`

2) Adding a cache version and logic to rebuild the cache if version in the cache file does not match version in the running code. This will remove problems with updates to newer dsc versions.