### PR TITLE
Change installing modules for testing to use AzArtifacts feed

### DIFF
--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -28,7 +28,7 @@ extends:
       WindowsHostVersion:
         Disk: Large
         Version: 2022    
-        Network: NetLock
+#        Network: NetLock
     customTags: 'ES365AIMigrationTooling'
     globalSdl:
       disableLegacyManifest: true

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -28,6 +28,7 @@ extends:
       WindowsHostVersion:
         Disk: Large
         Version: 2022    
+        Network: NetLock
     customTags: 'ES365AIMigrationTooling'
     globalSdl:
       disableLegacyManifest: true

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -33,9 +33,11 @@ extends:
   template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     featureFlags:
-      WindowsHostVersion:
+      WindowsHostVersion: 
         Disk: Large
-        Version: 2022    
+        Version: 2022
+          Network: KS3 # this retricts network access to public upstream repositories
+# Currently can't be used as some NPM pkgs like tree-sitter-cli reach out to GitHub to get the actual zip pkg
 #        Network: NetLock
     customTags: 'ES365AIMigrationTooling'
     globalSdl:
@@ -57,7 +59,7 @@ extends:
         apiscan:
           enabled: false
 
-    stages:
+    stages:     
     - stage: BuildAndSign
       displayName: Build Native Binaries
       dependsOn: []

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -7,6 +7,14 @@ pr:
     - onebranch
     - release*
 
+schedules:
+- cron: '0 3 * * 1'
+  displayName: Weekly Build
+  branches:
+    include:
+    - main
+  always: true
+
 variables:
   BuildConfiguration: 'release'
   PackageRoot: '$(System.ArtifactsDirectory)/Packages'

--- a/build.ps1
+++ b/build.ps1
@@ -368,7 +368,7 @@ if ($Test) {
         $FullyQualifiedName = @{ModuleName="PSDesiredStateConfiguration";ModuleVersion="2.0.7"}
         if (-not(Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName))
         {
-            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository $repository
+            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository $repository -Verbose
         }
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -368,6 +368,7 @@ if ($Test) {
         $FullyQualifiedName = @{ModuleName="PSDesiredStateConfiguration";ModuleVersion="2.0.7"}
         if (-not(Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName))
         {
+            write-verbose -verbose "Using '$repository' repository"
             Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository $repository -Verbose
         }
     }

--- a/build.ps1
+++ b/build.ps1
@@ -352,18 +352,23 @@ if (!$Clippy -and !$SkipBuild) {
 if ($Test) {
     $failed = $false
 
+    if ($null -eq (Get-PSResourceRepository -Name CFS -ErrorAction Ignore)) {
+        "Registering CFS repository"
+        Register-PSResourceRepository -uri 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v2' -Name CFS -Trusted
+    }
+
     if ($IsWindows) {
         # PSDesiredStateConfiguration module is needed for Microsoft.Windows/WindowsPowerShell adapter
         $FullyQualifiedName = @{ModuleName="PSDesiredStateConfiguration";ModuleVersion="2.0.7"}
         if (-not(Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName))
         {   "Installing module PSDesiredStateConfiguration 2.0.7"
-            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository PSGallery -TrustRepository
+            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository CFS
         }
     }
 
     if (-not(Get-Module -ListAvailable -Name Pester))
     {   "Installing module Pester"
-        Install-PSResource Pester -WarningAction Ignore -Repository PSGallery -TrustRepository
+        Install-PSResource Pester -WarningAction Ignore -Repository CFS
     }
 
     foreach ($project in $projects) {

--- a/build.ps1
+++ b/build.ps1
@@ -421,7 +421,7 @@ if ($Test) {
         if (-not(Get-Module -ListAvailable -Name Pester))
         {   "Installing module Pester"
             $InstallTargetDir = ($env:PSModulePath -split ";")[0]
-            Find-PSResource -Name 'Pester' -Repository 'PSGallery' | Save-PSResource -Path $InstallTargetDir -TrustRepository
+            Find-PSResource -Name 'Pester' -Repository $repository | Save-PSResource -Path $InstallTargetDir -TrustRepository
         }
 
         "Updated Pester module location:"

--- a/build.ps1
+++ b/build.ps1
@@ -368,14 +368,13 @@ if ($Test) {
         $FullyQualifiedName = @{ModuleName="PSDesiredStateConfiguration";ModuleVersion="2.0.7"}
         if (-not(Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName))
         {
-            write-verbose -verbose "Using '$repository' repository"
-            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository $repository -Verbose
+            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository $repository -TrustRepository
         }
     }
 
     if (-not(Get-Module -ListAvailable -Name Pester))
     {   "Installing module Pester"
-        Install-PSResource Pester -WarningAction Ignore -Repository $repository
+        Install-PSResource Pester -WarningAction Ignore -Repository $repository -TrustRepository
     }
 
     foreach ($project in $projects) {

--- a/build.ps1
+++ b/build.ps1
@@ -353,6 +353,7 @@ if ($Test) {
     $failed = $false
 
     $usingADO = ($null -ne $env:TF_BUILD)
+    $repository = 'PSGallery'
 
     if ($usingADO) {
         $repository = 'CFS'
@@ -361,15 +362,12 @@ if ($Test) {
             Register-PSResourceRepository -uri 'https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/nuget/v2' -Name CFS -Trusted
         }
     }
-    else {
-        $repository = 'PSGallery'
-    }
 
     if ($IsWindows) {
         # PSDesiredStateConfiguration module is needed for Microsoft.Windows/WindowsPowerShell adapter
         $FullyQualifiedName = @{ModuleName="PSDesiredStateConfiguration";ModuleVersion="2.0.7"}
         if (-not(Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName))
-        {   "Installing module PSDesiredStateConfiguration 2.0.7"
+        {
             Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository $repository
         }
     }

--- a/build.ps1
+++ b/build.ps1
@@ -362,13 +362,13 @@ if ($Test) {
         $FullyQualifiedName = @{ModuleName="PSDesiredStateConfiguration";ModuleVersion="2.0.7"}
         if (-not(Get-Module -ListAvailable -FullyQualifiedName $FullyQualifiedName))
         {   "Installing module PSDesiredStateConfiguration 2.0.7"
-            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository CFS
+            Install-PSResource -Name PSDesiredStateConfiguration -Version 2.0.7 -Repository CFS -Verbose
         }
     }
 
     if (-not(Get-Module -ListAvailable -Name Pester))
     {   "Installing module Pester"
-        Install-PSResource Pester -WarningAction Ignore -Repository CFS
+        Install-PSResource Pester -WarningAction Ignore -Repository CFS -Verbose
     }
 
     foreach ($project in $projects) {

--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "dsc"
-version = "3.0.0-preview.9"
+version = "3.0.0-preview.10"
 dependencies = [
  "atty",
  "clap",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Need to change installing of modules during testing to use our AzArtifacts feed

For GitHub CI, we need to use PSGallery as it won't successfully access the AzArtifacts feed, but when run in ADO, we need to use the AzArtifacts feed.

Also updated the lockfile to include the updated version for dsc.
