### PR TITLE
Fixed InDesiredState in PSAdapter Test operations

### DIFF
--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -57,6 +57,7 @@ Describe 'PowerShell adapter resource tests' {
         $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource test -r 'TestClassResource/TestClassResource'
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
+        $res.InDesiredState | Should -Be $True
         $res.actualState.result.properties.InDesiredState | Should -Be $True
 
         # verify that only properties with DscProperty attribute are returned
@@ -324,5 +325,20 @@ Describe 'PowerShell adapter resource tests' {
             dsc -l trace resource list -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
             "$TestDrive/tracing.txt" | Should -Not -FileContentMatchExactly 'Constructing Get-DscResource cache'
         }
+    }
+
+    It 'Verify InDesiredState in Test' {
+
+        $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource test -r 'TestClassResource/TestClassResource'
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.InDesiredState | Should -Be $True
+        $res.actualState.result.properties.InDesiredState | Should -Be $True
+
+        $r = "{'Name':'TestClassResource1','Prop1':'abcd'}" | dsc resource test -r 'TestClassResource/TestClassResource'
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.InDesiredState | Should -Be $False
+        $res.actualState.result.properties.InDesiredState | Should -Be $False
     }
 }

--- a/powershell-adapter/psDscAdapter/psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/psDscAdapter.psm1
@@ -480,9 +480,7 @@ function Invoke-DscOperation {
                             $dscResourceInstance.Set()
                         }
                         'Test' {
-                            $Result = @{}
-                            $raw_obj = $dscResourceInstance.Test()
-                            $ValidProperties | ForEach-Object { $Result[$_] = $raw_obj.$_ }
+                            $Result = $dscResourceInstance.Test()
                             $addToActualState.properties = [psobject]@{'InDesiredState'=$Result} 
                         }
                         'Export' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Fix #284 

Adding a special case to `dsc.exe` to set top-level `InDesiredState` result from same field returned from PSAdapter.