### PR TITLE
Change build to have `-UseCFS` switch otherwise uses crates-io

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,6 +4,10 @@ registry-auth = true
 
 [registries]
 powershell = { index = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/" }
+cratesio = { index = "sparse+https://index.crates.io/"}
+
+[registry]
+global-credential-providers = ["cargo:token"]
 
 # Enable Control Flow Guard (needed for OneBranch's post-build analysis).
 [target.x86_64-pc-windows-msvc]
@@ -11,3 +15,7 @@ rustflags = ["-Ccontrol-flow-guard", "-Ctarget-feature=+crt-static", "-Clink-arg
 
 [target.aarch64-windows-msvc]
 rustflags = ["-Ccontrol-flow-guard", "-Ctarget-feature=+crt-static", "-Clink-args=/DYNAMICBASE"]
+
+# The following is only needed for release builds
+[source.crates-io]
+replace-with = "powershell"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -4,7 +4,6 @@ registry-auth = true
 
 [registries]
 powershell = { index = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/" }
-cratesio = { index = "sparse+https://index.crates.io/"}
 
 [registry]
 global-credential-providers = ["cargo:token"]

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -141,13 +141,7 @@ extends:
             ob_restore_phase: true
         - pwsh: |
             Set-Location "$(Build.SourcesDirectory)/DSC"
-            Write-Host "Use 'powershell' CFS"
-            Add-Content -Path "./.cargo/config.toml" -Value '[source.crates-io]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'replace-with = "powershell"'
-            Add-Content -Path "./.cargo/config.toml" -Value '[registry]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'global-credential-providers = ["cargo:token"]'
-
-            ./build.ps1 -Release -Architecture $(buildName) -SkipLinkCheck
+            ./build.ps1 -Release -Architecture $(buildName) -SkipLinkCheck -UseCFS
           displayName: 'Build $(buildName)'
           env:
             ob_restore_phase: true
@@ -279,13 +273,7 @@ extends:
           env:
             ob_restore_phase: true
         - pwsh: |
-            Write-Host "Use 'powershell' CFS"
-            Add-Content -Path "./.cargo/config.toml" -Value '[source.crates-io]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'replace-with = "powershell"'
-            Add-Content -Path "./.cargo/config.toml" -Value '[registry]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'global-credential-providers = ["cargo:token"]'
-
-            ./build.ps1 -Release -Architecture x86_64-unknown-linux-gnu
+            ./build.ps1 -Release -Architecture x86_64-unknown-linux-gnu -UseCFS
             ./build.ps1 -PackageType tgz -Architecture x86_64-unknown-linux-gnu -Release
             Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
           displayName: 'Build x86_64-unknown-linux-gnu'
@@ -325,13 +313,7 @@ extends:
           env:
             ob_restore_phase: true
         - pwsh: |
-            Write-Host "Use 'powershell' CFS"
-            Add-Content -Path "./.cargo/config.toml" -Value '[source.crates-io]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'replace-with = "powershell"'
-            Add-Content -Path "./.cargo/config.toml" -Value '[registry]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'global-credential-providers = ["cargo:token"]'
-
-            ./build.ps1 -Release -Architecture aarch64-unknown-linux-gnu
+            ./build.ps1 -Release -Architecture aarch64-unknown-linux-gnu -UseCFS
             ./build.ps1 -PackageType tgz -Architecture aarch64-unknown-linux-gnu -Release
             Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
           displayName: 'Build aarch64-unknown-linux-gnu'
@@ -379,18 +361,7 @@ extends:
           env:
             ob_restore_phase: true
         - pwsh: |
-            Write-Host "Use 'powershell' CFS"
-            Add-Content -Path "./.cargo/config.toml" -Value '[source.crates-io]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'replace-with = "powershell"'
-            Add-Content -Path "./.cargo/config.toml" -Value '[registry]'
-            Add-Content -Path "./.cargo/config.toml" -Value 'global-credential-providers = ["cargo:token"]'
-
-            $c = get-content "./.cargo/config.toml" | Out-String
-            Write-Host $c
-
-            $env:CARGO_HTTP_DEBUG=true
-            $env:CARGO_LOG='network=trace'
-            ./build.ps1 -Release -Architecture $(buildName)
+            ./build.ps1 -Release -Architecture $(buildName) -UseCFS
             ./build.ps1 -PackageType tgz -Architecture $(buildName) -Release
             Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
             Write-Host "##vso[artifact.upload containerfolder=release;artifactname=release]$(ob_outputDirectory)/DSC-$(PackageVersion)-$(buildName).tar.gz"

--- a/archive/registry/.cargo/config.toml
+++ b/archive/registry/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/build.ps1
+++ b/build.ps1
@@ -175,10 +175,12 @@ if (!$SkipBuild) {
     if (!$UseCFS) {
         # this will override the config.toml
         Write-Host "Setting CARGO_SOURCE_crates-io_REPLACE_WITH to 'crates-io'"
-        ${env:CARGO_SOURCE_crates-io_REPLACE_WITH} = 'cratesio'
+        ${env:CARGO_SOURCE_crates-io_REPLACE_WITH} = 'CRATESIO'
+        $env:CARGO_REGISTRIES_CRATESIO_INDEX = 'sparse+https://index.crates.io/'
     } else {
         Write-Host "Using CFS for cargo source replacement"
         ${env:CARGO_SOURCE_crates-io_REPLACE_WITH} = $null
+        $env:CARGO_REGISTRIES_CRATESIO_INDEX = $null
     }
 
     # make sure dependencies are built first so clippy runs correctly

--- a/dsc/.cargo/config.toml
+++ b/dsc/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/dsc_lib/.cargo/config.toml
+++ b/dsc_lib/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/osinfo/.cargo/config.toml
+++ b/osinfo/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/process/.cargo/config.toml
+++ b/process/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/tools/dsctest/.cargo/config.toml
+++ b/tools/dsctest/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/tools/test_group_resource/.cargo/config.toml
+++ b/tools/test_group_resource/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]

--- a/y2j/.cargo/config.toml
+++ b/y2j/.cargo/config.toml
@@ -1,4 +1,0 @@
-[target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]
-[target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "target-feature=+crt-static"]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Needed to change the build to replace `crates-io` with the `powershell` feed to be compliant, but if `build.ps1 -UseCFS` is NOT specified, we replace it back with `crates-io`.  The change uses the equivalent env var as it takes precedence. 
 This will ensure that the release build is compliant while not impacting community builds or CI.  This also removes the injected lines in `config.toml` that replaces with `powershell` feed since that is now the default in the `config.toml` file. 

To pass compliance, `cratesio` registry has to be defined at runtime as an env var instead of being in the config.toml.