### PR TITLE
Add DSC home directory to PATH to find included resources

### DIFF
--- a/dsc/tests/dsc_osinfo.tests.ps1
+++ b/dsc/tests/dsc_osinfo.tests.ps1
@@ -18,4 +18,20 @@ Describe 'Tests for osinfo examples' {
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.inDesiredState | Should -Be $IsMacOS
     }
+
+    It 'Verify dsc home directory is added to PATH to find included resources' {
+        $oldPath = $env:PATH
+        try {
+            $exe_path = Resolve-Path "$PSScriptRoot/../../bin/debug"
+            # Remove unwanted elements
+            $new_path = ($oldPath.Split([System.IO.Path]::PathSeparator) | Where-Object { $_ -ne $exe_path }) -join [System.IO.Path]::PathSeparator
+            $env:PATH = $new_path
+
+            $null = & "$PSScriptRoot/../../bin/debug/dsc" config test -p "$PSScriptRoot/../examples/osinfo_parameters.dsc.yaml"
+            $LASTEXITCODE | Should -Be 0
+        }
+        finally {
+            $env:PATH = $oldPath
+        }
+    }
 }

--- a/dsc/tests/dsc_osinfo.tests.ps1
+++ b/dsc/tests/dsc_osinfo.tests.ps1
@@ -19,19 +19,22 @@ Describe 'Tests for osinfo examples' {
         $out.results[0].result.inDesiredState | Should -Be $IsMacOS
     }
 
-    It 'Verify dsc home directory is added to PATH to find included resources' {
+    It 'Verify dsc home directory is added to PATH to find included resources' -Tag z1{
         $oldPath = $env:PATH
+        $oldLocation = Get-Location
         try {
-            $exe_path = Resolve-Path "$PSScriptRoot/../../bin/debug"
-            # Remove unwanted elements
+            $exe_path = (Get-Command dsc).Path | Split-Path
+            $exe_path | Split-Path | Set-Location
+            # Remove exe_path from PATH if it is there
             $new_path = ($oldPath.Split([System.IO.Path]::PathSeparator) | Where-Object { $_ -ne $exe_path }) -join [System.IO.Path]::PathSeparator
             $env:PATH = $new_path
 
-            $null = & "$PSScriptRoot/../../bin/debug/dsc" config test -p "$PSScriptRoot/../examples/osinfo_parameters.dsc.yaml"
+            $null = & "$exe_path/dsc" config test -p "$PSScriptRoot/../examples/osinfo_parameters.dsc.yaml"
             $LASTEXITCODE | Should -Be 0
         }
         finally {
             $env:PATH = $oldPath
+            $oldLocation | Set-Location
         }
     }
 }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -66,7 +66,9 @@ impl CommandDiscovery {
         if !using_custom_path {
             if let Some(exe_home) = env::current_exe()?.parent() {
                 let exe_home_pb = exe_home.to_path_buf();
-                if !paths.contains(&exe_home_pb) {
+                if paths.contains(&exe_home_pb) {
+                    trace!("Exe home is already in path: {}", exe_home.to_string_lossy());
+                } else {
                     trace!("Adding exe home to path: {}", exe_home.to_string_lossy());
                     paths.push(exe_home_pb);
 
@@ -74,8 +76,6 @@ impl CommandDiscovery {
                         debug!("Using PATH: {:?}", new_path.to_string_lossy());
                         env::set_var("PATH", &new_path);
                     }
-                } else {
-                    trace!("Exe home is already in path: {}", exe_home.to_string_lossy());
                 }
             }
         };

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -48,7 +48,7 @@ impl CommandDiscovery {
             trace!("DSC_RESOURCE_PATH not set, trying PATH");
             match env::var_os("PATH") {
                 Some(value) => {
-                    trace!("Using PATH: {:?}", value.to_string_lossy());
+                    trace!("Original PATH: {:?}", value.to_string_lossy());
                     value
                 },
                 None => {
@@ -58,18 +58,27 @@ impl CommandDiscovery {
         };
 
         let mut paths = env::split_paths(&path_env).collect::<Vec<_>>();
-
-        // add exe home to start of path
-        if !using_custom_path {
-            if let Some(exe_home) = env::current_exe()?.parent() {
-                debug!("Adding exe home to path: {}", exe_home.to_string_lossy());
-                paths.insert(0, exe_home.to_path_buf());
-            }
-        }
-
-        // remove duplicate entries to improve perf of resource search
+        // remove duplicate entries
         let mut uniques = HashSet::new();
         paths.retain(|e|uniques.insert((*e).clone()));
+
+        // if exe home is not already in PATH env var then add it to env var and list of searched paths
+        if !using_custom_path {
+            if let Some(exe_home) = env::current_exe()?.parent() {
+                let exe_home_pb = exe_home.to_path_buf();
+                if !paths.contains(&exe_home_pb) {
+                    trace!("Adding exe home to path: {}", exe_home.to_string_lossy());
+                    paths.push(exe_home_pb);
+
+                    if let Ok(new_path) = env::join_paths(paths.clone()) {
+                        debug!("Using PATH: {:?}", new_path.to_string_lossy());
+                        env::set_var("PATH", &new_path);
+                    }
+                } else {
+                    trace!("Exe home is already in path: {}", exe_home.to_string_lossy());
+                }
+            }
+        };
 
         Ok(paths)
     }


### PR DESCRIPTION
# PR Summary

Fix #494 

As described in the issue, after this fix DSC will update its process PATH env var to have path to dsc.exe (unless it is already there), so that included resources manifests and executables are found.
A side effect of this change is that resource processes can assume that PATH env var that they are started with contains DSC home directory.

Note: the above behavior will not take place if `DSC_RESOURCE_PATH` env var is defined.
