### PR TITLE
Change how to pass STDIN input via `--file`, rename other args

### DIFF
--- a/archive/registry/registry.dsc.resource.json
+++ b/archive/registry/registry.dsc.resource.json
@@ -11,17 +11,23 @@
     "executable": "registry",
     "args": [
       "config",
-      "get"
-    ],
-    "input": "stdin"
+      "get",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   },
   "set": {
     "executable": "registry",
     "args": [
       "config",
-      "set"
+      "set",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "implementsPretest": true,
     "return": "state"
   },
@@ -29,9 +35,12 @@
     "executable": "registry",
     "args": [
       "config",
-      "test"
+      "test",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "return": "state"
   },
   "exitCodes": {

--- a/dsc/assertion.dsc.resource.json
+++ b/dsc/assertion.dsc.resource.json
@@ -12,9 +12,12 @@
       "config",
       "--as-group",
       "test",
-      "--as-get"
-    ],
-    "input": "stdin"
+      "--as-get",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   },
   "set": {
     "executable": "dsc",
@@ -23,9 +26,12 @@
       "pass-through",
       "config",
       "--as-group",
-      "test"
+      "test",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "implementsPretest": true,
     "return": "state"
   },
@@ -37,9 +43,12 @@
       "config",
       "--as-group",
       "test",
-      "--as-config"
+      "--as-config",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "return": "state"
   },
   "exitCodes": {
@@ -58,8 +67,11 @@
       "--trace-format",
       "pass-through",
       "config",
-      "validate"
-    ],
-    "input": "stdin"
+      "validate",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   }
 }

--- a/dsc/group.dsc.resource.json
+++ b/dsc/group.dsc.resource.json
@@ -11,9 +11,12 @@
       "pass-through",
       "config",
       "--as-group",
-      "get"
-    ],
-    "input": "stdin"
+      "get",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   },
   "set": {
     "executable": "dsc",
@@ -22,9 +25,12 @@
       "pass-through",
       "config",
       "--as-group",
-      "set"
+      "set",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "implementsPretest": true,
     "return": "state"
   },
@@ -35,9 +41,12 @@
       "pass-through",
       "config",
       "--as-group",
-      "test"
+      "test",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "return": "state"
   },
   "exitCodes": {
@@ -56,8 +65,11 @@
       "--trace-format",
       "pass-through",
       "config",
-      "validate"
-    ],
-    "input": "stdin"
+      "validate",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   }
 }

--- a/dsc/include.dsc.resource.json
+++ b/dsc/include.dsc.resource.json
@@ -12,9 +12,12 @@
       "config",
       "--as-include",
       "--as-group",
-      "get"
-    ],
-    "input": "stdin"
+      "get",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   },
   "set": {
     "executable": "dsc",
@@ -24,9 +27,12 @@
       "config",
       "--as-include",
       "--as-group",
-      "set"
+      "set",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "implementsPretest": true,
     "return": "state"
   },
@@ -38,9 +44,12 @@
       "config",
       "--as-include",
       "--as-group",
-      "test"
-    ],
-    "input": "stdin"
+      "test",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   },
   "exitCodes": {
     "0": "Success",
@@ -58,8 +67,11 @@
       "pass-through",
       "config",
       "--as-include",
-      "validate"
-    ],
-    "input": "stdin"
+      "validate",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   }
 }

--- a/dsc/parallel.dsc.resource.json
+++ b/dsc/parallel.dsc.resource.json
@@ -12,9 +12,12 @@
       "config",
       "--parallel",
       "--as-group",
-      "get"
-    ],
-    "input": "stdin"
+      "get",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   },
   "set": {
     "executable": "dsc",
@@ -24,9 +27,12 @@
       "config",
       "--parallel",
       "--as-group",
-      "set"
+      "set",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "implementsPretest": true,
     "return": "state"
   },
@@ -38,9 +44,12 @@
       "config",
       "--parallel",
       "--as-group",
-      "test"
+      "test",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
     ],
-    "input": "stdin",
     "return": "state"
   },
   "exitCodes": {
@@ -59,8 +68,11 @@
       "--trace-format",
       "pass-through",
       "config",
-      "validate"
-    ],
-    "input": "stdin"
+      "validate",
+      {
+        "jsonInputArg": "--input",
+        "mandatory": true
+      }
+    ]
   }
 }

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -30,7 +30,7 @@ pub struct Args {
     pub subcommand: SubCommand,
     #[clap(short = 'l', long, help = "Trace level to use", value_enum)]
     pub trace_level: Option<TraceLevel>,
-    #[clap(short = 'f', long, help = "Trace format to use", value_enum)]
+    #[clap(short = 't', long, help = "Trace format to use", value_enum)]
     pub trace_format: Option<TraceFormat>,
 }
 
@@ -67,7 +67,7 @@ pub enum SubCommand {
     Schema {
         #[clap(name = "type", short, long, help = "The type of DSC schema to get")]
         dsc_type: DscType,
-        #[clap(short = 'f', long, help = "The output format to use")]
+        #[clap(short = 'o', long, help = "The output format to use")]
         format: Option<OutputFormat>,
     },
 }
@@ -184,9 +184,9 @@ pub enum ResourceSubCommand {
         resource: String,
         #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "file")]
         input: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        #[clap(short = 'f', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
         file: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
+        #[clap(short = 'o', long, help = "The output format to use")]
         output_format: Option<OutputFormat>,
     },
     #[clap(name = "delete", about = "Invoke the delete operation to a resource", arg_required_else_help = true)]
@@ -195,7 +195,7 @@ pub enum ResourceSubCommand {
         resource: String,
         #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "file")]
         input: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        #[clap(short = 'f', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
         file: Option<String>,
     },
     #[clap(name = "schema", about = "Get the JSON schema for a resource", arg_required_else_help = true)]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -76,32 +76,32 @@ pub enum SubCommand {
 pub enum ConfigSubCommand {
     #[clap(name = "get", about = "Retrieve the current configuration")]
     Get {
-        #[clap(short = 'd', long, help = "The document to pass to the configuration or resource", conflicts_with = "path")]
-        document: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource", conflicts_with = "document")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'i', long, help = "The input document as JSON or YAML to pass to the configuration or resource", conflicts_with = "file")]
+        input: Option<String>,
+        #[clap(short = 'f', long, help = "The path to a file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "set", about = "Set the current configuration")]
     Set {
-        #[clap(short = 'd', long, help = "The document to pass to the configuration or resource", conflicts_with = "path")]
-        document: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource", conflicts_with = "document")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'i', long, help = "The input document as JSON or YAML to pass to the configuration or resource", conflicts_with = "file")]
+        input: Option<String>,
+        #[clap(short = 'f', long, help = "The path to a file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
         #[clap(short = 'w', long, help = "Run as a what-if operation instead of executing the configuration or resource")]
         what_if: bool,
     },
     #[clap(name = "test", about = "Test the current configuration")]
     Test {
-        #[clap(short = 'd', long, help = "The document to pass to the configuration or resource", conflicts_with = "path")]
-        document: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource", conflicts_with = "document")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'i', long, help = "The input document as JSON or YAML to pass to the configuration or resource", conflicts_with = "file")]
+        input: Option<String>,
+        #[clap(short = 'f', long, help = "The path to a file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
         // Used by Assertion resource to return `test` result as a `get` result
         #[clap(long, hide = true)]
         as_get: bool,
@@ -111,30 +111,30 @@ pub enum ConfigSubCommand {
     },
     #[clap(name = "validate", about = "Validate the current configuration", hide = true)]
     Validate {
-        #[clap(short = 'd', long, help = "The document to pass to the configuration or resource", conflicts_with = "path")]
-        document: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource", conflicts_with = "document")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'i', long, help = "The document to pass to the configuration or resource", conflicts_with = "file")]
+        input: Option<String>,
+        #[clap(short = 'f', long, help = "The path to a file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "export", about = "Export the current configuration")]
     Export {
-        #[clap(short = 'd', long, help = "The document to pass to the configuration or resource", conflicts_with = "path")]
-        document: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource", conflicts_with = "document")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'i', long, help = "The document to pass to the configuration or resource", conflicts_with = "file")]
+        input: Option<String>,
+        #[clap(short = 'f', long, help = "The path to a file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "resolve", about = "Resolve the current configuration", hide = true)]
     Resolve {
-        #[clap(short = 'd', long, help = "The document to pass to the configuration or resource", conflicts_with = "path")]
-        document: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a file used as input to the configuration or resource", conflicts_with = "document")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'i', long, help = "The document to pass to the configuration or resource", conflicts_with = "file")]
+        input: Option<String>,
+        #[clap(short = 'f', long, help = "The path to a file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     }
 }
 
@@ -151,8 +151,8 @@ pub enum ResourceSubCommand {
         description: Option<String>,
         #[clap(short, long, help = "Tag to search for in the resource tags")]
         tags: Option<Vec<String>>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "get", about = "Invoke the get operation to a resource", arg_required_else_help = true)]
     Get {
@@ -160,57 +160,57 @@ pub enum ResourceSubCommand {
         all: bool,
         #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `get` on")]
         resource: String,
-        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "path")]
+        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "file")]
         input: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource", conflicts_with = "input")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'f', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' as the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "set", about = "Invoke the set operation to a resource", arg_required_else_help = true)]
     Set {
         #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `set` on")]
         resource: String,
-        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "path")]
+        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "file")]
         input: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource", conflicts_with = "input")]
-        path: Option<String>,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'f', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "test", about = "Invoke the test operation to a resource", arg_required_else_help = true)]
     Test {
         #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `test` on")]
         resource: String,
-        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "path")]
+        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "file")]
         input: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource", conflicts_with = "input")]
-        path: Option<String>,
+        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
         #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "delete", about = "Invoke the delete operation to a resource", arg_required_else_help = true)]
     Delete {
         #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `delete` on")]
         resource: String,
-        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "path")]
+        #[clap(short, long, help = "The input to pass to the resource as JSON or YAML", conflicts_with = "file")]
         input: Option<String>,
-        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource", conflicts_with = "input")]
-        path: Option<String>,
+        #[clap(short = 'p', long, help = "The path to a JSON or YAML file used as input to the configuration or resource. Use '-' for the file to read from STDIN.", conflicts_with = "input")]
+        file: Option<String>,
     },
     #[clap(name = "schema", about = "Get the JSON schema for a resource", arg_required_else_help = true)]
     Schema {
         #[clap(short, long, help = "The name of the resource to get the JSON schema")]
         resource: String,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
     #[clap(name = "export", about = "Retrieve all resource instances", arg_required_else_help = true)]
     Export {
         #[clap(short, long, help = "The name or DscResource JSON of the resource to invoke `export` on")]
         resource: String,
-        #[clap(short = 'f', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        #[clap(short = 'o', long, help = "The output format to use")]
+        output_format: Option<OutputFormat>,
     },
 }
 

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -137,6 +137,8 @@ fn check_debug() {
 // Check if the dsc binary parent process is WinStore.App or Exploerer.exe
 #[cfg(windows)]
 fn check_store() {
+    use std::io::Read;
+
     let message = r"
 DSC.exe is a command-line tool and cannot be run directly from the Windows Store or Explorer.
 Visit https://aka.ms/dscv3-docs for more information on how to use DSC.exe.

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -220,6 +220,8 @@ pub fn config_export(configurator: &mut Configurator, format: &Option<OutputForm
 }
 
 fn initialize_config_root(path: &Option<String>) -> Option<String> {
+    // code that calls this pass in either None, Some("-"), or Some(path)
+    // in the case of `-` we treat it as None, but need to pass it back as subsequent processing needs to handle it
     let use_stdin = if let Some(specified_path) = path {
         if specified_path != "-" {
             return Some(set_dscconfigroot(specified_path));

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -220,33 +220,45 @@ pub fn config_export(configurator: &mut Configurator, format: &Option<OutputForm
 }
 
 fn initialize_config_root(path: &Option<String>) -> Option<String> {
-    if path.is_some() {
-        let config_path = path.clone().unwrap_or_default();
-        Some(set_dscconfigroot(&config_path))
-    } else if std::env::var(DSC_CONFIG_ROOT).is_ok() {
+    let use_stdin = if let Some(specified_path) = path {
+        if specified_path != "-" {
+            return Some(set_dscconfigroot(specified_path));
+        } else {
+            true
+        }
+    } else {
+        false
+    };
+
+    if std::env::var(DSC_CONFIG_ROOT).is_ok() {
         let config_root = std::env::var(DSC_CONFIG_ROOT).unwrap_or_default();
         debug!("Using {config_root} for {DSC_CONFIG_ROOT}");
-        None
     } else {
         let current_directory = std::env::current_dir().unwrap_or_default();
         debug!("Using current directory '{current_directory:?}' for {DSC_CONFIG_ROOT}");
         set_dscconfigroot(&current_directory.to_string_lossy());
-        None
     }
+
+    // if the path is "-", we need to return it so later processing can handle it correctly
+    if use_stdin {
+        return Some("-".to_string());
+    }
+
+    None
 }
 
 #[allow(clippy::too_many_lines)]
 pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounted_path: &Option<String>, as_group: &bool, as_include: &bool) {
     let (new_parameters, json_string) = match subcommand {
-        ConfigSubCommand::Get { input: document, file: path, .. } |
-        ConfigSubCommand::Set { input: document, file: path, .. } |
-        ConfigSubCommand::Test { input: document, file: path, .. } |
-        ConfigSubCommand::Validate { input: document, file: path, .. } |
-        ConfigSubCommand::Export { input: document, file: path, .. } => {
-            let new_path = initialize_config_root(path);
-            let input = get_input(document, &new_path);
+        ConfigSubCommand::Get { input, file, .. } |
+        ConfigSubCommand::Set { input, file, .. } |
+        ConfigSubCommand::Test { input, file, .. } |
+        ConfigSubCommand::Validate { input, file, .. } |
+        ConfigSubCommand::Export { input, file, .. } => {
+            let new_path = initialize_config_root(file);
+            let document = get_input(input, &new_path);
             if *as_include {
-                let (new_parameters, config_json) = match get_contents(&input) {
+                let (new_parameters, config_json) = match get_contents(&document) {
                     Ok((parameters, config_json)) => (parameters, config_json),
                     Err(err) => {
                         error!("{err}");
@@ -255,13 +267,13 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
                 };
                 (new_parameters, config_json)
             } else {
-                (None, input)
+                (None, document)
             }
         },
-        ConfigSubCommand::Resolve { input: document, file: path, .. } => {
-            let new_path = initialize_config_root(path);
-            let input = get_input(document, &new_path);
-            let (new_parameters, config_json) = match get_contents(&input) {
+        ConfigSubCommand::Resolve { input, file, .. } => {
+            let new_path = initialize_config_root(file);
+            let document = get_input(input, &new_path);
+            let (new_parameters, config_json) = match get_contents(&document) {
                 Ok((parameters, config_json)) => (parameters, config_json),
                 Err(err) => {
                     error!("{err}");
@@ -344,14 +356,14 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
         ConfigSubCommand::Test { output_format: format, as_get, as_config, .. } => {
             config_test(&mut configurator, format, as_group, as_get, as_config);
         },
-        ConfigSubCommand::Validate { input: document, file: path, output_format: format} => {
+        ConfigSubCommand::Validate { input, file, output_format: format} => {
             let mut result = ValidateResult {
                 valid: true,
                 reason: None,
             };
             if *as_include {
-                let new_path = initialize_config_root(path);
-                let input = get_input(document, &new_path);
+                let new_path = initialize_config_root(file);
+                let input = get_input(input, &new_path);
                 match serde_json::from_str::<Include>(&input) {
                     Ok(_) => {
                         // valid, so do nothing

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -223,9 +223,9 @@ fn initialize_config_root(path: &Option<String>) -> Option<String> {
     let use_stdin = if let Some(specified_path) = path {
         if specified_path != "-" {
             return Some(set_dscconfigroot(specified_path));
-        } else {
-            true
         }
+
+        true
     } else {
         false
     };

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -236,15 +236,15 @@ fn initialize_config_root(path: &Option<String>) -> Option<String> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounted_path: &Option<String>, stdin: &Option<String>, as_group: &bool, as_include: &bool) {
+pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounted_path: &Option<String>, as_group: &bool, as_include: &bool) {
     let (new_parameters, json_string) = match subcommand {
-        ConfigSubCommand::Get { document, path, .. } |
-        ConfigSubCommand::Set { document, path, .. } |
-        ConfigSubCommand::Test { document, path, .. } |
-        ConfigSubCommand::Validate { document, path, .. } |
-        ConfigSubCommand::Export { document, path, .. } => {
+        ConfigSubCommand::Get { input: document, file: path, .. } |
+        ConfigSubCommand::Set { input: document, file: path, .. } |
+        ConfigSubCommand::Test { input: document, file: path, .. } |
+        ConfigSubCommand::Validate { input: document, file: path, .. } |
+        ConfigSubCommand::Export { input: document, file: path, .. } => {
             let new_path = initialize_config_root(path);
-            let input = get_input(document, stdin, &new_path);
+            let input = get_input(document, &new_path);
             if *as_include {
                 let (new_parameters, config_json) = match get_contents(&input) {
                     Ok((parameters, config_json)) => (parameters, config_json),
@@ -258,9 +258,9 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
                 (None, input)
             }
         },
-        ConfigSubCommand::Resolve { document, path, .. } => {
+        ConfigSubCommand::Resolve { input: document, file: path, .. } => {
             let new_path = initialize_config_root(path);
-            let input = get_input(document, stdin, &new_path);
+            let input = get_input(document, &new_path);
             let (new_parameters, config_json) = match get_contents(&input) {
                 Ok((parameters, config_json)) => (parameters, config_json),
                 Err(err) => {
@@ -335,23 +335,23 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
     }
 
     match subcommand {
-        ConfigSubCommand::Get { format, .. } => {
+        ConfigSubCommand::Get { output_format: format, .. } => {
             config_get(&mut configurator, format, as_group);
         },
-        ConfigSubCommand::Set { format, .. } => {
+        ConfigSubCommand::Set { output_format: format, .. } => {
             config_set(&mut configurator, format, as_group);
         },
-        ConfigSubCommand::Test { format, as_get, as_config, .. } => {
+        ConfigSubCommand::Test { output_format: format, as_get, as_config, .. } => {
             config_test(&mut configurator, format, as_group, as_get, as_config);
         },
-        ConfigSubCommand::Validate { document, path, format} => {
+        ConfigSubCommand::Validate { input: document, file: path, output_format: format} => {
             let mut result = ValidateResult {
                 valid: true,
                 reason: None,
             };
             if *as_include {
                 let new_path = initialize_config_root(path);
-                let input = get_input(document, stdin, &new_path);
+                let input = get_input(document, &new_path);
                 match serde_json::from_str::<Include>(&input) {
                     Ok(_) => {
                         // valid, so do nothing
@@ -380,10 +380,10 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
 
             write_output(&json, format);
         },
-        ConfigSubCommand::Export { format, .. } => {
+        ConfigSubCommand::Export { output_format: format, .. } => {
             config_export(&mut configurator, format);
         },
-        ConfigSubCommand::Resolve { format, .. } => {
+        ConfigSubCommand::Resolve { output_format: format, .. } => {
             let configuration = match serde_json::from_str(&json_string) {
                 Ok(json) => json,
                 Err(err) => {
@@ -507,7 +507,7 @@ pub fn validate_config(config: &Configuration) -> Result<(), DscError> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
+pub fn resource(subcommand: &ResourceSubCommand) {
     let mut dsc = match DscManager::new() {
         Ok(dsc) => dsc,
         Err(err) => {
@@ -517,38 +517,38 @@ pub fn resource(subcommand: &ResourceSubCommand, stdin: &Option<String>) {
     };
 
     match subcommand {
-        ResourceSubCommand::List { resource_name, adapter_name, description, tags, format } => {
+        ResourceSubCommand::List { resource_name, adapter_name, description, tags, output_format: format } => {
             list_resources(&mut dsc, resource_name, adapter_name, description, tags, format);
         },
-        ResourceSubCommand::Schema { resource , format } => {
+        ResourceSubCommand::Schema { resource , output_format: format } => {
             dsc.find_resources(&[resource.to_string()]);
             resource_command::schema(&dsc, resource, format);
         },
-        ResourceSubCommand::Export { resource, format } => {
+        ResourceSubCommand::Export { resource, output_format: format } => {
             dsc.find_resources(&[resource.to_string()]);
             resource_command::export(&mut dsc, resource, format);
         },
-        ResourceSubCommand::Get { resource, input, path, all, format } => {
+        ResourceSubCommand::Get { resource, input, file: path, all, output_format: format } => {
             dsc.find_resources(&[resource.to_string()]);
             if *all { resource_command::get_all(&dsc, resource, format); }
             else {
-                let parsed_input = get_input(input, stdin, path);
+                let parsed_input = get_input(input, path);
                 resource_command::get(&dsc, resource, parsed_input, format);
             }
         },
-        ResourceSubCommand::Set { resource, input, path, format } => {
+        ResourceSubCommand::Set { resource, input, file: path, output_format: format } => {
             dsc.find_resources(&[resource.to_string()]);
-            let parsed_input = get_input(input, stdin, path);
+            let parsed_input = get_input(input, path);
             resource_command::set(&dsc, resource, parsed_input, format);
         },
-        ResourceSubCommand::Test { resource, input, path, format } => {
+        ResourceSubCommand::Test { resource, input, file: path, output_format: format } => {
             dsc.find_resources(&[resource.to_string()]);
-            let parsed_input = get_input(input, stdin, path);
+            let parsed_input = get_input(input, path);
             resource_command::test(&dsc, resource, parsed_input, format);
         },
-        ResourceSubCommand::Delete { resource, input, path } => {
+        ResourceSubCommand::Delete { resource, input, file: path } => {
             dsc.find_resources(&[resource.to_string()]);
-            let parsed_input = get_input(input, stdin, path);
+            let parsed_input = get_input(input, path);
             resource_command::delete(&dsc, resource, parsed_input);
         },
     }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -32,7 +32,7 @@ use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::env;
-use std::io::IsTerminal;
+use std::io::{IsTerminal, Read};
 use std::path::Path;
 use std::process::exit;
 use syntect::{
@@ -293,7 +293,7 @@ pub fn write_output(json: &str, format: &Option<OutputFormat>) {
 
 #[allow(clippy::too_many_lines)]
 pub fn enable_tracing(trace_level_arg: &Option<TraceLevel>, trace_format_arg: &Option<TraceFormat>) {
-    
+
     let mut policy_is_used = false;
     let mut tracing_setting = TracingSetting::default();
 
@@ -453,47 +453,52 @@ pub fn validate_json(source: &str, schema: &Value, json: &Value) -> Result<(), D
     Ok(())
 }
 
-pub fn get_input(input: &Option<String>, stdin: &Option<String>, path: &Option<String>) -> String {
-    let value = match (input, stdin, path) {
-        (Some(_), Some(_), None) | (None, Some(_), Some(_)) => {
-            error!("Error: Cannot specify both stdin and --document or --path");
-            exit(EXIT_INVALID_ARGS);
-        },
-        (Some(input), None, None) => {
-            debug!("Reading input from command line parameter");
+pub fn get_input(input: &Option<String>, file: &Option<String>) -> String {
+    let value = if let Some(input) = input {
+        debug!("Reading input from command line parameter");
 
-            // see if user accidentally passed in a file path
-            if Path::new(input).exists() {
-                error!("Error: Document provided is a file path, use --path instead");
-                exit(EXIT_INVALID_INPUT);
+        // see if user accidentally passed in a file path
+        if Path::new(input).exists() {
+            error!("Error: Document provided is a file path, use --path instead");
+            exit(EXIT_INVALID_INPUT);
+        }
+        input.clone()
+    } else if let Some(path) = file {
+        debug!("Reading input from file {}", path);
+        // check if need to read from STDIN
+        if path == "-" {
+            let mut stdin = Vec::<u8>::new();
+            match std::io::stdin().read_to_end(&mut stdin) {
+                Ok(_) => {
+                    match String::from_utf8(stdin) {
+                        Ok(input) => {
+                            input
+                        },
+                        Err(err) => {
+                            error!("Error: Invalid utf-8 input: {err}");
+                            exit(EXIT_INVALID_INPUT);
+                        }
+                    }
+                },
+                Err(err) => {
+                    error!("Error: Failed to read input from STDIN: {err}");
+                    exit(EXIT_INVALID_INPUT);
+                }
             }
-            input.clone()
-        },
-        (None, Some(stdin), None) => {
-            debug!("Reading input from stdin");
-            stdin.clone()
-        },
-        (None, None, Some(path)) => {
-            debug!("Reading input from file {}", path);
+        } else {
             match std::fs::read_to_string(path) {
                 Ok(input) => {
-                    input.clone()
+                    input
                 },
                 Err(err) => {
                     error!("Error: Failed to read input file: {err}");
                     exit(EXIT_INVALID_INPUT);
                 }
             }
-        },
-        (None, None, None) => {
-            debug!("No input provided via stdin, file, or command line");
-            return String::new();
-        },
-        _default => {
-            /* clap should handle these cases via conflicts_with so this should not get reached */
-            error!("Error: Invalid input");
-            exit(EXIT_INVALID_ARGS);
         }
+    } else {
+        debug!("No input provided");
+        return String::new();
     };
 
     if value.trim().is_empty() {

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -454,12 +454,13 @@ pub fn validate_json(source: &str, schema: &Value, json: &Value) -> Result<(), D
 }
 
 pub fn get_input(input: &Option<String>, file: &Option<String>) -> String {
+    trace!("Input: {input:?}, File: {file:?}");
     let value = if let Some(input) = input {
         debug!("Reading input from command line parameter");
 
         // see if user accidentally passed in a file path
         if Path::new(input).exists() {
-            error!("Error: Document provided is a file path, use --path instead");
+            error!("Error: Document provided is a file path, use '--file' instead");
             exit(EXIT_INVALID_INPUT);
         }
         input.clone()
@@ -467,6 +468,7 @@ pub fn get_input(input: &Option<String>, file: &Option<String>) -> String {
         debug!("Reading input from file {}", path);
         // check if need to read from STDIN
         if path == "-" {
+            info!("Reading input from STDIN");
             let mut stdin = Vec::<u8>::new();
             match std::io::stdin().read_to_end(&mut stdin) {
                 Ok(_) => {

--- a/dsc/tests/dsc_brew.tests.ps1
+++ b/dsc/tests/dsc_brew.tests.ps1
@@ -7,14 +7,14 @@ Describe 'Brew resource tests' {
     }
 
     It 'Config get works' -Skip:(-not $brewExists) {
-        $out = dsc config get -p $PSScriptRoot/../examples/brew.dsc.yaml | ConvertFrom-Json -Depth 10
+        $out = dsc config get -f $PSScriptRoot/../examples/brew.dsc.yaml | ConvertFrom-Json -Depth 10
         $LASTEXITCODE | Should -Be 0
         $exists = $null -ne (Get-Command gitui -CommandType Application -ErrorAction Ignore)
         $out.results[1].result.actualState._exist | Should -Be $exists
     }
 
     It 'Config test works' -Skip:(-not $brewExists) {
-        $out = dsc config test -p $PSScriptRoot/../examples/brew.dsc.yaml | ConvertFrom-Json -Depth 10
+        $out = dsc config test -f $PSScriptRoot/../examples/brew.dsc.yaml | ConvertFrom-Json -Depth 10
         $LASTEXITCODE | Should -Be 0
         $exists = $null -ne (Get-Command gitui -CommandType Application -ErrorAction Ignore)
         $out.results[1].result.inDesiredState | Should -Be $exists

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -9,7 +9,7 @@ Describe 'dsc config get tests' {
         param($config)
         $jsonPath = Join-Path $PSScriptRoot '../examples' $config
         $config = Get-Content $jsonPath -Raw
-        $out = $config | dsc config get | ConvertFrom-Json
+        $out = $config | dsc config get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.hadErrors | Should -BeFalse
         $out.results.Count | Should -Be 3
@@ -27,12 +27,12 @@ Describe 'dsc config get tests' {
     It 'will fail if resource schema does not match' -Skip:(!$IsWindows) {
         $jsonPath = Join-Path $PSScriptRoot '../examples/invalid_schema.dsc.yaml'
         $config = Get-Content $jsonPath -Raw
-        $testError = & {$config | dsc config get get 2>&1}
+        $testError = & {$config | dsc config get -f - 2>&1}
         $testError[0] | Should -match 'error:'
         $LASTEXITCODE | Should -Be 2
     }
 
-    It 'can accept the use of --format as a subcommand' {
+    It 'can accept the use of --output-format as a subcommand' {
         $config_yaml = @"
             `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
             resources:
@@ -41,7 +41,7 @@ Describe 'dsc config get tests' {
               properties:
                 output: hello
 "@
-        $result = $config_yaml | dsc config get --format pretty-json | ConvertFrom-Json
+        $result = $config_yaml | dsc config get --output-format pretty-json -f - | ConvertFrom-Json
         $result.hadErrors | Should -BeFalse
         $result.results.Count | Should -Be 1
         $result.results[0].Name | Should -Be 'Echo'

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -26,9 +26,8 @@ Describe 'dsc config get tests' {
 
     It 'will fail if resource schema does not match' -Skip:(!$IsWindows) {
         $jsonPath = Join-Path $PSScriptRoot '../examples/invalid_schema.dsc.yaml'
-        $config = Get-Content $jsonPath -Raw
-        $testError = & {$config | dsc config get -f - 2>&1}
-        $testError[0] | Should -match 'error:'
+        $testError = & {dsc config get -f $jsonPath 2>&1}
+        $testError[0] | Should -match 'Schema:'
         $LASTEXITCODE | Should -Be 2
     }
 

--- a/dsc/tests/dsc_config_set.tests.ps1
+++ b/dsc/tests/dsc_config_set.tests.ps1
@@ -15,7 +15,7 @@ Describe 'dsc config set tests' {
               properties:
                 _exist: false
 "@
-        $out = $config_yaml | dsc config set | ConvertFrom-Json
+        $out = $config_yaml | dsc config set -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.hadErrors | Should -BeFalse
         $out.results.Count | Should -Be 2

--- a/dsc/tests/dsc_config_test.tests.ps1
+++ b/dsc/tests/dsc_config_test.tests.ps1
@@ -21,7 +21,7 @@ Describe 'dsc config test tests' {
              family: Windows
 '@
 
-        $out = dsc config test -d $configYaml | ConvertFrom-Json
+        $out = dsc config test -i $configYaml | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
 
         if ($IsWindows) {

--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -131,7 +131,7 @@ Describe 'tests for resource discovery' {
         $TestClassResourcePath = Resolve-Path "$PSScriptRoot/../../powershell-adapter/Tests"
         $env:DSC_RESOURCE_PATH = $null
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $TestClassResourcePath
-        "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource' | Out-Null
+        "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource' -f - | Out-Null
 
         Test-Path $script:lookupTableFilePath -PathType Leaf | Should -BeTrue
         $script:lookupTableFilePath | Should -FileContentMatchExactly 'testclassresource/testclassresource'
@@ -155,7 +155,7 @@ Describe 'tests for resource discovery' {
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Saving lookup table"
 
         # second invocation (without an update) should use but not save adapter lookup table
-        "{'Name':'TestClassResource1'}" | dsc -l trace resource get -r 'TestClassResource/TestClassResource' 2> $TestDrive/tracing.txt
+        "{'Name':'TestClassResource1'}" | dsc -l trace resource get -r 'TestClassResource/TestClassResource' -f - 2> $TestDrive/tracing.txt
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Lookup table found resource 'testclassresource/testclassresource' in adapter 'Microsoft.DSC/PowerShell'"
         "$TestDrive/tracing.txt" | Should -Not -FileContentMatchExactly "Saving lookup table"
 
@@ -172,11 +172,11 @@ Describe 'tests for resource discovery' {
         $LASTEXITCODE | Should -Be 7
         $out = dsc resource get --all -r abc/def
         $LASTEXITCODE | Should -Be 7
-        $out = 'abc' | dsc resource set -r abc/def
+        $out = 'abc' | dsc resource set -r abc/def -f -
         $LASTEXITCODE | Should -Be 7
-        $out = 'abc' | dsc resource test -r abc/def
+        $out = 'abc' | dsc resource test -r abc/def -f -
         $LASTEXITCODE | Should -Be 7
-        $out = 'abc' | dsc resource delete -r abc/def
+        $out = 'abc' | dsc resource delete -r abc/def -f -
         $LASTEXITCODE | Should -Be 7
         $out = dsc resource export -r abc/def
         $LASTEXITCODE | Should -Be 7

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -32,7 +32,7 @@ Describe 'resource export tests' {
               properties:
                 pid: 0
 '@
-        $out = $yaml | dsc config export
+        $out = $yaml | dsc config export -f -
         $LASTEXITCODE | Should -Be 0
         $config_with_process_list = $out | ConvertFrom-Json
         $config_with_process_list.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json'
@@ -51,7 +51,7 @@ Describe 'resource export tests' {
               properties:
                 pid: 0
 '@
-        $out = $yaml | dsc config export | dsc config set
+        $out = $yaml | dsc config export -f - | dsc config set -f -
         $LASTEXITCODE | Should -Be 0
         $set_results = $out | ConvertFrom-Json
         $set_results.results.count | Should -BeGreaterThan 1
@@ -71,11 +71,11 @@ Describe 'resource export tests' {
               properties:
                 pid: 0
 '@
-        $out = $yaml | dsc config export 2>&1
+        $out = $yaml | dsc config export -f - 2>&1
         $LASTEXITCODE | Should -Be 0
     }
 
-    It 'Export can be called on individual resource with the use of --format as a subcommand' {
+    It 'Export can be called on individual resource with the use of --output-format as a subcommand' {
 
       $out = dsc resource export -r Microsoft/Process -f pretty-json
       $LASTEXITCODE | Should -Be 0
@@ -85,7 +85,7 @@ Describe 'resource export tests' {
       $config_with_process_list.resources.count | Should -BeGreaterThan 1
     }
 
-    It 'Export can be called on a configuration with the use of --format as a subcommand' {
+    It 'Export can be called on a configuration with the use of --output-format as a subcommand' {
 
       $yaml = @'
           $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
@@ -95,7 +95,7 @@ Describe 'resource export tests' {
             properties:
               pid: 0
 '@
-      $out = $yaml | dsc config export -f pretty-json
+      $out = $yaml | dsc config export -o pretty-json -f -
       $LASTEXITCODE | Should -Be 0
       $config_with_process_list = $out | ConvertFrom-Json
       $config_with_process_list.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json'

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -77,7 +77,7 @@ Describe 'resource export tests' {
 
     It 'Export can be called on individual resource with the use of --output-format as a subcommand' {
 
-      $out = dsc resource export -r Microsoft/Process -f pretty-json
+      $out = dsc resource export -r Microsoft/Process -o pretty-json
       $LASTEXITCODE | Should -Be 0
       $config_with_process_list = $out | ConvertFrom-Json
       $config_with_process_list.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json'

--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -41,8 +41,8 @@ resources:
   properties:
     output: "$text"
 "@
-        $debug = $yaml | dsc -l trace config get -f yaml 2>&1 | Out-String
-        $out = $yaml | dsc config get | ConvertFrom-Json
+        $debug = $yaml | dsc -l trace config get -o yaml -f - 2>&1 | Out-String
+        $out = $yaml | dsc config get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0 -Because $debug
         $out.results[0].result.actualState.output | Should -Be $expected -Because $debug
     }
@@ -62,7 +62,7 @@ resources:
   properties:
     output: "$expression"
 "@
-        $out = dsc config get -d $yaml 2>&1
+        $out = dsc config get -i $yaml 2>&1
         $LASTEXITCODE | Should -Be 2
         $out | Should -BeLike "*ERROR*"
     }

--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -69,7 +69,7 @@ resources:
 
     It 'Multi-line string literals work' {
       $yamlPath = "$PSScriptRoot/../examples/multiline.dsc.yaml"
-      $out = dsc config get -p $yamlPath | ConvertFrom-Json
+      $out = dsc config get -f $yamlPath | ConvertFrom-Json
       $LASTEXITCODE | Should -Be 0
       $out.results[0].result.actualState.output | Should -BeExactly @"
 This is a

--- a/dsc/tests/dsc_functions.tests.ps1
+++ b/dsc/tests/dsc_functions.tests.ps1
@@ -21,7 +21,7 @@ Describe 'tests for function expressions' {
               properties:
                 output: '$escapedText'
 "@
-        $out = $config_yaml | dsc config get | ConvertFrom-Json
+        $out = $config_yaml | dsc config get -f - | ConvertFrom-Json
         $out.results[0].result.actualState.output | Should -Be $expected
     }
 
@@ -39,7 +39,7 @@ Describe 'tests for function expressions' {
               properties:
                 output: "[path($path)]"
 "@
-        $out = $config_yaml | dsc config --system-root $PSHOME get | ConvertFrom-Json
+        $out = $config_yaml | dsc config --system-root $PSHOME get -f - | ConvertFrom-Json
         $out.results[0].result.actualState.output | Should -BeExactly $expected
     }
 
@@ -58,7 +58,7 @@ Describe 'tests for function expressions' {
         } else {
             '/'
         }
-        $out = $config_yaml | dsc config get | ConvertFrom-Json
+        $out = $config_yaml | dsc config get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.actualState.output | Should -BeExactly $expected
     }

--- a/dsc/tests/dsc_get.tests.ps1
+++ b/dsc/tests/dsc_get.tests.ps1
@@ -29,7 +29,7 @@ Describe 'resource get tests' {
             "valueName": "ProductName"
         }
 '@
-        $output = $json | dsc resource get -r $resource
+        $output = $json | dsc resource get -r $resource -f -
         $LASTEXITCODE | Should -Be 0
         $output = $output | ConvertFrom-Json
         $output.actualState.keyPath | Should -BeExactly 'HKLM\Software\Microsoft\Windows NT\CurrentVersion'
@@ -44,7 +44,7 @@ Describe 'resource get tests' {
             "Name": "ProductName"
         }
 '@
-        $testError = & {$json | dsc resource get -r Microsoft.Windows/Registry get 2>&1}
+        $testError = & {$json | dsc resource get -r Microsoft.Windows/Registry get -f - 2>&1}
         $testError[0] | SHould -match 'error:'
         $LASTEXITCODE | Should -Be 2
     }

--- a/dsc/tests/dsc_group.tests.ps1
+++ b/dsc/tests/dsc_group.tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Group resource tests' {
     It 'Nested groups should work for get' {
-        $out = (dsc config get -p $PSScriptRoot/../examples/groups.dsc.yaml -f yaml | Out-String).Trim()
+        $out = (dsc config get -f $PSScriptRoot/../examples/groups.dsc.yaml -o yaml | Out-String).Trim()
         $LASTEXITCODE | Should -Be 0
         $out | Should -BeLike @'
 metadata:

--- a/dsc/tests/dsc_include.tests.ps1
+++ b/dsc/tests/dsc_include.tests.ps1
@@ -165,7 +165,7 @@ resources:
     configurationFile: $nestedIncludeConfigPath
 "@
 
-        $out = $includeConfig | dsc config get | ConvertFrom-Json
+        $out = $includeConfig | dsc config get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result[0].result.actualState.output | Should -Be 'one'
         $out.results[1].result[0].name | Should -Be 'nested'
@@ -201,7 +201,7 @@ resources:
     configurationFile: "[concat('$echoConfigPathParent', '$directorySeparator', '$echoConfigPathLeaf')]"
 "@
 
-        $out = dsc config set -d $includeConfig | ConvertFrom-Json
+        $out = dsc config set -i $includeConfig | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.beforeState[0].name | Should -Be 'one'
         $out.results[0].result.beforeState[0].type | Should -Be 'Microsoft.DSC.Debug/Echo'

--- a/dsc/tests/dsc_include.tests.ps1
+++ b/dsc/tests/dsc_include.tests.ps1
@@ -23,7 +23,7 @@ Describe 'Include tests' {
 "@
         $configPath = Join-Path $TestDrive 'config.dsc.yaml'
         $config | Set-Content -Path $configPath
-        $out = dsc config get -p $configPath | ConvertFrom-Json
+        $out = dsc config get -f $configPath | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         if ($IsWindows) {
             $expectedOS = 'Windows'
@@ -47,7 +47,7 @@ Describe 'Include tests' {
 "@
         $configPath = Join-Path $TestDrive 'config.dsc.yaml'
         $config | Set-Content -Path $configPath
-        $out = dsc config get -p $configPath | ConvertFrom-Json
+        $out = dsc config get -f $configPath | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         if ($IsWindows) {
             $expectedOS = 'Windows'
@@ -79,7 +79,7 @@ Describe 'Include tests' {
 
         $configPath = Join-Path $TestDrive 'config.dsc.yaml'
         $configYaml | Set-Content -Path $configPath
-        $out = dsc config get -p $configPath 2> $logPath
+        $out = dsc config get -f $configPath 2> $logPath
         $LASTEXITCODE | Should -Be 2
         $log = Get-Content -Path $logPath -Raw
         $log | Should -BeLike "*ERROR*"
@@ -111,7 +111,7 @@ Describe 'Include tests' {
 
         $configPath = Join-Path $TestDrive 'config.dsc.yaml'
         $configYaml | Set-Content -Path $configPath
-        $out = dsc config get -p $configPath | ConvertFrom-Json
+        $out = dsc config get -f $configPath | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         if ($IsWindows) {
             $expectedOS = 'Windows'
@@ -211,7 +211,7 @@ resources:
 
     It 'Test with include works' {
         $includeYaml = Join-Path $PSScriptRoot ../../dsc/examples/include.dsc.yaml
-        $out = dsc config test -p $includeYaml | ConvertFrom-Json
+        $out = dsc config test -f $includeYaml | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].type | Should -BeExactly 'Microsoft.DSC/Include'
         $out.results[0].result[0].name | Should -BeExactly 'os'

--- a/dsc/tests/dsc_osinfo.tests.ps1
+++ b/dsc/tests/dsc_osinfo.tests.ps1
@@ -1,6 +1,6 @@
 Describe 'Tests for osinfo examples' {
     It 'Config with default parameters and get works' {
-        $out = dsc config get -p $PSScriptRoot/../examples/osinfo_parameters.dsc.yaml | ConvertFrom-Json -Depth 10
+        $out = dsc config get -f $PSScriptRoot/../examples/osinfo_parameters.dsc.yaml | ConvertFrom-Json -Depth 10
         $LASTEXITCODE | Should -Be 0
         $expected = if ($IsWindows) {
             'Windows'
@@ -14,12 +14,12 @@ Describe 'Tests for osinfo examples' {
     }
 
     It 'Config test works' {
-        $out = dsc config -f $PSScriptRoot/../examples/osinfo.parameters.yaml test -p $PSScriptRoot/../examples/osinfo_parameters.dsc.yaml | ConvertFrom-Json -Depth 10
+        $out = dsc config -f $PSScriptRoot/../examples/osinfo.parameters.yaml test -f $PSScriptRoot/../examples/osinfo_parameters.dsc.yaml | ConvertFrom-Json -Depth 10
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.inDesiredState | Should -Be $IsMacOS
     }
 
-    It 'Verify dsc home directory is added to PATH to find included resources' -Tag z1{
+    It 'Verify dsc home directory is added to PATH to find included resources' {
         $oldPath = $env:PATH
         $oldLocation = Get-Location
         try {
@@ -29,7 +29,7 @@ Describe 'Tests for osinfo examples' {
             $new_path = ($oldPath.Split([System.IO.Path]::PathSeparator) | Where-Object { $_ -ne $exe_path }) -join [System.IO.Path]::PathSeparator
             $env:PATH = $new_path
 
-            $null = & "$exe_path/dsc" config test -p "$PSScriptRoot/../examples/osinfo_parameters.dsc.yaml"
+            $null = & "$exe_path/dsc" config test -f "$PSScriptRoot/../examples/osinfo_parameters.dsc.yaml"
             $LASTEXITCODE | Should -Be 0
         }
         finally {

--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -24,10 +24,10 @@ Describe 'Parameters tests' {
         if ($inputType -eq 'file') {
             $file_path = "$TestDrive/test.parameters.json"
             Set-Content -Path $file_path -Value $params_json
-            $out = $config_yaml | dsc config -f $file_path get | ConvertFrom-Json
+            $out = dsc config -f $file_path get -f - | ConvertFrom-Json
         }
         else {
-            $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
+            $out = $config_yaml | dsc config -p $params_json get -f - | ConvertFrom-Json
         }
 
         $LASTEXITCODE | Should -Be 0
@@ -55,7 +55,7 @@ Describe 'Parameters tests' {
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
-        $out = $config_yaml | dsc config -p $params_json get | ConvertFrom-Json
+        $out = $config_yaml | dsc config -p $params_json get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.actualState.output | Should -BeExactly $value
     }
@@ -81,7 +81,7 @@ Describe 'Parameters tests' {
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
-        $testError = & {$config_yaml | dsc config -p $params_json get 2>&1}
+        $testError = & {$config_yaml | dsc config -p $params_json get -f - 2>&1}
         $testError | Should -match 'Parameter input failure:'
         $LASTEXITCODE | Should -Be 4
     }
@@ -109,7 +109,7 @@ Describe 'Parameters tests' {
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
-        $testError = & {$config_yaml | dsc config -p $params_json get get 2>&1}
+        $testError = & {$config_yaml | dsc config -p $params_json get -f - 2>&1}
         $testError[0] | Should -match 'error'
         $LASTEXITCODE | Should -Be 2
     }
@@ -136,7 +136,7 @@ Describe 'Parameters tests' {
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
-        $testError = & {$config_yaml | dsc config -p $params_json get get 2>&1}
+        $testError = & {$config_yaml | dsc config -p $params_json get -f - 2>&1}
         $testError[0] | Should -match 'error'
         $LASTEXITCODE | Should -Be 2
     }
@@ -161,7 +161,7 @@ Describe 'Parameters tests' {
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
-        $testError = & {$config_yaml | dsc config -p $params_json get get 2>&1}
+        $testError = & {$config_yaml | dsc config -p $params_json get -f - 2>&1}
         $testError[0] | Should -match 'error'
         $LASTEXITCODE | Should -Be 2
     }
@@ -188,7 +188,7 @@ Describe 'Parameters tests' {
 "@
         $params_json = @{ parameters = @{ param1 = $value }} | ConvertTo-Json
 
-        $testError = & {$config_yaml | dsc config -p $params_json get get 2>&1}
+        $testError = & {$config_yaml | dsc config -p $params_json get -f - 2>&1}
         $testError[0] | Should -match 'error'
         $LASTEXITCODE | Should -Be 2
     }
@@ -228,7 +228,7 @@ Describe 'Parameters tests' {
                 output: '[parameters(''paramArray'')]'
 "@
 
-        $out = $config_yaml | dsc config get | ConvertFrom-Json
+        $out = $config_yaml | dsc config get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.actualState.output | Should -BeExactly 'hello'
         $out.results[1].result.actualState.output | Should -BeExactly 7
@@ -268,7 +268,7 @@ Describe 'Parameters tests' {
             family: '[parameters(''osFamily'')]'
 '@
 
-      $out = dsc config -p $params test -d $config_yaml | ConvertFrom-Json
+      $out = dsc config -p $params test -i $config_yaml | ConvertFrom-Json
       $LASTEXITCODE | Should -Be 0
       $out.results[0].result.actualState.family | Should -BeExactly $os
       $out.results[0].result.inDesiredState | Should -BeTrue
@@ -305,7 +305,7 @@ Describe 'Parameters tests' {
 "@
 
       $params_json = @{ parameters = @{ param = $value }} | ConvertTo-Json
-      $null = $config_yaml | dsc config -p $params_json get
+      $null = $config_yaml | dsc config -p $params_json get -f -
       $LASTEXITCODE | Should -Be 4
     }
 }

--- a/dsc/tests/dsc_reference.tests.ps1
+++ b/dsc/tests/dsc_reference.tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'Tests for config using reference function' {
     It 'Reference works' {
-        $out = dsc config get -p $PSScriptRoot/../examples/reference.dsc.yaml | ConvertFrom-Json
+        $out = dsc config get -f $PSScriptRoot/../examples/reference.dsc.yaml | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $os = if ($IsWindows) {
             'Windows'

--- a/dsc/tests/dsc_resource_input.tests.ps1
+++ b/dsc/tests/dsc_resource_input.tests.ps1
@@ -110,7 +110,7 @@ Describe 'tests for resource input' {
         }
 "@
 
-        $result = $json | dsc resource $operation -r Test/EnvVarInput | ConvertFrom-Json
+        $result = $json | dsc resource $operation -r Test/EnvVarInput -f - | ConvertFrom-Json
         $result.$member.Hello | Should -BeExactly 'foo'
         $result.$member.World | Should -Be 2
         $result.$member.Boolean | Should -Be 'true'

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -48,10 +48,10 @@ Describe 'Tests for listing resources' {
         }
     }
 
-    It 'can accept the use of --format as a subcommand' {
+    It 'can accept the use of --output-format as a subcommand' {
         $expectedCount = 1
         $expectedType = 'Microsoft/OSInfo'
-        $resources = dsc resource list --description "operating system" --format pretty-json | ConvertFrom-Json
+        $resources = dsc resource list --description "operating system" --output-format pretty-json | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $resources.Count | Should -Be $expectedCount
         if ($expectedCount -gt 0) {

--- a/dsc/tests/dsc_resource_test.tests.ps1
+++ b/dsc/tests/dsc_resource_test.tests.ps1
@@ -15,7 +15,7 @@ Describe 'Invoke a resource test directly' {
 
         $out = @"
         { "family": "$os" }
-"@ | dsc resource test -r Microsoft/OSInfo | ConvertFrom-Json
+"@ | dsc resource test -r Microsoft/OSInfo -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.actualState.family | Should -BeExactly $os
         $out.inDesiredState | Should -Be $true

--- a/dsc/tests/dsc_schema.tests.ps1
+++ b/dsc/tests/dsc_schema.tests.ps1
@@ -30,7 +30,7 @@ Describe 'config schema tests' {
     }
 
     It 'can accept the use of --output-format as a subcommand' {
-        $schema = dsc resource schema -r Microsoft.DSC.Debug/Echo -f pretty-json
+        $schema = dsc resource schema -r Microsoft.DSC.Debug/Echo -o pretty-json
         $LASTEXITCODE | Should -Be 0
         $schema | Should -Not -BeNullOrEmpty
         $schema = $schema | ConvertFrom-Json

--- a/dsc/tests/dsc_schema.tests.ps1
+++ b/dsc/tests/dsc_schema.tests.ps1
@@ -29,7 +29,7 @@ Describe 'config schema tests' {
         $schema.'$schema' | Should -BeExactly 'http://json-schema.org/draft-07/schema#'
     }
 
-    It 'can accept the use of --format as a subcommand' {
+    It 'can accept the use of --output-format as a subcommand' {
         $schema = dsc resource schema -r Microsoft.DSC.Debug/Echo -f pretty-json
         $LASTEXITCODE | Should -Be 0
         $schema | Should -Not -BeNullOrEmpty

--- a/dsc/tests/dsc_securitycontext.tests.ps1
+++ b/dsc/tests/dsc_securitycontext.tests.ps1
@@ -13,7 +13,7 @@ Describe 'Tests for configuration security context metadata' {
     }
 
     It 'Require admin' {
-        $out = dsc config get -p $PSScriptRoot/../examples/require_admin.yaml
+        $out = dsc config get -f $PSScriptRoot/../examples/require_admin.yaml
         if ($isAdmin) {
             $LASTEXITCODE | Should -Be 0
             $out | Should -Not -BeNullOrEmpty
@@ -24,7 +24,7 @@ Describe 'Tests for configuration security context metadata' {
     }
 
     It 'Require non-admin' {
-        $out = dsc config get -p $PSScriptRoot/../examples/require_nonadmin.yaml
+        $out = dsc config get -f $PSScriptRoot/../examples/require_nonadmin.yaml
         if ($isAdmin) {
             $LASTEXITCODE | Should -Be 2
         }

--- a/dsc/tests/dsc_set.tests.ps1
+++ b/dsc/tests/dsc_set.tests.ps1
@@ -88,7 +88,7 @@ Describe 'resource set tests' {
             }
         }
 '@
-        $out = $json | dsc resource set -r Microsoft.Windows/Registry
+        $out = $json | dsc resource set -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
         $result.afterState.keyPath | Should -Be 'HKCU\1\2\3'
@@ -97,7 +97,7 @@ Describe 'resource set tests' {
         $result.changedProperties | Should -Be @('valueName', 'valueData', '_exist')
         ($result.psobject.properties | Measure-Object).Count | Should -Be 3
 
-        $out = $json | dsc resource get -r Microsoft.Windows/Registry
+        $out = $json | dsc resource get -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
         $result.actualState.keyPath | Should -Be 'HKCU\1\2\3'
@@ -111,7 +111,7 @@ Describe 'resource set tests' {
             "_exist": false
         }
 '@
-        $out = $json | dsc resource set -r Microsoft.Windows/Registry
+        $out = $json | dsc resource set -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
         $result.afterState.keyPath | Should -BeExactly 'HKCU\1'
@@ -119,7 +119,7 @@ Describe 'resource set tests' {
         ($result.psobject.properties | Measure-Object).Count | Should -Be 3
     }
 
-    It 'can accept the use of --format <format> as a subcommand' -Skip:(!$IsWindows) -TestCases @(
+    It 'can accept the use of --output-format <format> as a subcommand' -Skip:(!$IsWindows) -TestCases @(
         @{ format = 'yaml'; expected = @'
 beforeState:
   test: true
@@ -148,7 +148,7 @@ changedProperties:
         $oldPath = $env:DSC_RESOURCE_PATH
         try {
             $env:DSC_RESOURCE_PATH = $TestDrive
-            $out = '{ "test": true }' | dsc resource set -r Test/SetNoTest --format $format | Out-String
+            $out = '{ "test": true }' | dsc resource set -r Test/SetNoTest -f - --output-format $format | Out-String
             $LASTEXITCODE | Should -Be 0
             $out.Trim() | Should -BeExactly $expected
         }
@@ -161,7 +161,7 @@ changedProperties:
         $oldPath = $env:DSC_RESOURCE_PATH
         try {
             $env:DSC_RESOURCE_PATH = $TestDrive
-            $out = '{ "test": true }' | dsc resource set -r Test/SetNoTest | ConvertFrom-Json
+            $out = '{ "test": true }' | dsc resource set -r Test/SetNoTest -f - | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
             $out.BeforeState.test | Should -Be $true
             $out.AfterState.test | Should -Be $false

--- a/dsc/tests/dsc_test.tests.ps1
+++ b/dsc/tests/dsc_test.tests.ps1
@@ -10,7 +10,7 @@ Describe 'resource test tests' {
         }
 '@
         $current = registry config get --input $json
-        $out = $current | dsc resource test -r Microsoft.Windows/Registry
+        $out = $current | dsc resource test -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $out = $out | ConvertFrom-Json
         $out.inDesiredState | Should -BeTrue
@@ -27,7 +27,7 @@ Describe 'resource test tests' {
             }
         }
 '@
-        $out = $json | dsc resource test -r Microsoft.Windows/Registry
+        $out = $json | dsc resource test -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $out = $out | ConvertFrom-Json
         $out.inDesiredState | Should -BeFalse
@@ -45,7 +45,7 @@ Describe 'resource test tests' {
             }
         }
 '@
-        $out = $json | dsc resource test -r Microsoft.Windows/Registry
+        $out = $json | dsc resource test -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $out = $out | ConvertFrom-Json
         $out.inDesiredState | Should -BeFalse
@@ -54,8 +54,8 @@ Describe 'resource test tests' {
         $out.differingProperties[1] | Should -BeExactly '_exist'
     }
 
-    It 'can accept the use of --format as a subcommand' {
-        $null = "output: hello" | dsc resource test -r Microsoft.DSC.Debug/Echo --format pretty-json
+    It 'can accept the use of --output-format as a subcommand' {
+        $null = "output: hello" | dsc resource test -r Microsoft.DSC.Debug/Echo --output-format pretty-json -f -
         $LASTEXITCODE | Should -Be 0
     }
 }

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -88,9 +88,10 @@ Describe 'tracing tests' {
 
     It 'Pass-through tracing should only emit JSON for child processes' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $out = dsc -l info -f pass-through  config get -p ../examples/groups.dsc.yaml 2> $logPath
+        $out = dsc -l info -t pass-through config get -f ../examples/groups.dsc.yaml 2> $logPath
         foreach ($line in (Get-Content $logPath)) {
             $line | Should -Not -BeNullOrEmpty
+            Write-Verbose -Verbose $line
             $json = $line | ConvertFrom-Json
             $json.timestamp | Should -Not -BeNullOrEmpty
             $json.level | Should -BeIn 'ERROR', 'WARN', 'INFO', 'DEBUG', 'TRACE'

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -12,14 +12,14 @@ Describe 'tracing tests' {
         param($level)
 
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc -l $level resource get -r 'DoesNotExist' 2> $logPath
+        $null = dsc -l $level resource get -r 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         $log | Should -BeLikeExactly "* $($level.ToUpper()) *"
     }
 
     It 'trace level error does not emit other levels' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc --trace-level error resource list 'DoesNotExist' 2> $logPath
+        $null = dsc --trace-level error resource list 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         $log | Should -Not -BeLikeExactly "* WARNING *"
         $log | Should -Not -BeLikeExactly "* INFO *"
@@ -29,14 +29,14 @@ Describe 'tracing tests' {
 
     It 'trace format plaintext does not emit ANSI' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc --trace-format plaintext resource list 'DoesNotExist' 2> $logPath
+        $null = dsc --trace-format plaintext resource list 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         $log | Should -Not -BeLikeExactly "*``[0m*"
     }
 
     It 'trace format json emits json' {
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc --trace-format json resource list 'DoesNotExist' 2> $logPath
+        $null = dsc --trace-format json resource list 'DoesNotExist' 2> $logPath
         foreach ($line in (Get-Content $logPath)) {
             $trace = $line | ConvertFrom-Json -Depth 10
             $trace.timestamp | Should -Not -BeNullOrEmpty
@@ -55,7 +55,7 @@ Describe 'tracing tests' {
         param($level, $sourceExpected)
 
         $logPath = "$TestDrive/dsc_trace.log"
-        $null = '{}' | dsc -l $level resource list 'DoesNotExist' 2> $logPath
+        $null = dsc -l $level resource list 'DoesNotExist' 2> $logPath
         $log = Get-Content $logPath -Raw
         if ($sourceExpected) {
             $log | Should -BeLike "*dsc_lib*: *"
@@ -82,7 +82,7 @@ Describe 'tracing tests' {
                 level: trace
 "@
 
-        $out = (dsc -l $level config get -d $configYaml 2> $null) | ConvertFrom-Json
+        $out = (dsc -l $level config get -i $configYaml 2> $null) | ConvertFrom-Json
         $out.results[0].result.actualState.level | Should -BeExactly $level
     }
 

--- a/dsc/tests/dsc_variables.tests.ps1
+++ b/dsc/tests/dsc_variables.tests.ps1
@@ -21,7 +21,7 @@ resources:
   properties:
     output: "[variables('myVariable')]"
 '@
-        $out = dsc config get -d $configYaml | ConvertFrom-Json
+        $out = dsc config get -i $configYaml | ConvertFrom-Json
         Write-Verbose -Verbose $out
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.actualState.output | Should -Be 'bar'
@@ -38,7 +38,7 @@ resources:
   properties:
     output: "[variables('myVariable')]"
 '@
-        $out = dsc config get -d $configYaml 2>&1 | Out-String
+        $out = dsc config get -i $configYaml 2>&1 | Out-String
         Write-Verbose -Verbose $out
         $LASTEXITCODE | Should -Be 2
         $out | Should -BeLike "*Variable 'myVariable' does not exist or has not been initialized yet*"

--- a/dsc/tests/dsc_variables.tests.ps1
+++ b/dsc/tests/dsc_variables.tests.ps1
@@ -4,7 +4,7 @@
 Describe 'Configruation variables tests' {
     It 'Variables example config works' {
         $configFile = "$PSSCriptRoot/../examples/variables.dsc.yaml"
-        $out = dsc config get -p $configFile | ConvertFrom-Json
+        $out = dsc config get -f $configFile | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.actualState.output | Should -BeExactly 'myOutput is: Hello world!, myObject is: baz'
     }

--- a/dsc/tests/dsc_whatif.tests.ps1
+++ b/dsc/tests/dsc_whatif.tests.ps1
@@ -35,8 +35,8 @@ Describe 'whatif tests' {
               properties:
                 keyPath: 'HKCU\1\2'
 "@
-        $what_if_result = $config_yaml | dsc config set -w -f - | ConvertFrom-Json
-        $set_result = $config_yaml | dsc config set | ConvertFrom-Json
+        $what_if_result = dsc config set -w -i $config_yaml | ConvertFrom-Json
+        $set_result = dsc config set -i $config_yaml | ConvertFrom-Json
         $what_if_result.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'WhatIf'
         $what_if_result.results.result.beforeState._exist | Should -Be $set_result.results.result.beforeState._exist
         $what_if_result.results.result.beforeState.keyPath | Should -Be $set_result.results.result.beforeState.keyPath

--- a/dsc/tests/dsc_whatif.tests.ps1
+++ b/dsc/tests/dsc_whatif.tests.ps1
@@ -14,8 +14,8 @@ Describe 'whatif tests' {
               properties:
                 output: hello
 "@
-        $what_if_result = $config_yaml | dsc config set -w | ConvertFrom-Json
-        $set_result = $config_yaml | dsc config set | ConvertFrom-Json
+        $what_if_result = $config_yaml | dsc config set -w -f - | ConvertFrom-Json
+        $set_result = $config_yaml | dsc config set -f - | ConvertFrom-Json
         $what_if_result.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'WhatIf'
         $what_if_result.results.result.beforeState.output | Should -Be $set_result.results.result.beforeState.output
         $what_if_result.results.result.afterState.output | Should -Be $set_result.results.result.afterState.output
@@ -35,7 +35,7 @@ Describe 'whatif tests' {
               properties:
                 keyPath: 'HKCU\1\2'
 "@
-        $what_if_result = $config_yaml | dsc config set -w | ConvertFrom-Json
+        $what_if_result = $config_yaml | dsc config set -w -f - | ConvertFrom-Json
         $set_result = $config_yaml | dsc config set | ConvertFrom-Json
         $what_if_result.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'WhatIf'
         $what_if_result.results.result.beforeState._exist | Should -Be $set_result.results.result.beforeState._exist
@@ -59,7 +59,7 @@ Describe 'whatif tests' {
               properties:
                 _exist: false
 "@
-        $result = $config_yaml | dsc config set -w 2>&1
+        $result = $config_yaml | dsc config set -w -f - 2>&1
         $result | Should -Match 'ERROR.*?Not supported.*?what-if'
         $LASTEXITCODE | Should -Be 2
     }
@@ -79,7 +79,7 @@ Describe 'whatif tests' {
           properties:
             executionType: Actual
 "@
-        $result = $config_yaml | dsc config set | ConvertFrom-Json
+        $result = $config_yaml | dsc config set -f - | ConvertFrom-Json
         $result.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'Actual'
         $result.results.result.afterState.executionType | Should -BeExactly 'Actual'
         $result.results.result.changedProperties | Should -Be $null
@@ -97,7 +97,7 @@ Describe 'whatif tests' {
           properties:
             executionType: Actual
 "@
-        $result = $config_yaml | dsc config set -w | ConvertFrom-Json
+        $result = $config_yaml | dsc config set -w -f - | ConvertFrom-Json
         $result.metadata.'Microsoft.DSC'.executionType | Should -BeExactly 'WhatIf'
         $result.results.result.afterState.executionType | Should -BeExactly 'WhatIf'
         $result.results.result.changedProperties | Should -BeExactly 'executionType'

--- a/dsc/tests/dsc_whatif.tests.ps1
+++ b/dsc/tests/dsc_whatif.tests.ps1
@@ -65,7 +65,7 @@ Describe 'whatif tests' {
     }
 
     It 'config set whatif for group resource' {
-        $result = dsc config set -p $PSScriptRoot/../examples/groups.dsc.yaml -w 2>&1
+        $result = dsc config set -f $PSScriptRoot/../examples/groups.dsc.yaml -w 2>&1
         $result | Should -Match 'ERROR.*?Not implemented.*?what-if'
         $LASTEXITCODE | Should -Be 2
     }

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -31,7 +31,7 @@ Describe 'osinfo resource tests' {
         else {
             $invalid = 'Windows'
         }
-        $out = "{`"family`": `"$invalid`"}" | dsc resource test -r 'Microsoft/OSInfo' | ConvertFrom-Json
+        $out = "{`"family`": `"$invalid`"}" | dsc resource test -r 'Microsoft/OSInfo' -f - | ConvertFrom-Json
         $actual = dsc resource get -r Microsoft/OSInfo | ConvertFrom-Json
         $out.actualState.family | Should -BeExactly $actual.actualState.family
         $out.actualState.version | Should -BeExactly $actual.actualState.version

--- a/powershell-adapter/Tests/powershellgroup.config.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.config.tests.ps1
@@ -140,7 +140,7 @@ Describe 'PowerShell adapter resource tests' {
         $config_path = "$TestDrive/test_config.dsc.yaml"
         $yaml | Set-Content -Path $config_path
 
-        $out = dsc config get --path $config_path
+        $out = dsc config get --file $config_path
         $LASTEXITCODE | Should -Be 0
         $res = $out | ConvertFrom-Json
         $res.results.result.actualState.result.properties.Name | Should -Be $TestDrive

--- a/powershell-adapter/Tests/powershellgroup.config.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.config.tests.ps1
@@ -26,16 +26,16 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Get works on config with class-based resources' {
 
-        $r = Get-Content -Raw $pwshConfigPath | dsc config get
+        $r = Get-Content -Raw $pwshConfigPath | dsc config get -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.results[0].result.actualState.result[0].properties.Prop1 | Should -BeExactly 'ValueForProp1'
         $res.results[0].result.actualState.result[0].properties.EnumProp | Should -BeExactly 'Expected'
     }
-    
+
     It 'Test works on config with class-based resources' {
 
-        $r = Get-Content -Raw $pwshConfigPath | dsc config test
+        $r = Get-Content -Raw $pwshConfigPath | dsc config test -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.results[0].result.actualState.result[0] | Should -Not -BeNull
@@ -43,7 +43,7 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Set works on config with class-based resources' {
 
-        $r = Get-Content -Raw $pwshConfigPath | dsc config set
+        $r = Get-Content -Raw $pwshConfigPath | dsc config set -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.results.result.afterState.result[0].type | Should -Be "TestClassResource/TestClassResource"
@@ -61,7 +61,7 @@ Describe 'PowerShell adapter resource tests' {
                 - name: Class-resource Info
                   type: TestClassResource/TestClassResource
 '@
-        $out = $yaml | dsc config export
+        $out = $yaml | dsc config export -f -
         $LASTEXITCODE | Should -Be 0
         $res = $out | ConvertFrom-Json
         $res.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json'
@@ -82,7 +82,7 @@ Describe 'PowerShell adapter resource tests' {
                 - name: Class-resource Info
                   type: TestClassResource/NoExport
 '@
-        $out = $yaml | dsc config export 2>&1 | Out-String
+        $out = $yaml | dsc config export -f - 2>&1 | Out-String
         $LASTEXITCODE | Should -Be 2
         $out | Should -Not -BeNullOrEmpty
         $out | Should -BeLike "*ERROR*Export method not implemented by resource 'TestClassResource/NoExport'*"
@@ -107,7 +107,7 @@ Describe 'PowerShell adapter resource tests' {
                 - name: Class-resource Info
                   type: TestClassResource/TestClassResource
 "@
-            $out = $yaml | dsc config export
+            $out = $yaml | dsc config export -f -
             $LASTEXITCODE | Should -Be 0
             $res = $out | ConvertFrom-Json
             $res.'$schema' | Should -BeExactly 'https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json'
@@ -161,7 +161,7 @@ Describe 'PowerShell adapter resource tests' {
                   properties:
                     Name: "[envvar('DSC_CONFIG_ROOT')]"
 "@
-        $out = $yaml | dsc config get | ConvertFrom-Json
+        $out = $yaml | dsc config get -f - | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.actualState.result[0].properties.Name | Should -BeExactly (Get-Location).Path
     }

--- a/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
+++ b/powershell-adapter/Tests/powershellgroup.resource.tests.ps1
@@ -33,7 +33,7 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Get works on class-based resource' {
 
-        $r = "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource'
+        $r = "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource' -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.Prop1 | Should -BeExactly 'ValueForProp1'
@@ -46,7 +46,7 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Get uses enum names on class-based resource' {
 
-        $r = "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource'
+        $r = "{'Name':'TestClassResource1'}" | dsc resource get -r 'TestClassResource/TestClassResource' -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.EnumProp | Should -BeExactly 'Expected'
@@ -54,7 +54,7 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Test works on class-based resource' {
 
-        $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource test -r 'TestClassResource/TestClassResource'
+        $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource test -r 'TestClassResource/TestClassResource' -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.InDesiredState | Should -Be $True
@@ -68,7 +68,7 @@ Describe 'PowerShell adapter resource tests' {
 
     It 'Set works on class-based resource' {
 
-        $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource set -r 'TestClassResource/TestClassResource'
+        $r = "{'Name':'TestClassResource1','Prop1':'ValueForProp1'}" | dsc resource set -r 'TestClassResource/TestClassResource' -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.afterState.result | Should -Not -BeNull
@@ -229,7 +229,7 @@ Describe 'PowerShell adapter resource tests' {
             $adapterPath = Join-Path $PSScriptRoot 'TestAdapter'
             $env:PATH += [System.IO.Path]::PathSeparator + $adapterPath
 
-            $r = '{TestCaseId: 1}'| dsc resource get -r 'Test/TestCase'
+            $r = '{TestCaseId: 1}'| dsc resource get -r 'Test/TestCase' -f -
             $LASTEXITCODE | Should -Be 0
             $resources = $r | ConvertFrom-Json
             $resources.actualState.result | Should -Be $True
@@ -245,7 +245,7 @@ Describe 'PowerShell adapter resource tests' {
             $adapterPath = Join-Path $PSScriptRoot 'TestAdapter'
             $env:PATH += [System.IO.Path]::PathSeparator + $adapterPath
 
-            $r = '{TestCaseId: 1}'| dsc resource set -r 'Test/TestCase'
+            $r = '{TestCaseId: 1}'| dsc resource set -r 'Test/TestCase' -f -
             $LASTEXITCODE | Should -Be 0
             $resources = $r | ConvertFrom-Json
             $resources.beforeState.result | Should -Be $True
@@ -262,7 +262,7 @@ Describe 'PowerShell adapter resource tests' {
             $adapterPath = Join-Path $PSScriptRoot 'TestAdapter'
             $env:PATH += [System.IO.Path]::PathSeparator + $adapterPath
 
-            $r = '{TestCaseId: 1}'| dsc resource test -r 'Test/TestCase'
+            $r = '{TestCaseId: 1}'| dsc resource test -r 'Test/TestCase' -f -
             $LASTEXITCODE | Should -Be 0
             $resources = $r | ConvertFrom-Json
             $resources.actualState.result | Should -Be $True

--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
-Describe 'WindowsPowerShell adapter resource tests' {
+Describe 'WindowsPowerShell adapter resource tests - requires elevated permissions' {
 
     BeforeAll {
         if ($isWindows) {
@@ -63,12 +63,12 @@ Describe 'WindowsPowerShell adapter resource tests' {
 
     It 'Get works on config with File resource for WinPS' -Skip:(!$IsWindows){
 
-      $testFile = "$testdrive\test.txt"
-      'test' | Set-Content -Path $testFile -Force
-      $r = (Get-Content -Raw $winpsConfigPath).Replace('c:\test.txt',"$testFile") | dsc config get -f -
-      $LASTEXITCODE | Should -Be 0
-      $res = $r | ConvertFrom-Json
-      $res.results[0].result.actualState.result[0].properties.DestinationPath | Should -Be "$testFile"
+        $testFile = "$testdrive\test.txt"
+        'test' | Set-Content -Path $testFile -Force
+        $r = (Get-Content -Raw $winpsConfigPath).Replace('c:\test.txt',"$testFile") | dsc config get -f -
+        $LASTEXITCODE | Should -Be 0
+        $res = $r | ConvertFrom-Json
+        $res.results[0].result.actualState.result[0].properties.DestinationPath | Should -Be "$testFile"
     }
 
     It 'Verify that there are no cache rebuilds for several sequential executions' -Skip:(!$IsWindows) {

--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -6,7 +6,7 @@ Describe 'WindowsPowerShell adapter resource tests' {
     BeforeAll {
         if ($isWindows) {
             winrm quickconfig -quiet -force
-        }    
+        }
         $OldPSModulePath  = $env:PSModulePath
         $env:PSModulePath += [System.IO.Path]::PathSeparator + $PSScriptRoot
 
@@ -37,7 +37,7 @@ Describe 'WindowsPowerShell adapter resource tests' {
 
         $testFile = "$testdrive\test.txt"
         'test' | Set-Content -Path $testFile -Force
-        $r = '{"DestinationPath":"' + $testFile.replace('\','\\') + '"}' | dsc resource get -r 'PSDesiredStateConfiguration/File'
+        $r = '{"DestinationPath":"' + $testFile.replace('\','\\') + '"}' | dsc resource get -r 'PSDesiredStateConfiguration/File' -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.DestinationPath | Should -Be "$testFile"
@@ -46,7 +46,7 @@ Describe 'WindowsPowerShell adapter resource tests' {
     It 'Set works on Binary "File" resource' -Skip:(!$IsWindows){
 
         $testFile = "$testdrive\test.txt"
-        $r = '{"DestinationPath":"' + $testFile.replace('\','\\') + '", type: File, contents: HelloWorld, Ensure: present}' | dsc resource set -r 'PSDesiredStateConfiguration/File'
+        $null = '{"DestinationPath":"' + $testFile.replace('\','\\') + '", type: File, contents: HelloWorld, Ensure: present}' | dsc resource set -r 'PSDesiredStateConfiguration/File' -f -
         $LASTEXITCODE | Should -Be 0
         Get-Content -Raw -Path $testFile | Should -Be "HelloWorld"
     }
@@ -55,7 +55,7 @@ Describe 'WindowsPowerShell adapter resource tests' {
 
         $testFile = "$testdrive\test.txt"
         'test' | Set-Content -Path $testFile -Force
-        $r = '{"GetScript": "@{result = $(Get-Content ' + $testFile.replace('\','\\') + ')}", "SetScript": "throw", "TestScript": "throw"}' | dsc resource get -r 'PSDesiredStateConfiguration/Script'
+        $r = '{"GetScript": "@{result = $(Get-Content ' + $testFile.replace('\','\\') + ')}", "SetScript": "throw", "TestScript": "throw"}' | dsc resource get -r 'PSDesiredStateConfiguration/Script' -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.actualState.result.properties.result | Should -Be 'test'
@@ -65,7 +65,7 @@ Describe 'WindowsPowerShell adapter resource tests' {
 
       $testFile = "$testdrive\test.txt"
       'test' | Set-Content -Path $testFile -Force
-      $r = (Get-Content -Raw $winpsConfigPath).Replace('c:\test.txt',"$testFile") | dsc config get
+      $r = (Get-Content -Raw $winpsConfigPath).Replace('c:\test.txt',"$testFile") | dsc config get -f -
       $LASTEXITCODE | Should -Be 0
       $res = $r | ConvertFrom-Json
       $res.results[0].result.actualState.result[0].properties.DestinationPath | Should -Be "$testFile"

--- a/reboot_pending/tests/reboot_pending.tests.ps1
+++ b/reboot_pending/tests/reboot_pending.tests.ps1
@@ -10,7 +10,7 @@ Describe 'reboot_pending resource tests' {
 
     It 'reboot_pending works in a config' -Skip:(!$IsWindows) {
         $ConfigPath = Resolve-Path "$PSScriptRoot/reboot_pending.dsc.yaml"
-        $out = dsc config get --path $ConfigPath | ConvertFrom-Json
+        $out = dsc config get --file $ConfigPath | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results.result.actualState.rebootPending | Should -Not -BeNullOrEmpty
     }

--- a/registry/tests/registry.config.set.tests.ps1
+++ b/registry/tests/registry.config.set.tests.ps1
@@ -55,18 +55,18 @@ Describe 'registry config set tests' {
             )
         }
 
-        $out = dsc config set -d ($config | ConvertTo-Json -Depth 10)
+        $out = dsc config set -i ($config | ConvertTo-Json -Depth 10)
         $LASTEXITCODE | Should -Be 0
 
         $config.resources[0].properties._exist = $false
-        $out = dsc config set -d ($config | ConvertTo-Json -Depth 10) | ConvertFrom-Json
+        $out = dsc config set -i ($config | ConvertTo-Json -Depth 10) | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.afterState._exist | Should -Be $false
 
         Get-ItemProperty -Path 'HKCU:\1\2' -Name 'Test' -ErrorAction Ignore | Should -BeNullOrEmpty
 
         $config.resources[0].properties.valueName = $null
-        $out = dsc config set -d ($config | ConvertTo-Json -Depth 10) | ConvertFrom-Json
+        $out = dsc config set -i ($config | ConvertTo-Json -Depth 10) | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.results[0].result.afterState._exist | Should -Be $false
 

--- a/resources/apt/test/apt.tests.ps1
+++ b/resources/apt/test/apt.tests.ps1
@@ -27,7 +27,7 @@ Describe 'Apt resource tests' {
             if (-not $aptExists) {
                 Set-ItResult -Skip -Because "Apt not found"
             }
-            $out = dsc -l trace config get -p $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
+            $out = dsc -l trace config get -f $yamlPath 2> "$TestDrive/stderr.txt" | ConvertFrom-Json -Depth 10
             $LASTEXITCODE | Should -Be 0 -Because (Get-Content "$TestDrive/stderr.txt" | Out-String)
             $exists = $null -ne (Get-Command $pkgName -CommandType Application -ErrorAction Ignore)
             $observed = $out.results[1].result.actualState._exist
@@ -39,7 +39,7 @@ Describe 'Apt resource tests' {
                 Set-ItResult -Skip -Because "Apt not found"
             }
 
-            $out = dsc config test -p $yamlPath| ConvertFrom-Json -Depth 10
+            $out = dsc config test -f $yamlPath| ConvertFrom-Json -Depth 10
             $LASTEXITCODE | Should -Be 0
             $exists = $null -ne (Get-Command pkgName -CommandType Application -ErrorAction Ignore)
             $out.results[1].result.inDesiredState | Should -Be $exists
@@ -60,7 +60,7 @@ Describe 'Apt resource tests' {
                 apt remove -y $pkgname
             }
 
-            $result = dsc config set -p $yamlInstallPath | ConvertFrom-Json
+            $result = dsc config set -f $yamlInstallPath | ConvertFrom-Json
             $result.results[1].result.beforestate._exist | Should -Be false
             $result.results[1].result.afterstate._exist | Should -Be true
         }
@@ -72,7 +72,7 @@ Describe 'Apt resource tests' {
                 apt install -y $pkgname
             }
 
-            $result = dsc config set -p $yamlUnInstallPath | ConvertFrom-Json
+            $result = dsc config set -f $yamlUnInstallPath | ConvertFrom-Json
             $result.results[1].result.beforestate._exist | Should -Be true
             $result.results[1].result.afterstate._exist | Should -Be false
         }

--- a/runcommandonset/tests/runcommandonset.get.tests.ps1
+++ b/runcommandonset/tests/runcommandonset.get.tests.ps1
@@ -20,7 +20,7 @@ Describe 'tests for runcommandonset get' {
         }
 "@
 
-        $result = $json | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet | ConvertFrom-Json
+        $result = $json | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet -f - | ConvertFrom-Json
         $result.actualState.arguments | Should -BeExactly @('bar', 'baz')
         $result.actualState.executable | Should -BeExactly 'foo'
         $result.actualState.exitCode | Should -BeExactly 5
@@ -32,7 +32,7 @@ Describe 'tests for runcommandonset get' {
     }
 
     It 'Executable is a required input via STDIN' {
-        '{ "arguments": "foo" }' | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet
+        '{ "arguments": "foo" }' | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet -f -
         $LASTEXITCODE | Should -Be 2
     }
 }

--- a/runcommandonset/tests/runcommandonset.set.tests.ps1
+++ b/runcommandonset/tests/runcommandonset.set.tests.ps1
@@ -24,7 +24,7 @@ Describe 'tests for runcommandonset set' {
             "arguments": ["-Command", "echo hello world"]
         }
 "@
-        $input_json | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet
+        $input_json | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f -
         # TODO: test output once DSC PR to capture it is merged
         $LASTEXITCODE | Should -Be 0
     }
@@ -59,24 +59,24 @@ Describe 'tests for runcommandonset set' {
     }
 
     It 'Executable is a required input via STDIN' {
-        $null = '{ "arguments": "foo" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet
+        $null = '{ "arguments": "foo" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f -
         $LASTEXITCODE | Should -Be 2
     }
 
     It 'Executable can be provided without arguments' {
-        $result = '{ "executable": "pwsh" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet | ConvertFrom-Json
+        $result = '{ "executable": "pwsh" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - | ConvertFrom-Json
         $result.changedProperties | Should -Be @()
         $LASTEXITCODE | Should -Be 0
     }
 
     It 'Exit code does not need to be provided to detect difference' {
-        $result = '{ "executable": "pwsh", "arguments": ["invalid input"] }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet | ConvertFrom-Json
+        $result = '{ "executable": "pwsh", "arguments": ["invalid input"] }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - | ConvertFrom-Json
         $result.changedProperties | Should -Be @( 'exitCode' )
         $LASTEXITCODE | Should -Be 0
     }
 
     It 'Executable does not exist' {
-        '{ "executable": "foo" }' | dsc -l trace resource set -r Microsoft.DSC.Transitional/RunCommandOnSet 2> $TestDrive/output.txt
+        '{ "executable": "foo" }' | dsc -l trace resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2> $TestDrive/output.txt
         $actual = Get-Content -Path $TestDrive/output.txt -Raw
         $expected_logging = 'Failed to execute foo: No such file or directory (os error 2)'
         if ($IsWindows) {

--- a/wmi-adapter/Tests/wmi.tests.ps1
+++ b/wmi-adapter/Tests/wmi.tests.ps1
@@ -48,7 +48,7 @@ Describe 'WMI adapter resource tests' {
 
     It 'Example config works' -Skip:(!$IsWindows) {
         $configPath = Join-Path $PSScriptRoot '..\..\configurations\windows\windows_inventory.dsc.yaml'
-        $r = dsc config get -p $configPath
+        $r = dsc config get -f $configPath
         $LASTEXITCODE | Should -Be 0
         $r | Should -Not -BeNullOrEmpty
         $res = $r | ConvertFrom-Json

--- a/wmi-adapter/Tests/wmi.tests.ps1
+++ b/wmi-adapter/Tests/wmi.tests.ps1
@@ -37,7 +37,7 @@ Describe 'WMI adapter resource tests' {
 
     It 'Get works on a config with WMI resources' -Skip:(!$IsWindows){
 
-        $r = Get-Content -Raw $configPath | dsc config get
+        $r = Get-Content -Raw $configPath | dsc config get -f -
         $LASTEXITCODE | Should -Be 0
         $res = $r | ConvertFrom-Json
         $res.results[0].result.actualState[0].LastBootUpTime | Should -BeNullOrEmpty


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Remove automatic reading of STDIN as it can block in environments that redirect STDIN but never send input like ADO Pipelines
- Use convention `--file -` to indicate to read from STDIN, updated CLI help
- Rename `--format` to `--output-format` to use `-f` to only mean `--file`, shorthand is now `-o`
- Rename `--document` to `--input` to have it consistent for config and resource invocation
- Rename `--trace-format` shorthand to `-t`
- Lots of test changes due to the parameters change

## PR Context

Fix https://github.com/PowerShell/DSC/issues/588
