### PR TITLE
Add ability to use expression as array index within an expression

### DIFF
--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -10,6 +10,8 @@ Describe 'Expressions tests' {
         @{ text = "[parameters('test').objectArray[0].name]"; expected = 'one' }
         @{ text = "[parameters('test').objectArray[1].value[0]]"; expected = '2' }
         @{ text = "[parameters('test').objectArray[1].value[1].name]"; expected = 'three' }
+        @{ text = "[parameters('test').index]"; expected = '1' }
+        @{ text = "[parameters('test').objectArray[parameters('test').index].name]"; expected = 'two' }
     ) {
         param($text, $expected)
         $yaml = @"
@@ -18,6 +20,7 @@ parameters:
   test:
     type: object
     defaultValue:
+      index: 1
       hello:
         world: there
       array:
@@ -38,9 +41,9 @@ resources:
   properties:
     output: "$text"
 "@
-        $debug = $yaml | dsc -l debug config get -f yaml 2>&1 | Out-String
+        $debug = $yaml | dsc -l trace config get -f yaml 2>&1 | Out-String
         $out = $yaml | dsc config get | ConvertFrom-Json
-        $LASTEXITCODE | Should -Be 0
+        $LASTEXITCODE | Should -Be 0 -Because $debug
         $out.results[0].result.actualState.output | Should -Be $expected -Because $debug
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Was doing some ad hoc testing and I had not initially added the ability to use an expression as an array index.  Looked it up and ARM templates support it, so added it here.

The only interesting part is now I have an `IndexExpression` member of the `Accessor` enum, but both that and just `Index` needs to actually index into the array.  So instead of having the same code within two match blocks, I use a flag to track if it should run outside of the match.  

I also considered pulling it out as a helper function, but seemed overkill for this use.
