### PR TITLE
Add specific error if PS class resource doesn't implement export

### DIFF
--- a/powershell-adapter/Tests/TestClassResource/0.0.1/TestClassResource.psd1
+++ b/powershell-adapter/Tests/TestClassResource/0.0.1/TestClassResource.psd1
@@ -34,7 +34,7 @@ VariablesToExport = @()
 AliasesToExport = @()
 
 # DSC resources to export from this module
-DscResourcesToExport = 'TestClassResource'
+DscResourcesToExport = @('TestClassResource', 'NoExport')
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{

--- a/powershell-adapter/Tests/TestClassResource/0.0.1/TestClassResource.psm1
+++ b/powershell-adapter/Tests/TestClassResource/0.0.1/TestClassResource.psm1
@@ -74,6 +74,49 @@ class TestClassResource : BaseTestClass
     }
 }
 
+[DscResource()]
+class NoExport: BaseTestClass
+{
+    [DscProperty(Key)]
+    [string] $Name
+
+    [DscProperty()]
+    [string] $Prop1
+
+    [DscProperty()]
+    [string] $EnumProp
+
+    [void] Set()
+    {
+    }
+
+    [bool] Test()
+    {
+        if (($this.Name -eq "TestClassResource1") -and ($this.Prop1 -eq "ValueForProp1"))
+        {
+            return $true
+        }
+        else
+        {
+            return $false
+        }
+    }
+
+    [NoExport] Get()
+    {
+        if ($this.Name -eq "TestClassResource1")
+        {
+            $this.Prop1 = "ValueForProp1"
+        }
+        else
+        {
+            $this.Prop1 = $env:DSC_CONFIG_ROOT
+        }
+        $this.EnumProp = ([EnumPropEnumeration]::Expected).ToString()
+        return $this
+    }
+}
+
 function Test-World()
 {
     "Hello world from PSTestModule!"

--- a/powershell-adapter/Tests/TestClassResource/0.0.1/TestClassResource.psm1
+++ b/powershell-adapter/Tests/TestClassResource/0.0.1/TestClassResource.psm1
@@ -92,27 +92,11 @@ class NoExport: BaseTestClass
 
     [bool] Test()
     {
-        if (($this.Name -eq "TestClassResource1") -and ($this.Prop1 -eq "ValueForProp1"))
-        {
-            return $true
-        }
-        else
-        {
-            return $false
-        }
+        return $true
     }
 
     [NoExport] Get()
     {
-        if ($this.Name -eq "TestClassResource1")
-        {
-            $this.Prop1 = "ValueForProp1"
-        }
-        else
-        {
-            $this.Prop1 = $env:DSC_CONFIG_ROOT
-        }
-        $this.EnumProp = ([EnumPropEnumeration]::Expected).ToString()
         return $this
     }
 }

--- a/powershell-adapter/Tests/powershellgroup.config.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.config.tests.ps1
@@ -71,6 +71,23 @@ Describe 'PowerShell adapter resource tests' {
         $res.resources[0].properties.result[0].Prop1 | Should -Be "Property of object1"
     }
 
+    It 'Export fails when class-based resource does not implement' {
+        $yaml = @'
+            $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+            resources:
+            - name: Working with class-based resources
+              type: Microsoft.DSC/PowerShell
+              properties:
+                resources:
+                - name: Class-resource Info
+                  type: TestClassResource/NoExport
+'@
+        $out = $yaml | dsc config export 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 2
+        $out | Should -Not -BeNullOrEmpty
+        $out | Should -BeLike "*ERROR*Export method not implemented by resource 'TestClassResource/NoExport'*"
+    }
+
     It 'Custom psmodulepath in config works' {
 
         $OldPSModulePath  = $env:PSModulePath

--- a/powershell-adapter/psDscAdapter/psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/psDscAdapter.psm1
@@ -475,6 +475,10 @@ function Invoke-DscOperation {
                         'Export' {
                             $t = $dscResourceInstance.GetType()
                             $method = $t.GetMethod('Export')
+                            if ($null -eq $method) {
+                                "Export method not implemented by resource '$($DesiredState.Type)'" | Write-DscTrace -Operation Error
+                                exit 1
+                            }
                             $resultArray = $method.Invoke($null,$null)
                             $addToActualState = $resultArray
                         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The current adapter needs a check when discovering the `export` method of a class and it's not found.  In this case, it will return a specific error message is `export` is attempted and not implemented:

```console
PS> dsc config export -d $document
2024-07-30T00:34:43.531017Z ERROR Process id 3408 : Export method not implemented by resource 'Microsoft.WinGet.DSC/WinGetPackage'
2024-07-30T00:34:43.613933Z ERROR Error: Command: Resource 'pwsh' [Exit code 1] manifest description: Error
```

## PR Context

Fix https://github.com/PowerShell/DSC/issues/503