### PR TITLE
Set a non-zero exit code when a resource not found

### DIFF
--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -49,7 +49,8 @@
     "3": "JSON Serialization error",
     "4": "Invalid input format",
     "5": "Resource instance failed schema validation",
-    "6": "Command cancelled"
+    "6": "Command cancelled",
+    "7": "Resource not found"
   },
   "validate": {
     "executable": "dsc",

--- a/dsc/group.dsc.resource.json
+++ b/dsc/group.dsc.resource.json
@@ -47,7 +47,8 @@
     "3": "JSON Serialization error",
     "4": "Invalid input format",
     "5": "Resource instance failed schema validation",
-    "6": "Command cancelled"
+    "6": "Command cancelled",
+    "7": "Resource not found"
   },
   "validate": {
     "executable": "dsc",

--- a/dsc/parallel.dsc.resource.json
+++ b/dsc/parallel.dsc.resource.json
@@ -50,7 +50,8 @@
     "3": "JSON Serialization error",
     "4": "Invalid input format",
     "5": "Resource instance failed schema validation",
-    "6": "Command cancelled"
+    "6": "Command cancelled",
+    "7": "Resource not found"
   },
   "validate": {
     "executable": "dsc",

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 use crate::args::OutputFormat;
-use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_ARGS, EXIT_JSON_ERROR, add_type_name_to_json, write_output};
+use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_ARGS, EXIT_JSON_ERROR, EXIT_DSC_RESOURCE_NOT_FOUND, add_type_name_to_json, write_output};
 use dsc_lib::configure::config_doc::{Configuration, ExecutionKind};
 use dsc_lib::configure::add_resource_export_results_to_configuration;
 use dsc_lib::dscresources::{resource_manifest::Kind, invoke_result::{GetResult, ResourceGetResponse}};
@@ -18,7 +18,7 @@ use std::process::exit;
 pub fn get(dsc: &DscManager, resource_type: &str, mut input: String, format: &Option<OutputFormat>) {
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
@@ -60,7 +60,7 @@ pub fn get_all(dsc: &DscManager, resource_type: &str, format: &Option<OutputForm
     let mut input = String::new();
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
@@ -112,7 +112,7 @@ pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
 
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
@@ -158,7 +158,7 @@ pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: &O
 
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
@@ -199,7 +199,7 @@ pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: &O
 pub fn delete(dsc: &DscManager, resource_type: &str, mut input: String) {
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
 
     debug!("resource.type_name - {} implemented_as - {:?}", resource.type_name, resource.implemented_as);
@@ -230,7 +230,7 @@ pub fn delete(dsc: &DscManager, resource_type: &str, mut input: String) {
 pub fn schema(dsc: &DscManager, resource_type: &str, format: &Option<OutputFormat>) {
     let Some(resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
     if resource.kind == Kind::Adapter {
         error!("Can not perform this operation on the adapter {} itself", resource.type_name);
@@ -260,7 +260,7 @@ pub fn export(dsc: &mut DscManager, resource_type: &str, format: &Option<OutputF
     let mut input = String::new();
     let Some(dsc_resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
-        return
+        exit(EXIT_DSC_RESOURCE_NOT_FOUND);
     };
 
     if dsc_resource.kind == Kind::Adapter {

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -50,6 +50,7 @@ pub const EXIT_JSON_ERROR: i32 = 3;
 pub const EXIT_INVALID_INPUT: i32 = 4;
 pub const EXIT_VALIDATION_FAILED: i32 = 5;
 pub const EXIT_CTRL_C: i32 = 6;
+pub const EXIT_DSC_RESOURCE_NOT_FOUND: i32 = 7;
 
 pub const DSC_CONFIG_ROOT: &str = "DSC_CONFIG_ROOT";
 pub const DSC_TRACE_LEVEL: &str = "DSC_TRACE_LEVEL";

--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -150,4 +150,22 @@ Describe 'tests for resource discovery' {
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Lookup table found resource 'testclassresource/testclassresource' in adapter 'Microsoft.DSC/PowerShell'"
         $env:PSModulePath = $oldPSModulePath
     }
+
+    It 'Verify non-zero exit code when resource not found' {
+
+        $out = dsc resource get -r abc/def
+        $LASTEXITCODE | Should -Be 7
+        $out = dsc resource get --all -r abc/def
+        $LASTEXITCODE | Should -Be 7
+        $out = 'abc' | dsc resource set -r abc/def
+        $LASTEXITCODE | Should -Be 7
+        $out = 'abc' | dsc resource test -r abc/def
+        $LASTEXITCODE | Should -Be 7
+        $out = 'abc' | dsc resource delete -r abc/def
+        $LASTEXITCODE | Should -Be 7
+        $out = dsc resource export -r abc/def
+        $LASTEXITCODE | Should -Be 7
+        $out = dsc resource schema -r abc/def
+        $LASTEXITCODE | Should -Be 7
+    }
 }


### PR DESCRIPTION
# PR Summary

At this time `dsc resource ...` commands are just printing a `Resource not found` error, but exit code is 0.
This PR changes exit code to `7` in such cases.

before change:
```
PS C:\DSCv3> dsc resource get -r dfg/sdfg                     
2024-09-26T21:07:27.371778Z ERROR Resource not found: dfg/sdfg
PS C:\DSCv3> $LASTEXITCODE
0
```

after change:
```
PS C:\DSCv3> dsc resource get -r dfg/sdfg                     
2024-09-26T21:08:16.539682Z ERROR Resource not found: dfg/sdfg
PS C:\DSCv3> $LASTEXITCODE
7
```
