### PR TITLE
Fixed PSAdapter cache code when module files are missing

### DIFF
--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -120,6 +120,34 @@ Describe 'PowerShell adapter resource tests' {
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Incompatible version of cache in file'
     }
 
+    It 'Verify that removing a module results in cache rebuid' {
+
+        Copy-Item -Recurse -Force -Path "$PSScriptRoot/TestClassResource" -Destination $TestDrive
+        Copy-Item -Recurse -Force -Path "$PSScriptRoot/TestClassResource" -Destination "$PSScriptRoot/Backup/TestClassResource"
+        Remove-Item -Recurse -Force -Path "$PSScriptRoot/TestClassResource"
+
+        $oldPath = $env:PSModulePath
+        try {
+            $env:PSModulePath += [System.IO.Path]::PathSeparator + $TestDrive
+
+            # generate the cache
+            $null = dsc resource list '*' -a Microsoft.DSC/PowerShell
+            # remove the module files
+            Remove-Item -Recurse -Force -Path "$TestDrive/TestClassResource"
+            # verify that cache rebuid happened
+            dsc -l trace resource list '*' -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
+
+            $LASTEXITCODE | Should -Be 0
+            "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Detected non-existent cache entry'
+            "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Constructing Get-DscResource cache'
+        }
+        finally {
+            $env:PSModulePath = $oldPath
+            Copy-Item -Recurse -Force -Path "$PSScriptRoot/Backup/TestClassResource" -Destination "$PSScriptRoot"
+            Remove-Item -Recurse -Force -Path "$PSScriptRoot/Backup"
+        }
+    }
+
     It 'Verify inheritance works in class-based resources' {
 
         $r = dsc resource list '*' -a Microsoft.DSC/PowerShell

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -90,9 +90,15 @@ function Invoke-DscCacheRefresh {
 
                     $cacheEntry.LastWriteTimes.PSObject.Properties | ForEach-Object {
                     
-                        if (-not ((Get-Item $_.Name).LastWriteTime.Equals([DateTime]$_.Value)))
-                        {
-                            "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
+                        if (Test-Path $_.Name) {
+                            if (-not ((Get-Item $_.Name).LastWriteTime.Equals([DateTime]$_.Value)))
+                            {
+                                "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
+                                $refreshCache = $true
+                                break
+                            }
+                        } else {
+                            "Detected non-existent cache entry '$($_.Name)'" | Write-DscTrace
                             $refreshCache = $true
                             break
                         }
@@ -101,19 +107,21 @@ function Invoke-DscCacheRefresh {
                     if ($refreshCache) {break}
                 }
 
-                "Checking cache for stale PSModulePath" | Write-DscTrace
+                if (-not $refreshCache) {
+                    "Checking cache for stale PSModulePath" | Write-DscTrace
 
-                $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
+                    $m = $env:PSModulePath -split [IO.Path]::PathSeparator | %{Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue}
 
-                $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
-                $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
-                $hs_cache.SymmetricExceptWith($hs_live)
-                $diff = $hs_cache
+                    $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
+                    $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
+                    $hs_cache.SymmetricExceptWith($hs_live)
+                    $diff = $hs_cache
 
-                "PSModulePath diff '$diff'" | Write-DscTrace
+                    "PSModulePath diff '$diff'" | Write-DscTrace
 
-                if ($diff.Count -gt 0) {
-                    $refreshCache = $true
+                    if ($diff.Count -gt 0) {
+                        $refreshCache = $true
+                    }
                 }
             }
         }


### PR DESCRIPTION
# PR Summary

Fix #495 

There was a bug in PSAdapter cache code that cache was not rebuilt if module files were deleted externally.
Also added a small perf optimization to skip checking cache for stale PSModulePath if stale or non-existent cache timestamp entries are detected.
