### PR TITLE
Rename `Import` kind to `Importer`

### DIFF
--- a/dsc/include.dsc.resource.json
+++ b/dsc/include.dsc.resource.json
@@ -3,7 +3,7 @@
   "type": "Microsoft.DSC/Include",
   "version": "0.1.0",
   "description": "Allows including a configuration file with optional parameter file.",
-  "kind": "Import",
+  "kind": "Importer",
   "get": {
     "executable": "dsc",
     "args": [

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -267,7 +267,7 @@ pub fn invoke_test(resource: &ResourceManifest, cwd: &str, expected: &str) -> Re
         verify_json(resource, cwd, &stdout)?;
     }
 
-    if resource.kind == Some(Kind::Import) {
+    if resource.kind == Some(Kind::Importer) {
         debug!("Import resource kind, returning group test response");
         let group_test_response: Vec<ResourceTestResult> = serde_json::from_str(&stdout)?;
         return Ok(TestResult::Group(group_test_response));

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -13,7 +13,7 @@ use crate::dscerror::DscError;
 pub enum Kind {
     Adapter,
     Group,
-    Import,
+    Importer,
     Resource,
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Rename `Import` to `Importer` so all the kinds are nouns

## PR Context

Fix https://github.com/PowerShell/DSC/issues/436