### PR TITLE
Disable large trace in PSAdapter

### DIFF
--- a/powershell-adapter/psDscAdapter/psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/psDscAdapter.psm1
@@ -255,7 +255,7 @@ function Invoke-DscCacheRefresh {
             "Checking cache for stale entries" | Write-DscTrace
 
             foreach ($cacheEntry in $dscResourceCacheEntries) {
-                "Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
+                #"Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
 
                 $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
                 

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -81,7 +81,7 @@ function Invoke-DscCacheRefresh {
             "Checking cache for stale entries" | Write-DscTrace
 
             foreach ($cacheEntry in $dscResourceCacheEntries) {
-                "Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
+                #"Checking cache entry '$($cacheEntry.Type) $($cacheEntry.LastWriteTimes)'" | Write-DscTrace -Operation Trace
 
                 $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
                 


### PR DESCRIPTION
# PR Summary

Current `command_resource.rs` code has a bug where if `stderr` pipe is filled before `stdout`, then a hang happens.
This can happen if large traces are written by a resource process.
An example is PSAdapter cache processing code when a module with lots of files is present on the system (e.g. `SqlServerDsc`).

This will be auto-fixed by fixing #46 (changing to async child process execution);
Meanwhile, as a temporary workaround, this PR disables problematic trace line in PSAdapter.

