### PR TITLE
Fixed regression in PSAdapter Test operation

### DIFF
--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -58,6 +58,7 @@ Describe 'PowerShell adapter resource tests' {
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.InDesiredState | Should -Be $True
+        $res.actualState.result.properties.InDesiredState.GetType().Name | Should -Be "Boolean"
 
         # verify that only properties with DscProperty attribute are returned
         $propertiesNames = $res.actualState.result.properties.InDesiredState | Get-Member -MemberType NoteProperty | % Name

--- a/powershell-adapter/psDscAdapter/psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/psDscAdapter.psm1
@@ -480,9 +480,7 @@ function Invoke-DscOperation {
                             $dscResourceInstance.Set()
                         }
                         'Test' {
-                            $Result = @{}
-                            $raw_obj = $dscResourceInstance.Test()
-                            $ValidProperties | ForEach-Object { $Result[$_] = $raw_obj.$_ }
+                            $Result = $dscResourceInstance.Test()
                             $addToActualState.properties = [psobject]@{'InDesiredState'=$Result} 
                         }
                         'Export' {


### PR DESCRIPTION
# PR Summary

A recent regression made Test operation in PSAdapter return entire object instead of just `InDesiredState` field.
This PR fixes that.
