### PR TITLE
Enable multiline string support in tree-sitter gammar

### DIFF
--- a/dsc/examples/multiline.dsc.yaml
+++ b/dsc/examples/multiline.dsc.yaml
@@ -1,9 +1,13 @@
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
 resources:
-- name: test
+- name: test multi-line
   type: Test/Echo
   properties:
     output: |
       This is a
-      multi-line
+      'multi-line'
       string.
+- name: test single-quote escaping
+  type: Test/Echo
+  properties:
+    output: "[concat('This is a single-quote: ', '''')]"

--- a/dsc/examples/multiline.dsc.yaml
+++ b/dsc/examples/multiline.dsc.yaml
@@ -1,0 +1,9 @@
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+resources:
+- name: test
+  type: Test/Echo
+  properties:
+    output: |
+      This is a
+      multi-line
+      string.

--- a/dsc/examples/winps_script.dsc.yaml
+++ b/dsc/examples/winps_script.dsc.yaml
@@ -1,0 +1,25 @@
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+metadata:
+  Microsoft.DSC:
+    securityContext: Elevated
+resources:
+  - type: Microsoft.Windows/WindowsPowerShell
+    name: Run WinPS script
+    properties: 
+      resources:
+        - name: Run script
+          type: PSDesiredStateConfiguration/Script
+          properties:
+            GetScript: |
+              $text = @"
+              get
+              "@
+              # Returning result must be this type of hashtable
+              @{Result=$text}
+            TestScript: |
+              # TestScript must return a boolean
+              $true
+            SetScript: |
+              $text = @"
+              set
+              "@

--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -63,4 +63,16 @@ resources:
         $LASTEXITCODE | Should -Be 2
         $out | Should -BeLike "*ERROR*"
     }
+
+    It 'Multi-line string literals work' {
+      $yamlPath = "$PSScriptRoot/../examples/multiline.dsc.yaml"
+      $out = dsc config get -p $yamlPath | ConvertFrom-Json
+      $LASTEXITCODE | Should -Be 0
+      $out.results[0].result.actualState.output | Should -BeExactly @"
+This is a
+multi-line
+string.
+
+"@
+    }
 }

--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -70,9 +70,10 @@ resources:
       $LASTEXITCODE | Should -Be 0
       $out.results[0].result.actualState.output | Should -BeExactly @"
 This is a
-multi-line
+'multi-line'
 string.
 
-"@
+"@.Replace("`r", "")
+      $out.results[1].result.actualState.output | Should -BeExactly "This is a single-quote: '"
     }
 }

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -97,7 +97,8 @@ fn convert_args_node(statement_bytes: &[u8], args: &Option<Node>) -> Result<Opti
         match arg.kind() {
             "string" => {
                 let value = arg.utf8_text(statement_bytes)?;
-                result.push(FunctionArg::Value(Value::String(value.to_string())));
+                // Resolve escaped single quotes
+                result.push(FunctionArg::Value(Value::String(value.to_string().replace("''", "'"))));
             },
             "number" => {
                 let value = arg.utf8_text(statement_bytes)?;

--- a/tree-sitter-dscexpression/build.ps1
+++ b/tree-sitter-dscexpression/build.ps1
@@ -48,7 +48,7 @@ if ($UpdatePackages) {
     npm cache clean --force
     npm logout
     vsts-npm-auth -config .npmrc -F -V
-    npm install --force --verbose
+    npm install --force --verbose --registry https://pkgs.dev.azure.com/mseng/_packaging/OneESD-DevOps/npm/registry/
 }
 
 Invoke-NativeCommand 'npx tree-sitter generate --build'

--- a/tree-sitter-dscexpression/grammar.js
+++ b/tree-sitter-dscexpression/grammar.js
@@ -7,6 +7,8 @@ const PREC = {
 module.exports = grammar({
   name: 'dscexpression',
 
+  extras: $ => ['\n', ' '],
+
   rules: {
     statement: $ => choice(
       $.escapedStringLiteral,
@@ -16,7 +18,7 @@ module.exports = grammar({
     escapedStringLiteral: $ => token(prec(PREC.ESCAPEDSTRING, seq('[[', /.*?/))),
     _expressionString: $ => prec(PREC.EXPRESSIONSTRING, seq('[', $.expression, ']')),
     expression: $ => seq(field('function', $.function), optional(field('accessor',$.accessor))),
-    stringLiteral: $ => token(prec(PREC.STRINGLITERAL, /[^\[].*?/)),
+    stringLiteral: $ => token(prec(PREC.STRINGLITERAL, /[^\[](.|\n)*?/)),
 
     function: $ => seq(field('name', $.functionName), '(', field('args', optional($.arguments)), ')'),
     functionName: $ => /[a-z][a-zA-Z0-9]*/,
@@ -24,8 +26,8 @@ module.exports = grammar({
     _argument: $ => choice($.expression, $._quotedString, $.number, $.boolean),
 
     _quotedString: $ => seq('\'', $.string, '\''),
-    // ARM strings are allowed to contain single-quote characters
-    string: $ => /[^']*/,
+    // ARM strings are not allowed to contain single-quote characters unless escaped
+    string: $ => /([^']|''|\n)*/,
     number: $ => /-?\d+/,
     boolean: $ => choice('true', 'false'),
 

--- a/tree-sitter-dscexpression/package-lock.json
+++ b/tree-sitter-dscexpression/package-lock.json
@@ -866,7 +866,7 @@
     },
     "node_modules/ometajs": {
       "version": "3.2.4",
-      "integrity": "sha1-gHzfTA6N8XJ/Ikym2x+qxD6L2rE=",
+      "integrity": "sha512-Usw3SnzRqklgU2kFJNrO+8npseWuywNyTL5LC0q47IM/7AS0AEWzeNRmLf8I77xTeU3y88gwY8eTApQ0oCjcGg==",
       "optional": true,
       "dependencies": {
         "coa": "0.3.x",
@@ -1316,7 +1316,7 @@
     },
     "node_modules/uglify-js": {
       "version": "1.3.5",
-      "integrity": "sha1-S1v/+Rhu/7qoiOTJ6UvZ/EyUkp0=",
+      "integrity": "sha512-YPX1DjKtom8l9XslmPFQnqWzTBkvI4N0pbkzLuPZZ4QTyig0uQqvZz9NgUdfEV+qccJzi7fVcGWdESvRIjWptQ==",
       "optional": true,
       "bin": {
         "uglifyjs": "bin/uglifyjs"

--- a/tree-sitter-dscexpression/test/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/test/corpus/invalid_expressions.txt
@@ -198,3 +198,19 @@ Expression with index accessor outside
             (number))))
       (ERROR
         (number)))
+
+=====
+String with un-escaped single-quote
+=====
+[myFunction('argString'test'value')]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (arguments
+            (string))
+          (ERROR
+            (functionName)
+            (functionName)))))

--- a/tree-sitter-dscexpression/test/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/test/corpus/valid_expressions.txt
@@ -274,3 +274,50 @@ Array index with function and nested dot-notation with index
               (memberName)))))
       (index
         (number)))))
+
+=====
+Multi-line expression
+=====
+[myFunction(
+  'argString',
+  1,
+  -1,
+  true
+)]
+---
+
+(statement
+  (expression
+    (function
+      (functionName)
+      (arguments
+        (string)
+        (number)
+        (number)
+        (boolean)))))
+
+=====
+Multi-line literal string
+=====
+This
+is
+a
+multiline
+string
+---
+
+(statement
+  (stringLiteral))
+
+=====
+Escaped single-quotes
+=====
+[myFunction('this ''is'' a string')]
+---
+
+(statement
+  (expression
+    (function
+      (functionName)
+      (arguments
+        (string)))))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The grammar did not allow for newlines so each newline had the tree-sitter parser evaluate it as a new statement which was wrong.  The change in the grammar is:

- allow newlines and spaces anywhere
- explicitly allow literal strings to contain newlines
- also fixed it so strings can contain escaped single quotes

Updated tree-sitter tests and added example of WinPS Script resource with multi-line

## PR Context

Fix https://github.com/PowerShell/DSC/issues/518