### PR TITLE
Add `pass-through` trace format to `dsc` so that child-processes get traced appropriately by top process

### DIFF
--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -500,6 +500,7 @@ dependencies = [
  "base64",
  "cc",
  "chrono",
+ "clap",
  "derive_builder",
  "indicatif",
  "jsonschema",

--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -7,6 +7,8 @@
   "get": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-group",
       "test",
@@ -17,6 +19,8 @@
   "set": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-group",
       "test"
@@ -28,6 +32,8 @@
   "test": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-group",
       "test",
@@ -45,19 +51,11 @@
     "5": "Resource instance failed schema validation",
     "6": "Command cancelled"
   },
-  "schema": {
-    "command": {
-      "executable": "dsc",
-      "args": [
-        "schema",
-        "--type",
-        "configuration"
-      ]
-    }
-  },
   "validate": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "validate"
     ],

--- a/dsc/group.dsc.resource.json
+++ b/dsc/group.dsc.resource.json
@@ -7,6 +7,8 @@
   "get": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-group",
       "get"
@@ -16,6 +18,8 @@
   "set": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-group",
       "set"
@@ -27,6 +31,8 @@
   "test": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-group",
       "test"
@@ -46,6 +52,8 @@
   "validate": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "validate"
     ],

--- a/dsc/include.dsc.resource.json
+++ b/dsc/include.dsc.resource.json
@@ -7,6 +7,8 @@
   "get": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-include",
       "--as-group",
@@ -17,6 +19,8 @@
   "set": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-include",
       "--as-group",
@@ -29,6 +33,8 @@
   "test": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-include",
       "--as-group",
@@ -48,6 +54,8 @@
   "validate": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--as-include",
       "validate"

--- a/dsc/parallel.dsc.resource.json
+++ b/dsc/parallel.dsc.resource.json
@@ -7,6 +7,8 @@
   "get": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--parallel",
       "--as-group",
@@ -17,6 +19,8 @@
   "set": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--parallel",
       "--as-group",
@@ -29,6 +33,8 @@
   "test": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "--parallel",
       "--as-group",
@@ -49,6 +55,8 @@
   "validate": {
     "executable": "dsc",
     "args": [
+      "--trace-format",
+      "pass-through",
       "config",
       "validate"
     ],

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -16,6 +16,8 @@ pub enum TraceFormat {
     Default,
     Plaintext,
     Json,
+    #[clap(hide = true)]
+    PassThrough,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -3,6 +3,7 @@
 
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
+use dsc_lib::dscresources::command_resource::TraceLevel;
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum OutputFormat {
@@ -18,15 +19,6 @@ pub enum TraceFormat {
     Json,
     #[clap(hide = true)]
     PassThrough,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
-pub enum TraceLevel {
-    Error,
-    Warn,
-    Info,
-    Debug,
-    Trace
 }
 
 #[derive(Debug, Parser)]

--- a/dsc/src/tablewriter.rs
+++ b/dsc/src/tablewriter.rs
@@ -1,4 +1,4 @@
-use crossterm::terminal::{size};
+use crossterm::terminal::size;
 
 pub struct Table {
     header: Vec<String>,
@@ -8,13 +8,13 @@ pub struct Table {
 
 impl Table {
     /// Create a new table.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `header` - The header row
-    /// 
+    ///
     /// # Returns
-    /// 
+    ///
     /// * `Table` - The new table
     #[must_use]
     pub fn new(header: &[&str]) -> Table {
@@ -31,9 +31,9 @@ impl Table {
     }
 
     /// Add a row to the table.
-    /// 
+    ///
     /// # Arguments
-    /// 
+    ///
     /// * `row` - The row to add
     pub fn add_row(&mut self, row: Vec<String>) {
         for (i, column) in row.iter().enumerate() {

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -323,7 +323,7 @@ pub fn enable_tracing(trace_level: &Option<TraceLevel>, trace_format: &TraceForm
                 .with_line_number(with_source)
                 .boxed()
         },
-        TraceFormat::Json => {
+        TraceFormat::Json | TraceFormat::PassThrough => {
             layer
                 .with_ansi(false)
                 .with_level(true)
@@ -331,7 +331,7 @@ pub fn enable_tracing(trace_level: &Option<TraceLevel>, trace_format: &TraceForm
                 .with_line_number(with_source)
                 .json()
                 .boxed()
-        }
+        },
     };
 
     let subscriber = tracing_subscriber::Registry::default().with(fmt).with(filter).with(indicatif_layer);

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::args::{DscType, OutputFormat, TraceFormat, TraceLevel};
-
+use crate::args::{DscType, OutputFormat, TraceFormat};
 use atty::Stream;
 use crate::resolve::Include;
 use dsc_lib::{
@@ -16,6 +15,7 @@ use dsc_lib::{
     },
     dscerror::DscError,
     dscresources::{
+        command_resource::TraceLevel,
         dscresource::DscResource, invoke_result::{
             GetResult,
             SetResult,

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -85,4 +85,16 @@ Describe 'tracing tests' {
         $out = (dsc -l $level config get -d $configYaml 2> $null) | ConvertFrom-Json
         $out.results[0].result.actualState.level | Should -BeExactly $level
     }
+
+    It 'Pass-through tracing should only emit JSON for child processes' {
+        $logPath = "$TestDrive/dsc_trace.log"
+        $out = dsc -l info -f pass-through  config get -p ../examples/groups.dsc.yaml 2> $logPath
+        foreach ($line in (Get-Content $logPath)) {
+            $line | Should -Not -BeNullOrEmpty
+            $json = $line | ConvertFrom-Json
+            $json.timestamp | Should -Not -BeNullOrEmpty
+            $json.level | Should -BeIn 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'
+        }
+        $out | Should -BeNullOrEmpty
+    }
 }

--- a/dsc_lib/Cargo.lock
+++ b/dsc_lib/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "base64",
  "cc",
  "chrono",
+ "clap",
  "derive_builder",
  "indicatif",
  "jsonschema",

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 base64 = "0.22.1"
 chrono = "0.4.26"
+clap = { version = "4.4", features = ["derive"] }
 derive_builder ="0.20.0"
 indicatif = "0.17.0"
 jsonschema = "0.18.0"

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -826,46 +826,26 @@ pub fn log_stderr_line<'a>(process_id: &u32, trace_line: &'a str) -> &'a str
                 include_target = false;
                 0
             };
+            let trace_message = if include_target {
+                format!("Process {process_id}: {target}: {line_number}: {}", trace_object.fields.message)
+            } else {
+                format!("Process {process_id}: {}", trace_object.fields.message)
+            };
             match trace_object.level {
                 TraceLevel::Error => {
-                    if include_target {
-                        error!("Process {process_id}: {target}: {line_number}: {}", trace_object.fields.message);
-                    }
-                    else {
-                        error!("Process {process_id}: {}", trace_object.fields.message);
-                    }
+                    error!(trace_message);
                 },
                 TraceLevel::Warning => {
-                    if include_target {
-                        warn!("Process {process_id}: {target}: {line_number}: {}", trace_object.fields.message);
-                    }
-                    else {
-                        warn!("Process {process_id}: {}", trace_object.fields.message);
-                    }
+                    warn!(trace_message);
                 },
                 TraceLevel::Info => {
-                    if include_target {
-                        info!("Process {process_id}: {target}: {line_number}: {}", trace_object.fields.message);
-                    }
-                    else {
-                        info!("Process {process_id}: {}", trace_object.fields.message);
-                    }
+                    info!(trace_message);
                 },
                 TraceLevel::Debug => {
-                    if include_target {
-                        debug!("Process {process_id}: {target}: {line_number}: {}", trace_object.fields.message);
-                    }
-                    else {
-                        debug!("Process {process_id}: {}", trace_object.fields.message);
-                    }
+                    debug!(trace_message);
                 },
                 TraceLevel::Trace => {
-                    if include_target {
-                        trace!("Process {process_id}: {target}: {line_number}: {}", trace_object.fields.message);
-                    }
-                    else {
-                        trace!("Process {process_id}: {}", trace_object.fields.message);
-                    }
+                    trace!(trace_message);
                 },
             }
         }

--- a/runcommandonset/RunCommandOnSet.dsc.resource.json
+++ b/runcommandonset/RunCommandOnSet.dsc.resource.json
@@ -6,6 +6,8 @@
     "get": {
         "executable": "runcommandonset",
         "args": [
+          "--trace-format",
+          "json",
           "get"
         ],
         "input": "stdin"
@@ -13,6 +15,8 @@
     "set": {
         "executable": "runcommandonset",
         "args": [
+          "--trace-format",
+          "json",
           "set"
         ],
         "input": "stdin",

--- a/tools/test_group_resource/Cargo.lock
+++ b/tools/test_group_resource/Cargo.lock
@@ -369,6 +369,7 @@ dependencies = [
  "base64",
  "cc",
  "chrono",
+ "clap",
  "derive_builder",
  "indicatif",
  "jsonschema",

--- a/tree-sitter-dscexpression/build.ps1
+++ b/tree-sitter-dscexpression/build.ps1
@@ -29,7 +29,12 @@ if ($null -eq (Get-Command npm -ErrorAction Ignore)) {
     }
 }
 
-npm ci --omit:optional --force --registry https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/npm/registry/
+if ($null -ne $env:TF_BUILD) {
+    npm ci --omit:optional --registry https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/npm/registry/
+}
+else {
+    npm install --omit:optional --registry https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/npm/registry/
+}
 
 #npm list tree-sitter-cli
 #if ($LASTEXITCODE -ne 0) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Previously traces were rendered by child `dsc` processes which polluted the output and trace level didn't match what the user requested as they would be written at `trace` level only.

Change is to add a `pass-through` format which also makes child `dsc` not trace the output but instead write the JSON to stderr.

The top most `dsc` process will deserialize the JSON and write the traces with the appropriate trace level and also include the child process id to get a better idea of the process tree.

Also update the tree-sitter build script to not do a clean install of node modules unless running in ADO as it's way too slow.

Example with just INFO level:

<img width="1792" alt="image" src="https://github.com/user-attachments/assets/246432d8-dbef-44ec-b45b-174a0051713a">


## Context

Fix https://github.com/PowerShell/DSC/issues/512