### PR TITLE
Add error if input to `dsc resource test` is empty

### DIFF
--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -96,7 +96,7 @@ pub fn get_all(dsc: &DscManager, resource_type: &str, format: &Option<OutputForm
 
 pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Option<OutputFormat>) {
     if input.is_empty() {
-        error!("Error: Input is empty");
+        error!("Error: Desired input is empty");
         exit(EXIT_INVALID_ARGS);
     }
 
@@ -137,6 +137,11 @@ pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
 }
 
 pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: &Option<OutputFormat>) {
+    if input.is_empty() {
+        error!("Error: Expected input is required");
+        exit(EXIT_INVALID_ARGS);
+    }
+
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
         return

--- a/dsc/tests/dsc_resource_test.tests.ps1
+++ b/dsc/tests/dsc_resource_test.tests.ps1
@@ -1,0 +1,29 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Invoke a resource test directly' {
+    It 'test can be called on a resource' {
+        $os = if ($IsWindows) {
+            'Windows'
+        } elseif ($IsLinux) {
+            'Linux'
+        } elseif ($IsMacOS) {
+            'macOS'
+        } else {
+            'Unknown'
+        }
+
+        $out = @"
+        { "family": "$os" }
+"@ | dsc resource test -r Microsoft/OSInfo | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.actualState.family | Should -BeExactly $os
+        $out.inDesiredState | Should -Be $true
+    }
+
+    It 'test returns proper error code if no input is provded' {
+        $out = dsc resource test -r Microsoft/OSInfo 2>&1
+        $LASTEXITCODE | Should -Be 1
+        $out | Should -BeLike '*ERROR*'
+    }
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Currently, you get a error about `EOF` while `dsc` tries to read from STDIN (assuming input isn't provided via a file or directly either) and can be confusing.  This change explicitly checks if the input is empty and provides a better error message.

## PR Context

Fix #484 