### PR TITLE
Return error message if specified adapter doesn't exist

### DIFF
--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -66,4 +66,10 @@ Describe 'Tests for listing resources' {
         $resource.capabilities | Should -Contain 'Get'
         $resource.capabilities | Should -Contain 'Export'
     }
+
+    It 'Invalid adapter returns an error' {
+        $out = dsc resource list --adapter 'foo*' 2>&1 | Out-String
+        $LASTEXITCODE | Should -Be 0
+        $out | Should -BeLike "*ERROR*Adapter 'foo`*' not found*"
+    }
 }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -204,12 +204,14 @@ impl ResourceDiscovery for CommandDiscovery {
 
         let mut adapted_resources = BTreeMap::<String, Vec<DscResource>>::new();
 
+        let mut found_adapter: bool = false;
         for (adapter_name, adapters) in &self.adapters {
             for adapter in adapters {
                 if !regex.is_match(adapter_name) {
                     continue;
                 }
 
+                found_adapter = true;
                 info!("Enumerating resources for adapter '{}'", adapter_name);
                 let pb_adapter_span = warn_span!("");
                 pb_adapter_span.pb_set_style(&ProgressStyle::with_template(
@@ -270,6 +272,10 @@ impl ResourceDiscovery for CommandDiscovery {
 
                 debug!("Adapter '{}' listed {} resources", adapter_name, adapter_resources_count);
             }
+        }
+
+        if !found_adapter {
+            return Err(DscError::AdapterNotFound(adapter_filter.to_string()));
         }
 
         self.adapted_resources = adapted_resources;

--- a/dsc_lib/src/dscerror.rs
+++ b/dsc_lib/src/dscerror.rs
@@ -10,6 +10,9 @@ use tree_sitter::LanguageError;
 
 #[derive(Error, Debug)]
 pub enum DscError {
+    #[error("Adapter '{0}' not found")]
+    AdapterNotFound(String),
+
     #[error("Function boolean argument conversion error: {0}")]
     BooleanConversion(#[from] std::str::ParseBoolError),
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

With this change, if the specified adapter (or wildcard) returns no results, an error message is displayed, however a zero exit code is still returned.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/477