### PR TITLE
fix output of Assertion resource for test to resemble config and add support for array comparison

### DIFF
--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -37,7 +37,7 @@
       "config",
       "--as-group",
       "test",
-      "--as-test"
+      "--as-config"
     ],
     "input": "stdin",
     "return": "state"

--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -37,7 +37,7 @@
       "config",
       "--as-group",
       "test",
-      "--as-get"
+      "--as-test"
     ],
     "input": "stdin",
     "return": "state"

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -102,8 +102,10 @@ pub enum ConfigSubCommand {
         path: Option<String>,
         #[clap(short = 'f', long, help = "The output format to use")]
         format: Option<OutputFormat>,
+        // Used by Assertion resource to return `test` result as a `get` result
         #[clap(long, hide = true)]
         as_get: bool,
+        // Used by Assertion resource to return `test` result as a configuration `test` result
         #[clap(long, hide = true)]
         as_config: bool,
     },

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -103,6 +103,8 @@ pub enum ConfigSubCommand {
         #[clap(short = 'f', long, help = "The output format to use")]
         format: Option<OutputFormat>,
         #[clap(long, hide = true)]
+        as_get: bool,
+        #[clap(long, hide = true)]
         as_test: bool,
     },
     #[clap(name = "validate", about = "Validate the current configuration", hide = true)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -103,7 +103,7 @@ pub enum ConfigSubCommand {
         #[clap(short = 'f', long, help = "The output format to use")]
         format: Option<OutputFormat>,
         #[clap(long, hide = true)]
-        as_get: bool,
+        as_test: bool,
     },
     #[clap(name = "validate", about = "Validate the current configuration", hide = true)]
     Validate {

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -105,7 +105,7 @@ pub enum ConfigSubCommand {
         #[clap(long, hide = true)]
         as_get: bool,
         #[clap(long, hide = true)]
-        as_test: bool,
+        as_config: bool,
     },
     #[clap(name = "validate", about = "Validate the current configuration", hide = true)]
     Validate {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -104,12 +104,12 @@ pub fn config_set(configurator: &mut Configurator, format: &Option<OutputFormat>
     }
 }
 
-pub fn config_test(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool, as_get: &bool, as_test: &bool)
+pub fn config_test(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool, as_get: &bool, as_config: &bool)
 {
     match configurator.invoke_test() {
         Ok(result) => {
             if *as_group {
-                let json = if *as_test {
+                let json = if *as_config {
                     let mut result_configuration = Configuration::new();
                     result_configuration.resources = Vec::new();
                     for test_result in result.results {
@@ -341,8 +341,8 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
         ConfigSubCommand::Set { format, .. } => {
             config_set(&mut configurator, format, as_group);
         },
-        ConfigSubCommand::Test { format, as_get, as_test, .. } => {
-            config_test(&mut configurator, format, as_group, as_get, as_test);
+        ConfigSubCommand::Test { format, as_get, as_config, .. } => {
+            config_test(&mut configurator, format, as_group, as_get, as_config);
         },
         ConfigSubCommand::Validate { document, path, format} => {
             let mut result = ValidateResult {

--- a/dsc/tests/dsc_config_test.tests.ps1
+++ b/dsc/tests/dsc_config_test.tests.ps1
@@ -1,0 +1,35 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'dsc config test tests' {
+    It 'Assertion works correctly' {
+        $configYaml = @'
+ $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+ resources:
+   - name: Operating System Assertion
+     type: Microsoft.DSC/Assertion
+     properties:
+       $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+       resources:
+         - name: Is64BitOS
+           type: Microsoft/OSInfo
+           properties:
+             bitness: '64'
+         - name: 64bit test 2
+           type: Microsoft/OSInfo
+           properties:
+             family: Windows
+'@
+
+        $out = dsc config test -d $configYaml | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+
+        if ($IsWindows) {
+            $out.results[0].result.inDesiredState | Should -BeTrue
+        }
+        else {
+            $out.results[0].result.inDesiredState | Should -BeFalse
+            $out.results[0].result.differingProperties | Should -Contain 'resources'
+        }
+    }
+}

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -95,7 +95,7 @@ impl CommandDiscovery {
             Ok(v) => {
                 resource_path_setting = v;
             },
-            Err(e) => { 
+            Err(e) => {
                 debug!("{e}");
             }
         }
@@ -144,7 +144,7 @@ impl CommandDiscovery {
                     paths.push(exe_home_pb);
 
                     if let Ok(new_path) = env::join_paths(paths.clone()) {
-                        env::set_var("PATH", &new_path);
+                        env::set_var("PATH", new_path);
                     }
                 }
             }
@@ -369,7 +369,7 @@ impl ResourceDiscovery for CommandDiscovery {
         } else {
             self.discover_resources("*")?;
             self.discover_adapted_resources(type_name_filter, adapter_name_filter)?;
-            
+
             // add/update found adapted resources to the lookup_table
             add_resources_to_lookup_table(&self.adapted_resources);
 
@@ -652,7 +652,7 @@ fn save_adapted_resources_lookup_table(lookup_table: &HashMap<String, String>)
 fn load_adapted_resources_lookup_table() -> HashMap<String, String>
 {
     let file_path = get_lookup_table_file_path();
-    
+
     let lookup_table: HashMap<String, String> = match fs::read(file_path.clone()){
         Ok(data) => { serde_json::from_slice(&data).unwrap_or_default() },
         Err(_) => { HashMap::new() }

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -467,10 +467,74 @@ fn array_contains(array: &Vec<Value>, find: &Value) -> bool {
             }
         }
 
-        if find.is_array() && item.is_array() && array_contains(item.as_array().unwrap(), find) {
+        if find.is_array() && item.is_array() && is_same_array(item.as_array().unwrap(), find.as_array().unwrap()) {
             return true;
         }
     }
 
     false
+}
+
+#[test]
+fn same_array() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(null)];
+    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(null)];
+    assert_eq!(is_same_array(&array_one, &array_two), true);
+}
+
+#[test]
+fn same_array_out_of_order() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(true), json!(r#"{"a":"b"}"#)];
+    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a"), json!(true)];
+    assert_eq!(is_same_array(&array_one, &array_two), true);
+}
+
+#[test]
+fn different_array() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#)];
+    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a"), json!(2)];
+    assert_eq!(is_same_array(&array_one, &array_two), false);
+}
+
+#[test]
+fn different_array_sizes() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#)];
+    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a")];
+    assert_eq!(is_same_array(&array_one, &array_two), false);
+}
+
+#[test]
+fn array_with_multiple_objects_with_superset() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(r#"{"c":"d"}"#)];
+    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b", "c":"d"}"#), json!(r#"{"c":"d"}"#)];
+    assert_eq!(is_same_array(&array_one, &array_two), false);
+}
+
+#[test]
+fn array_with_duplicates_out_of_order() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(r#"{"a":"b"}"#)];
+    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a"), json!(1), json!(r#"{"a":"b"}"#)];
+    assert_eq!(is_same_array(&array_one, &array_two), true);
+}
+
+#[test]
+fn same_array_with_nested_array() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(1)])];
+    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(1)])];
+    assert_eq!(is_same_array(&array_one, &array_two), true);
+}
+
+#[test]
+fn different_array_with_nested_array() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(1)])];
+    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(2)])];
+    assert_eq!(is_same_array(&array_one, &array_two), false);
 }

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -478,63 +478,71 @@ fn array_contains(array: &Vec<Value>, find: &Value) -> bool {
 #[test]
 fn same_array() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(null)];
-    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(null)];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"}), json!(null)];
+    let array_two = vec![json!("a"), json!(1), json!({"a":"b"}), json!(null)];
     assert_eq!(is_same_array(&array_one, &array_two), true);
 }
 
 #[test]
 fn same_array_out_of_order() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(true), json!(r#"{"a":"b"}"#)];
-    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a"), json!(true)];
+    let array_one = vec![json!("a"), json!(true), json!({"a":"b"})];
+    let array_two = vec![json!({"a":"b"}), json!("a"), json!(true)];
     assert_eq!(is_same_array(&array_one, &array_two), true);
 }
 
 #[test]
 fn different_array() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#)];
-    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a"), json!(2)];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"})];
+    let array_two = vec![json!({"a":"b"}), json!("a"), json!(2)];
     assert_eq!(is_same_array(&array_one, &array_two), false);
 }
 
 #[test]
 fn different_array_sizes() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#)];
-    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a")];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"})];
+    let array_two = vec![json!({"a":"b"}), json!("a")];
     assert_eq!(is_same_array(&array_one, &array_two), false);
 }
 
 #[test]
-fn array_with_multiple_objects_with_superset() {
+fn array_with_multiple_objects_with_actual_superset() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(r#"{"c":"d"}"#)];
-    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b", "c":"d"}"#), json!(r#"{"c":"d"}"#)];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"}), json!({"c":"d"})];
+    let array_two = vec![json!("a"), json!(1), json!({"c":"d", "a":"b"}), json!({"c":"d"})];
+    assert_eq!(is_same_array(&array_one, &array_two), true);
+}
+
+#[test]
+fn array_with_multiple_objects_with_expected_superset() {
+    use serde_json::json;
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b", "c":"d"}), json!({"c":"d"})];
+    let array_two = vec![json!("a"), json!(1), json!({"a":"b"}), json!({"c":"d"})];
     assert_eq!(is_same_array(&array_one, &array_two), false);
 }
 
 #[test]
 fn array_with_duplicates_out_of_order() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(r#"{"a":"b"}"#)];
-    let array_two = vec![json!(r#"{"a":"b"}"#), json!("a"), json!(1), json!(r#"{"a":"b"}"#)];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"}), json!({"a":"b"})];
+    let array_two = vec![json!({"a":"b"}), json!("a"), json!(1), json!({"a":"b"})];
     assert_eq!(is_same_array(&array_one, &array_two), true);
 }
 
 #[test]
 fn same_array_with_nested_array() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(1)])];
-    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(1)])];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"}), json!(vec![json!("a"), json!(1)])];
+    let array_two = vec![json!("a"), json!(1), json!({"a":"b"}), json!(vec![json!("a"), json!(1)])];
     assert_eq!(is_same_array(&array_one, &array_two), true);
 }
 
 #[test]
 fn different_array_with_nested_array() {
     use serde_json::json;
-    let array_one = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(1)])];
-    let array_two = vec![json!("a"), json!(1), json!(r#"{"a":"b"}"#), json!(vec![json!("a"), json!(2)])];
+    let array_one = vec![json!("a"), json!(1), json!({"a":"b"}), json!(vec![json!("a"), json!(1)])];
+    let array_two = vec![json!("a"), json!(1), json!({"a":"b"}), json!(vec![json!("a"), json!(2)])];
     assert_eq!(is_same_array(&array_one, &array_two), false);
 }

--- a/dsc_lib/src/dscresources/dscresource.rs
+++ b/dsc_lib/src/dscresources/dscresource.rs
@@ -338,6 +338,16 @@ pub fn get_well_known_properties() -> HashMap<String, Value> {
 }
 
 #[must_use]
+/// Performs a comparison of two JSON Values if the expected is a strict subset of the actual
+///
+/// # Arguments
+///
+/// * `expected` - The expected value
+/// * `actual` - The actual value
+///
+/// # Returns
+///
+/// An array of top level properties that differ, if any
 pub fn get_diff(expected: &Value, actual: &Value) -> Vec<String> {
     let mut diff_properties: Vec<String> = Vec::new();
     if expected.is_null() {
@@ -373,34 +383,28 @@ pub fn get_diff(expected: &Value, actual: &Value) -> Vec<String> {
                     continue;
                 }
 
-                match actual.as_object() {
-                    Some(actual_object) => {
-                        if actual_object.contains_key(key) {
-                            if value.is_array() {
-                                if !actual[key].is_array() {
-                                    info!("diff: {} is not an array", actual[key]);
+                if let Some(actual_object) = actual.as_object() {
+                    if actual_object.contains_key(key) {
+                        if let Some(value_array) = value.as_array() {
+                            if let Some(actual_array) = actual[key].as_array() {
+                                if !is_same_array(value_array, actual_array) {
+                                    info!("diff: arrays differ for {key}");
                                     diff_properties.push(key.to_string());
                                 }
-                                else {
-                                    if !is_same_array(&value.as_array().unwrap(), &actual[key].as_array().unwrap()) {
-                                        info!("diff: arrays differ for {key}");
-                                        diff_properties.push(key.to_string());
-                                    }
-                                }
-                            }
-                            else if value != &actual[key] {
+                            } else {
+                                info!("diff: {} is not an array", actual[key]);
                                 diff_properties.push(key.to_string());
                             }
-                        }
-                        else {
-                            info!("diff: {key} missing");
+                        } else if value != &actual[key] {
                             diff_properties.push(key.to_string());
                         }
-                    },
-                    None => {
-                        info!("diff: {key} not object");
+                    } else {
+                        info!("diff: {key} missing");
                         diff_properties.push(key.to_string());
-                    },
+                    }
+                } else {
+                    info!("diff: {key} not object");
+                    diff_properties.push(key.to_string());
                 }
             }
         }
@@ -417,7 +421,7 @@ fn is_same_array(expected: &Vec<Value>, actual: &Vec<Value>) -> bool {
     }
 
     for item in expected {
-        if !array_contains(&actual, &item) {
+        if !array_contains(actual, item) {
             info!("diff: actual array missing expected element");
             return false;
         }
@@ -428,57 +432,43 @@ fn is_same_array(expected: &Vec<Value>, actual: &Vec<Value>) -> bool {
 
 fn array_contains(array: &Vec<Value>, find: &Value) -> bool {
     for item in array {
-        if find.is_boolean() && item.is_boolean() {
-            if find.as_bool().unwrap() == item.as_bool().unwrap() {
-                return true;
-            }
+        if find.is_boolean() && item.is_boolean() && find.as_bool().unwrap() == item.as_bool().unwrap() {
+            return true;
         }
 
-        if find.is_f64() && item.is_f64() {
-            if find.as_f64().unwrap() == item.as_f64().unwrap() {
-                return true;
-            }
+        if find.is_f64() && item.is_f64() && (find.as_f64().unwrap() - item.as_f64().unwrap()).abs() < 0.1 {
+            return true;
         }
 
-        if find.is_i64() && item.is_i64() {
-            if find.as_i64().unwrap() == item.as_i64().unwrap() {
-                return true;
-            }
+        if find.is_i64() && item.is_i64() && find.as_i64().unwrap() == item.as_i64().unwrap() {
+            return true;
         }
 
         if find.is_null() && item.is_null() {
             return true;
         }
 
-        if find.is_number() && item.is_number() {
-            if find.as_number().unwrap() == item.as_number().unwrap() {
-                return true;
-            }
+        if find.is_number() && item.is_number() && find.as_number().unwrap() == item.as_number().unwrap() {
+            return true;
         }
 
-        if find.is_string() && item.is_string() {
-            if find.as_str().unwrap() == item.as_str().unwrap() {
-                return true;
-            }
+        if find.is_string() && item.is_string() && find.as_str().unwrap() == item.as_str().unwrap() {
+            return true;
         }
 
-        if find.is_u64() && item.is_u64() {
-            if find.as_u64().unwrap() == item.as_u64().unwrap() {
-                return true;
-            }
+        if find.is_u64() && item.is_u64() && find.as_u64().unwrap() == item.as_u64().unwrap() {
+            return true;
         }
 
         if find.is_object() && item.is_object() {
             let obj_diff = get_diff(find, item);
-            if obj_diff.len() == 0 {
+            if obj_diff.is_empty() {
                 return true;
             }
         }
 
-        if find.is_array() && item.is_array() {
-            if array_contains(item.as_array().unwrap(), find) {
-                return true;
-            }
+        if find.is_array() && item.is_array() && array_contains(item.as_array().unwrap(), find) {
+            return true;
         }
     }
 

--- a/resources/apt/test/apt.tests.ps1
+++ b/resources/apt/test/apt.tests.ps1
@@ -27,7 +27,7 @@ Describe 'Apt resource tests' {
             if (-not $aptExists) {
                 Set-ItResult -Skip -Because "Apt not found"
             }
-            $out = dsc config get -p $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
+            $out = dsc -l trace config get -p $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
             $LASTEXITCODE | Should -Be 0 -Because (Get-Content "$TestDrive/stderr.txt")
             $exists = $null -ne (Get-Command $pkgName -CommandType Application -ErrorAction Ignore)
             $observed = $out.results[1].result.actualState._exist

--- a/resources/apt/test/apt.tests.ps1
+++ b/resources/apt/test/apt.tests.ps1
@@ -27,8 +27,8 @@ Describe 'Apt resource tests' {
             if (-not $aptExists) {
                 Set-ItResult -Skip -Because "Apt not found"
             }
-            $out = dsc config get -p $yamlPath | ConvertFrom-Json -Depth 10
-            $LASTEXITCODE | Should -Be 0
+            $out = dsc config get -p $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
+            $LASTEXITCODE | Should -Be 0 -Because (Get-Content "$TestDrive/stderr.txt")
             $exists = $null -ne (Get-Command $pkgName -CommandType Application -ErrorAction Ignore)
             $observed = $out.results[1].result.actualState._exist
             $observed | Should -Be $exists

--- a/resources/apt/test/apt.tests.ps1
+++ b/resources/apt/test/apt.tests.ps1
@@ -28,8 +28,7 @@ Describe 'Apt resource tests' {
                 Set-ItResult -Skip -Because "Apt not found"
             }
             $out = dsc -l trace config get -p $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
-            write-verbose -verbose (Get-Content "$TestDrive/stderr.txt" | Out-String)
-            $LASTEXITCODE | Should -Be 0
+            $LASTEXITCODE | Should -Be 0 -Because (Get-Content "$TestDrive/stderr.txt" | Out-String)
             $exists = $null -ne (Get-Command $pkgName -CommandType Application -ErrorAction Ignore)
             $observed = $out.results[1].result.actualState._exist
             $observed | Should -Be $exists

--- a/resources/apt/test/apt.tests.ps1
+++ b/resources/apt/test/apt.tests.ps1
@@ -28,7 +28,8 @@ Describe 'Apt resource tests' {
                 Set-ItResult -Skip -Because "Apt not found"
             }
             $out = dsc -l trace config get -p $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
-            $LASTEXITCODE | Should -Be 0 -Because (Get-Content "$TestDrive/stderr.txt")
+            write-verbose -verbose (Get-Content "$TestDrive/stderr.txt" | Out-String)
+            $LASTEXITCODE | Should -Be 0
             $exists = $null -ne (Get-Command $pkgName -CommandType Application -ErrorAction Ignore)
             $observed = $out.results[1].result.actualState._exist
             $observed | Should -Be $exists


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Two problems addressed by this PR:

- The output of `Assertion` simply returned the actual result to look like a `get` result, however, this causes the synthetic test doing a diff to fail as they don't resemble each other.  To address this, added a new hidden switch `--as--config` to inform `dsc` that this is a special case and the output needs to be transformed to a Configuration so that the synthetic test can work.

Here's example of the new output:

```yaml
metadata:
  Microsoft.DSC:
    version: 3.0.0
    operation: Test
    executionType: Actual
    startDatetime: 2024-11-07T16:45:48.237829-08:00
    endDatetime: 2024-11-07T16:45:48.789203-08:00
    duration: PT0.551374S
    securityContext: Restricted
results:
- metadata:
    Microsoft.DSC:
      duration: PT0.441752S
  name: Operating System Assertion
  type: Microsoft.DSC/Assertion
  result:
    desiredState:
      $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
      resources:
      - name: Is64BitOS
        type: Microsoft/OSInfo
        properties:
          bitness: '64'
      - name: 64bit test 2
        type: Microsoft/OSInfo
        properties:
          family: Windows
    actualState:
      $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
      resources:
      - type: Microsoft/OSInfo
        name: Is64BitOS
        properties:
          $id: https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json
          family: macOS
          version: 15.1.0
          bitness: '64'
          architecture: arm64
      - type: Microsoft/OSInfo
        name: 64bit test 2
        properties:
          $id: https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json
          family: macOS
          version: 15.1.0
          bitness: '64'
          architecture: arm64
    inDesiredState: false
    differingProperties:
    - resources
messages: []
hadErrors: false
```

- The second issue is that the synthetic test didn't handle arrays at all and `resources` is always an array.  Arrays need to be the same per the current diff rules:
  - same size
  - each element needs to exist
  - objects in actual can be superset of the expected

## PR Context

Fix https://github.com/PowerShell/DSC/issues/165