### PR TITLE
Only build linux musl and update CFS auth

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 registry-auth = true
 
 [registries]
-POWERSHELL = { index = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/" }
+POWERSHELL = { index = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell~force-auth/Cargo/index/" }
 
 [registry]
 global-credential-providers = ["cargo:token"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,7 +3,7 @@
 registry-auth = true
 
 [registries]
-POWERSHELL = { index = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell~force-auth/Cargo/index/" }
+POWERSHELL = { index = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/" }
 
 [registry]
 global-credential-providers = ["cargo:token"]

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,7 +28,7 @@ jobs:
   #     shell: pwsh
   #     run: ./build.ps1 -test
 
-  build-musl:
+  build-linux:
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,18 +15,18 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-linux:
+  # build-linux:
 
-    runs-on: ubuntu-latest
+  #   runs-on: ubuntu-latest
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Build
-      shell: pwsh
-      run: ./build.ps1 -clippy
-    - name: Run tests
-      shell: pwsh
-      run: ./build.ps1 -test
+  #   steps:
+  #   - uses: actions/checkout@v3
+  #   - name: Build
+  #     shell: pwsh
+  #     run: ./build.ps1 -clippy
+  #   - name: Run tests
+  #     shell: pwsh
+  #     run: ./build.ps1 -test
 
   build-musl:
 

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -5,7 +5,7 @@ pr:
   branches:
     include:
     - onebranch
-    - v3.*
+    - release/v*
 
 schedules:
 - cron: '0 3 * * 1'

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -5,7 +5,7 @@ pr:
   branches:
     include:
     - onebranch
-    - release*
+    - v3.*
 
 schedules:
 - cron: '0 3 * * 1'
@@ -33,7 +33,7 @@ extends:
   template: v2/OneBranch.Official.CrossPlat.yml@onebranchTemplates
   parameters:
     featureFlags:
-      WindowsHostVersion: 
+      WindowsHostVersion:
         Disk: Large
         Version: 2022
         Network: KS1 # note that this property is sticky so commenting out will use the previous set one
@@ -59,7 +59,7 @@ extends:
         apiscan:
           enabled: false
 
-    stages:     
+    stages:
     - stage: BuildAndSign
       displayName: Build Native Binaries
       dependsOn: []
@@ -225,61 +225,61 @@ extends:
           displayName: 'Create msixbundle'
           condition: succeeded()
 
-      - job: BuildLinux
-        dependsOn: SetPackageVersion
-        variables:
-          LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2204:latest'
-          PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
-          ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
-        displayName: Linux-x64-gnu
-        pool:
-          type: linux
-        steps:
-        - task: RustInstaller@1
-          inputs:
-            rustVersion: ms-stable
-            toolchainFeed: https://pkgs.dev.azure.com/mscodehub/Rust/_packaging/Rust/nuget/v3/index.json
-            additionalTargets: x86_64-unknown-linux-gnu
-          displayName: Install Rust
-          env:
-            ob_restore_phase: true
-        - pwsh: |
-            ./build.ps1 -Release -Architecture x86_64-unknown-linux-gnu
-            ./build.ps1 -PackageType tgz -Architecture x86_64-unknown-linux-gnu -Release
-            Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
-          displayName: 'Build x86_64-unknown-linux-gnu'
-          condition: succeeded()
+      # - job: BuildLinux
+      #   dependsOn: SetPackageVersion
+      #   variables:
+      #     LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2204:latest'
+      #     PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
+      #     ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+      #   displayName: Linux-x64-gnu
+      #   pool:
+      #     type: linux
+      #   steps:
+      #   - task: RustInstaller@1
+      #     inputs:
+      #       rustVersion: ms-stable
+      #       toolchainFeed: https://pkgs.dev.azure.com/mscodehub/Rust/_packaging/Rust/nuget/v3/index.json
+      #       additionalTargets: x86_64-unknown-linux-gnu
+      #     displayName: Install Rust
+      #     env:
+      #       ob_restore_phase: true
+      #   - pwsh: |
+      #       ./build.ps1 -Release -Architecture x86_64-unknown-linux-gnu
+      #       ./build.ps1 -PackageType tgz -Architecture x86_64-unknown-linux-gnu -Release
+      #       Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
+      #     displayName: 'Build x86_64-unknown-linux-gnu'
+      #     condition: succeeded()
 
-      - job: BuildLinuxArm64
-        dependsOn: SetPackageVersion
-        variables:
-          LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest'
-          PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
-          ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
-        displayName: Linux-ARM64-gnu
-        pool:
-          type: linux
-          hostArchitecture: arm64
-        steps:
-        - task: RustInstaller@1
-          inputs:
-            rustVersion: ms-stable
-            toolchainFeed: https://pkgs.dev.azure.com/mscodehub/Rust/_packaging/Rust/nuget/v3/index.json
-            additionalTargets: aarch64-unknown-linux-gnu
-          displayName: Install Rust
-          env:
-            ob_restore_phase: true
-        - pwsh: |
-            apt update
-            apt -y install gcc-aarch64-linux-gnu
-            if ((openssl version -d) -match 'OPENSSLDIR: "(?<dir>.*?)"') {
-              $env:OPENSSL_LIB_DIR = $matches['dir']
-            }
-            ./build.ps1 -Release -Architecture aarch64-unknown-linux-gnu
-            ./build.ps1 -PackageType tgz -Architecture aarch64-unknown-linux-gnu -Release
-            Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
-          displayName: 'Build aarch64-unknown-linux-gnu'
-          condition: succeeded()
+      # - job: BuildLinuxArm64
+      #   dependsOn: SetPackageVersion
+      #   variables:
+      #     LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest'
+      #     PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
+      #     ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
+      #   displayName: Linux-ARM64-gnu
+      #   pool:
+      #     type: linux
+      #     hostArchitecture: arm64
+      #   steps:
+      #   - task: RustInstaller@1
+      #     inputs:
+      #       rustVersion: ms-stable
+      #       toolchainFeed: https://pkgs.dev.azure.com/mscodehub/Rust/_packaging/Rust/nuget/v3/index.json
+      #       additionalTargets: aarch64-unknown-linux-gnu
+      #     displayName: Install Rust
+      #     env:
+      #       ob_restore_phase: true
+      #   - pwsh: |
+      #       apt update
+      #       apt -y install gcc-aarch64-linux-gnu
+      #       if ((openssl version -d) -match 'OPENSSLDIR: "(?<dir>.*?)"') {
+      #         $env:OPENSSL_LIB_DIR = $matches['dir']
+      #       }
+      #       ./build.ps1 -Release -Architecture aarch64-unknown-linux-gnu
+      #       ./build.ps1 -PackageType tgz -Architecture aarch64-unknown-linux-gnu -Release
+      #       Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
+      #     displayName: 'Build aarch64-unknown-linux-gnu'
+      #     condition: succeeded()
 
       - job: BuildLinuxMusl
         dependsOn: SetPackageVersion

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -25,5 +25,6 @@
     "sarif-viewer.connectToGithubCodeScanning": "off",
     "vscode-nmake-tools.workspaceBuildDirectories": [
         "."
-    ]
+    ],
+    "azure-pipelines.1ESPipelineTemplatesSchemaFile": true
 }

--- a/build.ps1
+++ b/build.ps1
@@ -200,7 +200,7 @@ if (!$SkipBuild) {
             $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "Failed to get access token, use 'az login' first, or use '-useCratesIO' to use crates.io.  Proceeding with anonymous access."
-                $env:CARGO_REGISITRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/"
+                $env:CARGO_REGISTRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/"
             } else {
                 $header = "Bearer $accessToken"
                 $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
@@ -209,7 +209,7 @@ if (!$SkipBuild) {
         }
         else {
             Write-Warning "Azure CLI not found, proceeding with anonymous access."
-            $env:CARGO_REGISITRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/"
+            $env:CARGO_REGISTRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/"
         }
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -655,6 +655,13 @@ if ($packageType -eq 'msixbundle') {
         }
     }
 
+    # for Linux, we only build musl as its statically linked, so we remove the musl suffix
+    if ($architecture -eq 'aarch64-unknown-linux-musl') {
+        $architecture = 'aarch64-linux'
+    } elseif ($architecture -eq 'x86_64-unknown-linux-musl') {
+        $architecture = 'x86_64-linux'
+    }
+
     $packageName = "DSC-$productVersion-$architecture.tar"
     $tarFile = Join-Path $PSScriptRoot 'bin' $packageName
     tar cvf $tarFile -C $tgzTarget .

--- a/build.ps1
+++ b/build.ps1
@@ -661,13 +661,15 @@ if ($packageType -eq 'msixbundle') {
     }
 
     # for Linux, we only build musl as its statically linked, so we remove the musl suffix
-    if ($architecture -eq 'aarch64-unknown-linux-musl') {
-        $architecture = 'aarch64-linux'
+    $productArchitecture = if ($architecture -eq 'aarch64-unknown-linux-musl') {
+        'aarch64-linux'
     } elseif ($architecture -eq 'x86_64-unknown-linux-musl') {
-        $architecture = 'x86_64-linux'
+        'x86_64-linux'
+    } else {
+        $architecture
     }
 
-    $packageName = "DSC-$productVersion-$architecture.tar"
+    $packageName = "DSC-$productVersion-$productArchitecture.tar"
     $tarFile = Join-Path $PSScriptRoot 'bin' $packageName
     tar cvf $tarFile -C $tgzTarget .
     if ($LASTEXITCODE -ne 0) {

--- a/build.ps1
+++ b/build.ps1
@@ -195,9 +195,7 @@ if (!$SkipBuild) {
             throw "Azure CLI not found"
         }
 
-        if ($null -ne $env:CARGO_REGISTRIES_POWERSHELL_TOKEN) {
-            Write-Host "Using existing token"
-        } else {
+        if ($null -ne (Get-Command az -ErrorAction Ignore)) {
             Write-Host "Getting token"
             $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
             if ($LASTEXITCODE -ne 0) {
@@ -207,6 +205,9 @@ if (!$SkipBuild) {
                 $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
                 $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
             }
+        }
+        else {
+            Write-Warning "Azure CLI not found, proceeding with anonymous access."
         }
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -200,6 +200,7 @@ if (!$SkipBuild) {
             $accessToken = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
             if ($LASTEXITCODE -ne 0) {
                 Write-Warning "Failed to get access token, use 'az login' first, or use '-useCratesIO' to use crates.io.  Proceeding with anonymous access."
+                $env:CARGO_REGISITRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/"
             } else {
                 $header = "Bearer $accessToken"
                 $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
@@ -208,6 +209,7 @@ if (!$SkipBuild) {
         }
         else {
             Write-Warning "Azure CLI not found, proceeding with anonymous access."
+            $env:CARGO_REGISITRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell/Cargo/index/"
         }
     }
 

--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -1744,9 +1744,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -11,22 +11,22 @@ opt-level = 2
 lto = true
 
 [dependencies]
-clap = { version = "4.5.17", features = ["derive"] }
-clap_complete = { version = "4.5.28" }
-crossterm = { version = "0.28.1" }
-ctrlc = { version = "3.4.0" }
+clap = { version = "4.5", features = ["derive"] }
+clap_complete = { version = "4.5" }
+crossterm = { version = "0.28" }
+ctrlc = { version = "3.4" }
 dsc_lib = { path = "../dsc_lib" }
 indicatif = { version = "0.17" }
-jsonschema = { version = "0.23.0", default-features = false }
-path-absolutize = { version = "3.1.1" }
+jsonschema = { version = "0.23", default-features = false }
+path-absolutize = { version = "3.1" }
 # reqwest = { version = "0.12.8", features = ["native-tls"], default-features = false }
-schemars = { version = "0.8.12" }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = { version = "1.0.128", features = ["preserve_order"] }
-serde_yaml = { version = "0.9.3" }
+schemars = { version = "0.8" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_yaml = { version = "0.9" }
 syntect = { version = "5.0", features = ["default-fancy"], default-features = false }
-sysinfo = { version = "0.32.0" }
-thiserror = "1.0.52"
+sysinfo = { version = "0.32" }
+thiserror = "1.0"
 tracing = { version = "0.1.37" }
-tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }
-tracing-indicatif = { version = "0.3.6" }
+tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
+tracing-indicatif = { version = "0.3" }

--- a/dsc_lib/Cargo.lock
+++ b/dsc_lib/Cargo.lock
@@ -1360,9 +1360,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -3,6 +3,13 @@ name = "dsc_lib"
 version = "3.0.0"
 edition = "2021"
 
+[profile.release]
+strip = true
+# optimize for size
+opt-level = 2
+# enable link time optimization to remove dead code
+lto = true
+
 [dependencies]
 base64 = "0.22"
 chrono = "0.4"

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -4,32 +4,32 @@ version = "3.0.0"
 edition = "2021"
 
 [dependencies]
-base64 = "0.22.1"
-chrono = "0.4.26"
-clap = { version = "4.5.17", features = ["derive"] }
-derive_builder ="0.20.1"
-indicatif = "0.17.0"
-jsonschema = { version = "0.23.0", default-features = false }
-linked-hash-map = "0.5.6"
-num-traits = "0.2.14"
-regex = "1.7.0"
+base64 = "0.22"
+chrono = "0.4"
+clap = { version = "4.5", features = ["derive"] }
+derive_builder ="0.20"
+indicatif = "0.17"
+jsonschema = { version = "0.23", default-features = false }
+linked-hash-map = "0.5"
+num-traits = "0.2"
+regex = "1.11"
 # reqwest = { version = "0.12.8", features = ["native-tls"], default-features = false }
-schemars = { version = "0.8.12", features = ["preserve_order"] }
-serde = { version = "1.0.210", features = ["derive"] }
-serde_json = { version = "1.0.128", features = ["preserve_order"] }
-serde_yaml = { version = "0.9.3" }
-thiserror = "1.0.0"
+schemars = { version = "0.8", features = ["preserve_order"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+serde_yaml = { version = "0.9" }
+thiserror = "1.0"
 security_context_lib = { path = "../security_context_lib" }
-semver = "1.0.0"
-tokio = { version = "1.40.0", features = ["full"] }
-tracing = "0.1.37"
-tracing-indicatif = { version = "0.3.6" }
-tree-sitter = "0.24.3"
-tree-sitter-rust = "0.23.0"
+semver = "1.0"
+tokio = { version = "1.41", features = ["full"] }
+tracing = "0.1"
+tracing-indicatif = { version = "0.3" }
+tree-sitter = "0.24"
+tree-sitter-rust = "0.23"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
 
 [dev-dependencies]
-serde_yaml = "0.9.3"
+serde_yaml = "0.9"
 
 [build-dependencies]
 cc="1.1"

--- a/osinfo/Cargo.toml
+++ b/osinfo/Cargo.toml
@@ -3,7 +3,12 @@ name = "osinfo"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+strip = true
+# optimize for size
+opt-level = 2
+# enable link time optimization to remove dead code
+lto = true
 
 [dependencies]
 os_info = { version = "3.7" }

--- a/osinfo/Cargo.toml
+++ b/osinfo/Cargo.toml
@@ -6,6 +6,6 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-os_info = { version = "3.7.0" }
-serde = { version = "1.0.0", features = ["derive"] }
-serde_json = { version = "1.0.0", features = ["preserve_order"] }
+os_info = { version = "3.7" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/pal/Cargo.toml
+++ b/pal/Cargo.toml
@@ -13,4 +13,4 @@ opt-level = 2
 lto = true
 
 [build-dependencies]
-cc = "1.1.20"
+cc = "1.1"

--- a/process/Cargo.toml
+++ b/process/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-sysinfo = "0.31.2"
-serde = { version = "1.0.0", features = ["derive"] }
-serde_json = { version = "1.0.0", features = ["preserve_order"] }
+sysinfo = "0.31"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -14,16 +14,16 @@ lto = true
 lto = true
 
 [dependencies]
-clap = { version = "4.5.20", features = ["derive"] }
-crossterm = "0.28.1"
-registry = "1.2.3"
-schemars = "0.8.0"
-serde = "1.0.130"
-serde_json = "1.0.68"
-thiserror = "1.0.64"
-tracing = { version = "0.1.37" }
-tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }
-utfx = "0.1.0"
+clap = { version = "4.5", features = ["derive"] }
+crossterm = "0.28"
+registry = "1.2"
+schemars = "0.8"
+serde = "1.0"
+serde_json = "1.0"
+thiserror = "1.0"
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }
+utfx = "0.1"
 
 [build-dependencies]
 static_vcruntime = "2.0"

--- a/registry/Cargo.toml
+++ b/registry/Cargo.toml
@@ -10,9 +10,6 @@ opt-level = 2
 # enable link time optimization to remove dead code
 lto = true
 
-[profile.dev]
-lto = true
-
 [dependencies]
 clap = { version = "4.5", features = ["derive"] }
 crossterm = "0.28"

--- a/runcommandonset/Cargo.toml
+++ b/runcommandonset/Cargo.toml
@@ -3,7 +3,12 @@ name = "runcommandonset"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[profile.release]
+strip = true
+# optimize for size
+opt-level = 2
+# enable link time optimization to remove dead code
+lto = true
 
 [dependencies]
 clap = { version = "4.4", features = ["derive"] }

--- a/runcommandonset/Cargo.toml
+++ b/runcommandonset/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.4.0", features = ["derive"] }
-serde = { version = "1.0.0", features = ["derive"] }
-serde_json = { version = "1.0.0", features = ["preserve_order"] }
-tracing = { version = "0.1.37" }
-tracing-subscriber = { version = "0.3.17", features = ["ansi", "env-filter", "json"] }
+clap = { version = "4.4", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", features = ["preserve_order"] }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3", features = ["ansi", "env-filter", "json"] }

--- a/security_context_lib/Cargo.toml
+++ b/security_context_lib/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-is_elevated = "0.1.0"
+is_elevated = "0.1"
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
-nix = { version = "0.29.0", features = ["user"] }
+nix = { version = "0.29", features = ["user"] }

--- a/security_context_lib/Cargo.toml
+++ b/security_context_lib/Cargo.toml
@@ -3,6 +3,13 @@ name = "security_context_lib"
 version = "0.1.0"
 edition = "2021"
 
+[profile.release]
+strip = true
+# optimize for size
+opt-level = 2
+# enable link time optimization to remove dead code
+lto = true
+
 [target.'cfg(target_os = "windows")'.dependencies]
 is_elevated = "0.1"
 

--- a/tools/test_group_resource/Cargo.lock
+++ b/tools/test_group_resource/Cargo.lock
@@ -1371,9 +1371,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
 dependencies = [
  "backtrace",
  "bytes",

--- a/tree-sitter-dscexpression/Cargo.toml
+++ b/tree-sitter-dscexpression/Cargo.toml
@@ -20,9 +20,9 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter-rust = "0.23.0"
-tree-sitter = "0.24.3"
-tree-sitter-language = "0.1.2"
+tree-sitter-rust = "0.23"
+tree-sitter = "0.24"
+tree-sitter-language = "0.1"
 
 [build-dependencies]
 cc = "1.1"

--- a/tree-sitter-dscexpression/Cargo.toml
+++ b/tree-sitter-dscexpression/Cargo.toml
@@ -19,6 +19,13 @@ include = [
 [lib]
 path = "bindings/rust/lib.rs"
 
+[profile.release]
+strip = true
+# optimize for size
+opt-level = 2
+# enable link time optimization to remove dead code
+lto = true
+
 [dependencies]
 tree-sitter-rust = "0.23"
 tree-sitter = "0.24"

--- a/y2j/Cargo.toml
+++ b/y2j/Cargo.toml
@@ -3,6 +3,13 @@ name = "y2j"
 version = "1.0.0"
 edition = "2021"
 
+[profile.release]
+strip = true
+# optimize for size
+opt-level = 2
+# enable link time optimization to remove dead code
+lto = true
+
 [dependencies]
 serde_json = { version = "1.0.0", features = ["preserve_order"] }
 serde_yaml = { version = "0.9.3" }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Since musl build is statically linked, it will work on non-musl based Linux distros and have no dynamic dependencies.
- Update release pipeline to only build musl
- Update build.ps1 tar.gz packaging to rename linux package to just `linux`
- Add suffix to CFS feed so it always authenticates
- With CFS change, we can update cargo.toml and cargo.lock to just specify major.minor versions

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
