### PR TITLE
Update PSAdapter to properly handle multiple modules with same name

### DIFF
--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -134,10 +134,10 @@ Describe 'PowerShell adapter resource tests' {
         $srcPath = Join-Path $PSScriptRoot 'TestClassResource'
         $pathRoot1 = Join-Path $TestDrive 'A'
         $pathRoot2 = Join-Path $TestDrive 'B'
-        $path1 = Join-Path $pathRoot1 'TestClassResource' '0.0.1'
-        $path2 = Join-Path $pathRoot1 'TestClassResource' '0.0.2'
-        $path3 = Join-Path $pathRoot2 'TestClassResource' '0.0.3'
-        $path4 = Join-Path $pathRoot2 'TestClassResource' '0.0.4'
+        $path1 = Join-Path $pathRoot1 'TestClassResource' '1.0'
+        $path2 = Join-Path $pathRoot1 'TestClassResource' '1.1'
+        $path3 = Join-Path $pathRoot2 'TestClassResource' '2.0'
+        $path4 = Join-Path $pathRoot2 'TestClassResource' '2.0.1'
 
         New-Item -ItemType Directory -Force -Path $path1 | Out-Null
         New-Item -ItemType Directory -Force -Path $path2 | Out-Null
@@ -151,13 +151,13 @@ Describe 'PowerShell adapter resource tests' {
         $files | Copy-Item -Destination $path4
 
         $filePath = Join-Path $path1 'TestClassResource.psd1'
-        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'0.0.1`'") | Set-Content $filePath
+        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'1.0`'") | Set-Content $filePath
         $filePath = Join-Path $path2 'TestClassResource.psd1'
-        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'0.0.2`'") | Set-Content $filePath
+        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'1.1`'") | Set-Content $filePath
         $filePath = Join-Path $path3 'TestClassResource.psd1'
-        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'0.0.3`'") | Set-Content $filePath
+        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'2.0`'") | Set-Content $filePath
         $filePath = Join-Path $path4 'TestClassResource.psd1'
-        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'0.0.4`'") | Set-Content $filePath
+        (Get-Content -Raw $filePath).Replace("ModuleVersion = `'0.0.1`'", "ModuleVersion = `'2.0.1`'") | Set-Content $filePath
 
 
         $oldPath = $env:PSModulePath
@@ -170,7 +170,7 @@ Describe 'PowerShell adapter resource tests' {
             $resources = $r | ConvertFrom-Json
             $r = @($resources | ? {$_.Type -eq 'TestClassResource/TestClassResource'})
             $r.Count | Should -Be 1
-            $r[0].Version | Should -Be '0.0.4'
+            $r[0].Version | Should -Be '2.0.1'
         }
         finally {
             $env:PSModulePath = $oldPath


### PR DESCRIPTION
# PR Summary

Fix #487 

1) There was a bug if a module with same name is present in several locations in PSModulePath.
    This PR changes PSAdapter to select the module with highest version number in such cases.
2) Plumbed resource 'Version' field to show up in `dsc list`. Resource version is taken from corresponding module version.
