### PR TITLE
Add proper tracing to `registry` resource

### DIFF
--- a/registry/Cargo.lock
+++ b/registry/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +196,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +230,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -232,6 +256,28 @@ dependencies = [
  "wasi",
  "windows-sys",
 ]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+
+[[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "parking_lot"
@@ -255,6 +301,12 @@ dependencies = [
  "smallvec",
  "windows-targets",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
 
 [[package]]
 name = "proc-macro2"
@@ -284,6 +336,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex"
+version = "1.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
 name = "registry"
 version = "0.1.0"
 dependencies = [
@@ -295,6 +391,8 @@ dependencies = [
  "serde_json",
  "static_vcruntime",
  "thiserror",
+ "tracing",
+ "tracing-subscriber",
  "utfx",
 ]
 
@@ -404,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "signal-hook"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -483,6 +590,90 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3523ab5a71916ccf420eebdf5521fcef02141234bbc0b8a49f2fdc4544364ef"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c06d3da6113f116aaee68e4d601191614c9053067f9ab7f6edbcb161237daa54"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +690,12 @@ name = "utfx"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "133bf74f01486773317ddfcde8e2e20d2933cc3b68ab797e5d718bef996a81de"
+
+[[package]]
+name = "valuable"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 
 [[package]]
 name = "wasi"

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -21,6 +21,8 @@ schemars = "0.8.0"
 serde = "1.0.130"
 serde_json = "1.0.68"
 thiserror = "1.0.30"
+tracing = { version = "0.1.37" }
+tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }
 utfx = "0.1.0"
 
 [build-dependencies]

--- a/registry/src/main.rs
+++ b/registry/src/main.rs
@@ -123,7 +123,7 @@ fn main() {
 
 pub fn enable_tracing() {
     // default filter to trace level
-    let filter = EnvFilter::builder().with_default_directive(LevelFilter::TRACE.into()).parse("").unwrap();
+    let filter = EnvFilter::builder().with_default_directive(LevelFilter::TRACE.into()).parse("").unwrap_or_default();
     let layer = tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
     let fmt = layer
                 .with_ansi(false)

--- a/registry/src/main.rs
+++ b/registry/src/main.rs
@@ -12,8 +12,7 @@ use registry_helper::RegistryHelper;
 use schemars::schema_for;
 use std::process::exit;
 use tracing::{debug, error};
-use tracing_subscriber::{EnvFilter, Layer, prelude::__tracing_subscriber_SubscriberExt};
-
+use tracing_subscriber::{filter::LevelFilter, prelude::__tracing_subscriber_SubscriberExt, EnvFilter, Layer};
 use crate::config::Registry;
 
 mod args;
@@ -49,6 +48,7 @@ fn main() {
         args::SubCommand::Config { subcommand } => {
             match subcommand {
                 args::ConfigSubCommand::Get{input} => {
+                    debug!("Get input: {input}");
                     let reg_helper = match RegistryHelper::new(&input) {
                         Ok(reg_helper) => reg_helper,
                         Err(err) => {
@@ -68,6 +68,7 @@ fn main() {
                     }
                 },
                 args::ConfigSubCommand::Set{input, what_if} => {
+                    debug!("Set input: {input}, what_if: {what_if}");
                     let mut reg_helper = match RegistryHelper::new(&input) {
                         Ok(reg_helper) => reg_helper,
                         Err(err) => {
@@ -92,6 +93,7 @@ fn main() {
                     }
                 },
                 args::ConfigSubCommand::Delete{input} => {
+                    debug!("Delete input: {input}");
                     let reg_helper = match RegistryHelper::new(&input) {
                         Ok(reg_helper) => reg_helper,
                         Err(err) => {
@@ -120,9 +122,8 @@ fn main() {
 }
 
 pub fn enable_tracing() {
-    let filter = EnvFilter::try_from_default_env()
-        .or_else(|_| EnvFilter::try_new("trace"))
-        .unwrap_or_default();
+    // default filter to trace level
+    let filter = EnvFilter::builder().with_default_directive(LevelFilter::TRACE.into()).parse("").unwrap();
     let layer = tracing_subscriber::fmt::Layer::default().with_writer(std::io::stderr);
     let fmt = layer
                 .with_ansi(false)

--- a/registry/tests/registry.config.get.tests.ps1
+++ b/registry/tests/registry.config.get.tests.ps1
@@ -35,13 +35,13 @@ Describe 'Registry config get tests' {
         # keyPath should return Access Denied
         $json = @'
         {
-            "keyPath": "HKLM\\SYSTEM\\CurrentControlSet\\Control\\SecurePipeServers\\Winreg"
+            "keyPath": "HKLM\\SYSTEM\\CurrentControlSet\\Control"
         }
 '@
         $out = registry config get --input $json 2>&1
-        $LASTEXITCODE | Should -Be 3
+        $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
-        $result.level | Should -BeExactly 'ERROR'
-        $result.fields.message | Should -BeLike '*Permission denied*'
+        $result[0].level | Should -BeExactly 'DEBUG'
+        $result[0].fields.message | Should -BeLike 'Get Input:*'
     }
 }

--- a/registry/tests/registry.config.get.tests.ps1
+++ b/registry/tests/registry.config.get.tests.ps1
@@ -30,4 +30,18 @@ Describe 'Registry config get tests' {
         $result.valueData.ExpandString | Should -Be '%ProgramFiles%'
         ($result.psobject.properties | Measure-Object).Count | Should -Be 3
     }
+
+    It 'Traces should be JSON' -Skip:(!$IsWindows) {
+        # keyPath should return Access Denied
+        $json = @'
+        {
+            "keyPath": "HKLM\\SYSTEM\\CurrentControlSet\\Control\\SecurePipeServers\\Winreg"
+        }
+'@
+        $out = registry config get --input $json 2>&1
+        $LASTEXITCODE | Should -Be 3
+        $result = $out | ConvertFrom-Json
+        $result.level | Should -BeExactly 'ERROR'
+        $result.fields.message | Should -BeLike '*Permission denied*'
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Errors were previously just written to stderr which resulted them being only shown at `TRACE` level.  Using tracing crate so that errors show up by default so user knows why the resource failed.
