### PR TITLE
fix vscode settings for `dscecho` resource

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
     "rust-analyzer.linkedProjects": [
         "./dsc/Cargo.toml",
         "./dsc_lib/Cargo.toml",
-        "./echo/Cargo.toml",
+        "./dscecho/Cargo.toml",
         "./osinfo/Cargo.toml",
         "./registry/Cargo.toml",
         "./runcommandonset/Cargo.toml",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The `echo` resource was renamed to `dscecho` and now part of the product but the vscode setting was still referring to the old project name which causes rust-analyzer to fail.