### PR TITLE
Perf optimization in adapter lookup table

### DIFF
--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -144,10 +144,25 @@ Describe 'tests for resource discovery' {
         $TestClassResourcePath = Resolve-Path "$PSScriptRoot/../../powershell-adapter/Tests"
         $env:DSC_RESOURCE_PATH = $null
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $TestClassResourcePath
-        dsc resource list -a Microsoft.DSC/PowerShell | Out-Null
-        "{'Name':'TestClassResource1'}" | dsc -l trace resource get -r 'TestClassResource/TestClassResource' 2> $TestDrive/tracing.txt
 
+        # remove adapter lookup table file
+        Remove-Item -Force -Path $script:lookupTableFilePath -ErrorAction SilentlyContinue
+        Test-Path $script:lookupTableFilePath -PathType Leaf | Should -BeFalse
+
+        # initial invocation should populate and save adapter lookup table
+        dsc -l trace resource list -a Microsoft.DSC/PowerShell 2> $TestDrive/tracing.txt
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Read 0 items into lookup table"
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Saving lookup table"
+
+        # second invocation (without an update) should use but not save adapter lookup table
+        "{'Name':'TestClassResource1'}" | dsc -l trace resource get -r 'TestClassResource/TestClassResource' 2> $TestDrive/tracing.txt
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Lookup table found resource 'testclassresource/testclassresource' in adapter 'Microsoft.DSC/PowerShell'"
+        "$TestDrive/tracing.txt" | Should -Not -FileContentMatchExactly "Saving lookup table"
+
+        # third invocation (with an update) should save updated adapter lookup table
+        dsc -l trace resource list -a Test/TestGroup 2> $TestDrive/tracing.txt
+        "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Saving lookup table"
+
         $env:PSModulePath = $oldPSModulePath
     }
 

--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -146,7 +146,7 @@ Describe 'tests for resource discovery' {
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $TestClassResourcePath
 
         # remove adapter lookup table file
-        Remove-Item -Force -Path $script:lookupTableFilePath -ErrorAction SilentlyContinue
+        Remove-Item -Force -Path $script:lookupTableFilePath -ErrorAction Stop
         Test-Path $script:lookupTableFilePath -PathType Leaf | Should -BeFalse
 
         # initial invocation should populate and save adapter lookup table

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -541,7 +541,7 @@ fn add_resources_to_lookup_table(adapted_resources: &BTreeMap<String, Vec<DscRes
         if let Some(adapter_name) = &res_vec[0].require_adapter {
             let new_value = adapter_name.to_string();
             let oldvalue = lookup_table.insert(resource_name.to_string().to_lowercase(), new_value.clone());
-            if !lookup_table_changed && (oldvalue == None || oldvalue.is_some_and(|val| val != new_value)) {
+            if !lookup_table_changed && (oldvalue.is_none() || oldvalue.is_some_and(|val| val != new_value)) {
                 lookup_table_changed = true;
             };
         } else {

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -536,15 +536,22 @@ fn add_resources_to_lookup_table(adapted_resources: &BTreeMap<String, Vec<DscRes
 {
     let mut lookup_table = load_adapted_resources_lookup_table();
 
+    let mut lookup_table_changed = false;
     for (resource_name, res_vec) in adapted_resources {
         if let Some(adapter_name) = &res_vec[0].require_adapter {
-            lookup_table.insert(resource_name.to_string().to_lowercase(), adapter_name.to_string());
+            let new_value = adapter_name.to_string();
+            let oldvalue = lookup_table.insert(resource_name.to_string().to_lowercase(), new_value.clone());
+            if !lookup_table_changed && (oldvalue == None || oldvalue.is_some_and(|val| val != new_value)) {
+                lookup_table_changed = true;
+            };
         } else {
             info!("Resource '{resource_name}' in 'adapted_resources' is missing 'require_adapter' field.");
         }
     };
 
-    save_adapted_resources_lookup_table(&lookup_table);
+    if lookup_table_changed {
+        save_adapted_resources_lookup_table(&lookup_table);
+    }
 }
 
 fn save_adapted_resources_lookup_table(lookup_table: &HashMap<String, String>)


### PR DESCRIPTION
# PR Summary

Previously adapter lookup table was serialized and saved every time;
With over 1000 entries for adapters shipped with `dsc.exe` this is performance expensive.

This change makes saving only when necessary - when the lookup table is actually updated.
