### PR TITLE
Fixed WinPSAdapter operations for Binary resources

### DIFF
--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -43,6 +43,14 @@ Describe 'WindowsPowerShell adapter resource tests' {
         $res.actualState.result.properties.DestinationPath | Should -Be "$testFile"
     }
 
+    It 'Set works on Binary "File" resource' -Skip:(!$IsWindows){
+
+        $testFile = "$testdrive\test.txt"
+        $r = '{"DestinationPath":"' + $testFile.replace('\','\\') + '", type: File, contents: HelloWorld, Ensure: present}' | dsc resource set -r 'PSDesiredStateConfiguration/File'
+        $LASTEXITCODE | Should -Be 0
+        Get-Content -Raw -Path $testFile | Should -Be "HelloWorld"
+    }
+
     It 'Get works on traditional "Script" resource' -Skip:(!$IsWindows){
 
         $testFile = "$testdrive\test.txt"


### PR DESCRIPTION
# PR Summary
Fix #445 

1) Fixing a typo in `WinPSAdapter` which was causing it to always run `Get` operation regardless of what operation was requested by the `dsc`.
2) renamed several local variables in `WinPSAdapter` to more accurately describe their use. 