### PR TITLE
Add example configurations for Windows baselines

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -44,7 +44,9 @@ $filesForWindowsPackage = @(
     'RunCommandOnSet.exe',
     'windowspowershell.dsc.resource.json',
     'wmi.dsc.resource.json',
-    'wmi.resource.ps1'
+    'wmi.resource.ps1',
+    'configurations/windows_baseline.dsc.yaml',
+    'configurations/windows_inventory.dsc.yaml'
 )
 
 $filesForLinuxPackage = @(

--- a/configurations/windows_baseline.dsc.yaml
+++ b/configurations/windows_baseline.dsc.yaml
@@ -1,0 +1,62 @@
+# This configuration validates a Windows system against a security baseline configuration
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+metadata:
+  Microsoft.DSC:
+    securityContext: Elevated
+resources:
+- name: Validate the OS is Windows
+  type: Microsoft.DSC/Assertion
+  properties:
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+    resources:
+    - name: os
+      type: Microsoft/OSInfo
+      properties:
+        family: Windows
+- name: Registry checks
+  type: Microsoft.DSC/Group
+  dependsOn: 
+    - "[resourceId('Microsoft.DSC/Assertion','Validate the OS is Windows')]"
+  properties:
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+    resources:
+      - name: Default RDP port
+        type: Microsoft.Windows/Registry
+        metadata:
+          area: Network Access
+          severity: Critical
+        properties:
+          keyPath: HKLM\System\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp
+          valueName: PortNumber
+          valueData:
+            DWord: 3389
+      - name: Disable SMBv1
+        type: Microsoft.Windows/Registry
+        metadata:
+          area: Network Access
+          severity: Critical
+        properties:
+          keyPath: HKLM\SYSTEM\CurrentControlSet\Services\LanmanServer\Parameters
+          valueName: SMB1
+          valueData:
+            DWord: 0 # Disabled
+      - name: Disable Windows Search service
+        type: Microsoft.Windows/Registry
+        metadata:
+          area: Services
+          severity: Critical
+        properties:
+          keyPath: HKLM\SYSTEM\CurrentControlSet\Services\WSearch
+          valueName: Start
+          valueData:
+            DWord: 4 # Disabled
+      - name: Scan Removeable Drives
+        type: Microsoft.Windows/Registry
+        metadata:
+          area: Services
+          severity: Critical
+        properties:
+          keyPath: HKLM\SOFTWARE\Policies\Microsoft\Windows Defender
+          valueName: DisableRemovableDriveScanning
+          valueData:
+            DWord: 0 # Disabled

--- a/configurations/windows_inventory.dsc.yaml
+++ b/configurations/windows_inventory.dsc.yaml
@@ -1,7 +1,18 @@
 $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
 resources:
+- name: Validate the OS is Windows
+  type: Microsoft.DSC/Assertion
+  properties:
+    $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+    resources:
+    - name: os
+      type: Microsoft/OSInfo
+      properties:
+        family: Windows
 - name: WMI
   type: Microsoft.Windows/WMI
+  dependsOn:
+    - "[resourceId('Microsoft.DSC/Assertion','Validate the OS is Windows')]"
   properties:
     resources:
       - name: computer system
@@ -39,4 +50,4 @@ resources:
           adaptertype:
           netconnectionid:
           serviceName:
-          netconnectionstatus: 2
+          netconnectionstatus: 2 # Connected

--- a/wmi-adapter/Tests/wmi.tests.ps1
+++ b/wmi-adapter/Tests/wmi.tests.ps1
@@ -52,10 +52,10 @@ Describe 'WMI adapter resource tests' {
         $LASTEXITCODE | Should -Be 0
         $r | Should -Not -BeNullOrEmpty
         $res = $r | ConvertFrom-Json
-        $res.results[0].result.actualState[0].Name | Should -Not -BeNullOrEmpty
-        $res.results[0].result.actualState[0].BootupState | Should -BeNullOrEmpty
-        $res.results[0].result.actualState[1].Caption | Should -Not -BeNullOrEmpty
-        $res.results[0].result.actualState[1].BuildNumber | Should -BeNullOrEmpty
-        $res.results[0].result.actualState[4].AdapterType | Should -BeLike "Ethernet*"
+        $res.results[1].result.actualState[0].Name | Should -Not -BeNullOrEmpty
+        $res.results[1].result.actualState[0].BootupState | Should -BeNullOrEmpty
+        $res.results[1].result.actualState[1].Caption | Should -Not -BeNullOrEmpty
+        $res.results[1].result.actualState[1].BuildNumber | Should -BeNullOrEmpty
+        $res.results[1].result.actualState[4].AdapterType | Should -BeLike "Ethernet*"
     }
 }

--- a/wmi-adapter/Tests/wmi.tests.ps1
+++ b/wmi-adapter/Tests/wmi.tests.ps1
@@ -47,7 +47,7 @@ Describe 'WMI adapter resource tests' {
     }
 
     It 'Example config works' -Skip:(!$IsWindows) {
-        $configPath = Join-Path $PSScriptRoot '..\..\dsc\examples\wmi_inventory.dsc.yaml'
+        $configPath = Join-Path $PSScriptRoot '..\..\configurations\windows_inventory.dsc.yaml'
         $r = dsc config get -p $configPath
         $LASTEXITCODE | Should -Be 0
         $r | Should -Not -BeNullOrEmpty

--- a/wmi-adapter/wmi.resource.ps1
+++ b/wmi-adapter/wmi.resource.ps1
@@ -165,12 +165,6 @@ elseif ($Operation -eq 'Get')
 
                 $result += @($instance_result)
             }
-            else
-            {
-                $errmsg = "Can not find type " + $r.type + "; please ensure that Get-CimInstance returns this resource type"
-                Write-Trace $errmsg
-                exit 1
-            }
         }
     }
     else # we are processing an individual resource call


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Start of creating usable Windows configuration examples for security baseline and inventory via WMI
Fix in wmi-adapter to not return an error if no instances are returned, the trap handles all the error cases while returning zero instances can be valid
