### PR TITLE
Remove dependency on libssl

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -112,10 +112,6 @@ if ($null -ne $packageType) {
         }
     }
 
-    if ($IsLinux -and (Test-Path /etc/mariner-release)) {
-        tdnf install -y openssl-devel
-    }
-
     $BuildToolsPath = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2022\BuildTools\VC\Tools\MSVC"
 
     & $rustup default stable

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -20,6 +20,7 @@ dsc_lib = { path = "../dsc_lib" }
 indicatif = { version = "0.17" }
 jsonschema = "0.18"
 path-absolutize = { version = "3.1.1" }
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 schemars = { version = "0.8.12" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -8,9 +8,10 @@ base64 = "0.22"
 chrono = { version = "0.4.26" }
 derive_builder ="0.20"
 indicatif = { version = "0.17" }
-jsonschema = "0.17"
+jsonschema = "0.18"
 num-traits = "0.2"
 regex = "1.7"
+reqwest = { version = "0.12", features = ["rustls-tls"], default-features = false }
 schemars = { version = "0.8.12", features = ["preserve_order"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", features = ["preserve_order"] }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Explicitly use `rustls-tls` and set `default-features` to `false` for `reqwest` so that it doesn't use libssl

```console
PS> ldd ./bin/debug/dsc
        linux-vdso.so.1 (0x00007fff761ea000)
        libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007efd595ee000)
        libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007efd59507000)
        libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007efd592de000)
        /lib64/ld-linux-x86-64.so.2 (0x00007efd5b29d000)
```

## PR Context

Fix https://github.com/PowerShell/DSC/issues/442