### PR TITLE
Fix change in clippy rule from `&Option<Type>` to `Option<&Type>`

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -68,7 +68,7 @@ pub enum SubCommand {
         #[clap(name = "type", short, long, help = "The type of DSC schema to get")]
         dsc_type: DscType,
         #[clap(short = 'o', long, help = "The output format to use")]
-        format: Option<OutputFormat>,
+        output_format: Option<OutputFormat>,
     },
 }
 

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -33,7 +33,7 @@ fn main() {
 
     let args = Args::parse();
 
-    util::enable_tracing(&args.trace_level, &args.trace_format);
+    util::enable_tracing(args.trace_level.as_ref(), args.trace_format.as_ref());
 
     debug!("Running dsc {}", env!("CARGO_PKG_VERSION"));
 
@@ -47,7 +47,7 @@ fn main() {
             if let Some(file_name) = parameters_file {
                 info!("Reading parameters from file {file_name}");
                 match std::fs::read_to_string(&file_name) {
-                    Ok(parameters) => subcommand::config(&subcommand, &Some(parameters), &system_root, &as_group, &as_include),
+                    Ok(parameters) => subcommand::config(&subcommand, &Some(parameters), system_root.as_ref(), &as_group, &as_include),
                     Err(err) => {
                         error!("Error: Failed to read parameters file '{file_name}': {err}");
                         exit(util::EXIT_INVALID_INPUT);
@@ -55,13 +55,13 @@ fn main() {
                 }
             }
             else {
-                subcommand::config(&subcommand, &parameters, &system_root, &as_group, &as_include);
+                subcommand::config(&subcommand, &parameters, system_root.as_ref(), &as_group, &as_include);
             }
         },
         SubCommand::Resource { subcommand } => {
             subcommand::resource(&subcommand);
         },
-        SubCommand::Schema { dsc_type , format } => {
+        SubCommand::Schema { dsc_type , output_format } => {
             let schema = util::get_schema(dsc_type);
             let json = match serde_json::to_string(&schema) {
                 Ok(json) => json,
@@ -70,7 +70,7 @@ fn main() {
                     exit(util::EXIT_JSON_ERROR);
                 }
             };
-            util::write_output(&json, &format);
+            util::write_output(&json, output_format.as_ref());
         },
     }
 

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -15,7 +15,7 @@ use dsc_lib::{
 };
 use std::process::exit;
 
-pub fn get(dsc: &DscManager, resource_type: &str, mut input: String, format: &Option<OutputFormat>) {
+pub fn get(dsc: &DscManager, resource_type: &str, mut input: String, format: Option<&OutputFormat>) {
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
         exit(EXIT_DSC_RESOURCE_NOT_FOUND);
@@ -56,7 +56,7 @@ pub fn get(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
     }
 }
 
-pub fn get_all(dsc: &DscManager, resource_type: &str, format: &Option<OutputFormat>) {
+pub fn get_all(dsc: &DscManager, resource_type: &str, format: Option<&OutputFormat>) {
     let mut input = String::new();
     let Some(mut resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
@@ -104,7 +104,7 @@ pub fn get_all(dsc: &DscManager, resource_type: &str, format: &Option<OutputForm
     }
 }
 
-pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Option<OutputFormat>) {
+pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: Option<&OutputFormat>) {
     if input.is_empty() {
         error!("Error: Desired input is empty");
         exit(EXIT_INVALID_ARGS);
@@ -150,7 +150,7 @@ pub fn set(dsc: &DscManager, resource_type: &str, mut input: String, format: &Op
     }
 }
 
-pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: &Option<OutputFormat>) {
+pub fn test(dsc: &DscManager, resource_type: &str, mut input: String, format: Option<&OutputFormat>) {
     if input.is_empty() {
         error!("Error: Expected input is required");
         exit(EXIT_INVALID_ARGS);
@@ -227,7 +227,7 @@ pub fn delete(dsc: &DscManager, resource_type: &str, mut input: String) {
     }
 }
 
-pub fn schema(dsc: &DscManager, resource_type: &str, format: &Option<OutputFormat>) {
+pub fn schema(dsc: &DscManager, resource_type: &str, format: Option<&OutputFormat>) {
     let Some(resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());
         exit(EXIT_DSC_RESOURCE_NOT_FOUND);
@@ -256,7 +256,7 @@ pub fn schema(dsc: &DscManager, resource_type: &str, format: &Option<OutputForma
     }
 }
 
-pub fn export(dsc: &mut DscManager, resource_type: &str, format: &Option<OutputFormat>) {
+pub fn export(dsc: &mut DscManager, resource_type: &str, format: Option<&OutputFormat>) {
     let mut input = String::new();
     let Some(dsc_resource) = get_resource(dsc, resource_type) else {
         error!("{}", DscError::ResourceNotFound(resource_type.to_string()).to_string());

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -34,7 +34,7 @@ use std::{
 };
 use tracing::{debug, error, trace};
 
-pub fn config_get(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool)
+pub fn config_get(configurator: &mut Configurator, format: Option<&OutputFormat>, as_group: &bool)
 {
     match configurator.invoke_get() {
         Ok(result) => {
@@ -69,7 +69,7 @@ pub fn config_get(configurator: &mut Configurator, format: &Option<OutputFormat>
     }
 }
 
-pub fn config_set(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool)
+pub fn config_set(configurator: &mut Configurator, format: Option<&OutputFormat>, as_group: &bool)
 {
     match configurator.invoke_set(false) {
         Ok(result) => {
@@ -104,7 +104,7 @@ pub fn config_set(configurator: &mut Configurator, format: &Option<OutputFormat>
     }
 }
 
-pub fn config_test(configurator: &mut Configurator, format: &Option<OutputFormat>, as_group: &bool, as_get: &bool, as_config: &bool)
+pub fn config_test(configurator: &mut Configurator, format: Option<&OutputFormat>, as_group: &bool, as_get: &bool, as_config: &bool)
 {
     match configurator.invoke_test() {
         Ok(result) => {
@@ -190,7 +190,7 @@ pub fn config_test(configurator: &mut Configurator, format: &Option<OutputFormat
     }
 }
 
-pub fn config_export(configurator: &mut Configurator, format: &Option<OutputFormat>)
+pub fn config_export(configurator: &mut Configurator, format: Option<&OutputFormat>)
 {
     match configurator.invoke_export() {
         Ok(result) => {
@@ -219,7 +219,7 @@ pub fn config_export(configurator: &mut Configurator, format: &Option<OutputForm
     }
 }
 
-fn initialize_config_root(path: &Option<String>) -> Option<String> {
+fn initialize_config_root(path: Option<&String>) -> Option<String> {
     // code that calls this pass in either None, Some("-"), or Some(path)
     // in the case of `-` we treat it as None, but need to pass it back as subsequent processing needs to handle it
     let use_stdin = if let Some(specified_path) = path {
@@ -250,15 +250,15 @@ fn initialize_config_root(path: &Option<String>) -> Option<String> {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounted_path: &Option<String>, as_group: &bool, as_include: &bool) {
+pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounted_path: Option<&String>, as_group: &bool, as_include: &bool) {
     let (new_parameters, json_string) = match subcommand {
         ConfigSubCommand::Get { input, file, .. } |
         ConfigSubCommand::Set { input, file, .. } |
         ConfigSubCommand::Test { input, file, .. } |
         ConfigSubCommand::Validate { input, file, .. } |
         ConfigSubCommand::Export { input, file, .. } => {
-            let new_path = initialize_config_root(file);
-            let document = get_input(input, &new_path);
+            let new_path = initialize_config_root(file.as_ref());
+            let document = get_input(input.as_ref(), new_path.as_ref());
             if *as_include {
                 let (new_parameters, config_json) = match get_contents(&document) {
                     Ok((parameters, config_json)) => (parameters, config_json),
@@ -273,8 +273,8 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
             }
         },
         ConfigSubCommand::Resolve { input, file, .. } => {
-            let new_path = initialize_config_root(file);
-            let document = get_input(input, &new_path);
+            let new_path = initialize_config_root(file.as_ref());
+            let document = get_input(input.as_ref(), new_path.as_ref());
             let (new_parameters, config_json) = match get_contents(&document) {
                 Ok((parameters, config_json)) => (parameters, config_json),
                 Err(err) => {
@@ -343,29 +343,29 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
         configurator.set_system_root(path);
     }
 
-    if let Err(err) = configurator.set_context(&parameters) {
+    if let Err(err) = configurator.set_context(parameters.as_ref()) {
         error!("Error: Parameter input failure: {err}");
         exit(EXIT_INVALID_INPUT);
     }
 
     match subcommand {
-        ConfigSubCommand::Get { output_format: format, .. } => {
-            config_get(&mut configurator, format, as_group);
+        ConfigSubCommand::Get { output_format, .. } => {
+            config_get(&mut configurator, output_format.as_ref(), as_group);
         },
-        ConfigSubCommand::Set { output_format: format, .. } => {
-            config_set(&mut configurator, format, as_group);
+        ConfigSubCommand::Set { output_format, .. } => {
+            config_set(&mut configurator, output_format.as_ref(), as_group);
         },
-        ConfigSubCommand::Test { output_format: format, as_get, as_config, .. } => {
-            config_test(&mut configurator, format, as_group, as_get, as_config);
+        ConfigSubCommand::Test { output_format, as_get, as_config, .. } => {
+            config_test(&mut configurator, output_format.as_ref(), as_group, as_get, as_config);
         },
-        ConfigSubCommand::Validate { input, file, output_format: format} => {
+        ConfigSubCommand::Validate { input, file, output_format} => {
             let mut result = ValidateResult {
                 valid: true,
                 reason: None,
             };
             if *as_include {
-                let new_path = initialize_config_root(file);
-                let input = get_input(input, &new_path);
+                let new_path = initialize_config_root(file.as_ref());
+                let input = get_input(input.as_ref(), new_path.as_ref());
                 match serde_json::from_str::<Include>(&input) {
                     Ok(_) => {
                         // valid, so do nothing
@@ -392,12 +392,12 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
                 exit(EXIT_JSON_ERROR);
             };
 
-            write_output(&json, format);
+            write_output(&json, output_format.as_ref());
         },
-        ConfigSubCommand::Export { output_format: format, .. } => {
-            config_export(&mut configurator, format);
+        ConfigSubCommand::Export { output_format, .. } => {
+            config_export(&mut configurator, output_format.as_ref());
         },
-        ConfigSubCommand::Resolve { output_format: format, .. } => {
+        ConfigSubCommand::Resolve { output_format, .. } => {
             let configuration = match serde_json::from_str(&json_string) {
                 Ok(json) => json,
                 Err(err) => {
@@ -426,7 +426,7 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
                     exit(EXIT_JSON_ERROR);
                 }
             };
-            write_output(&json_string, format);
+            write_output(&json_string, output_format.as_ref());
         },
     }
 }
@@ -531,51 +531,51 @@ pub fn resource(subcommand: &ResourceSubCommand) {
     };
 
     match subcommand {
-        ResourceSubCommand::List { resource_name, adapter_name, description, tags, output_format: format } => {
-            list_resources(&mut dsc, resource_name, adapter_name, description, tags, format);
+        ResourceSubCommand::List { resource_name, adapter_name, description, tags, output_format } => {
+            list_resources(&mut dsc, resource_name.as_ref(), adapter_name.as_ref(), description.as_ref(), tags.as_ref(), output_format.as_ref());
         },
-        ResourceSubCommand::Schema { resource , output_format: format } => {
+        ResourceSubCommand::Schema { resource , output_format } => {
             dsc.find_resources(&[resource.to_string()]);
-            resource_command::schema(&dsc, resource, format);
+            resource_command::schema(&dsc, resource, output_format.as_ref());
         },
-        ResourceSubCommand::Export { resource, output_format: format } => {
+        ResourceSubCommand::Export { resource, output_format } => {
             dsc.find_resources(&[resource.to_string()]);
-            resource_command::export(&mut dsc, resource, format);
+            resource_command::export(&mut dsc, resource, output_format.as_ref());
         },
-        ResourceSubCommand::Get { resource, input, file: path, all, output_format: format } => {
+        ResourceSubCommand::Get { resource, input, file: path, all, output_format } => {
             dsc.find_resources(&[resource.to_string()]);
-            if *all { resource_command::get_all(&dsc, resource, format); }
+            if *all { resource_command::get_all(&dsc, resource, output_format.as_ref()); }
             else {
-                let parsed_input = get_input(input, path);
-                resource_command::get(&dsc, resource, parsed_input, format);
+                let parsed_input = get_input(input.as_ref(), path.as_ref());
+                resource_command::get(&dsc, resource, parsed_input, output_format.as_ref());
             }
         },
-        ResourceSubCommand::Set { resource, input, file: path, output_format: format } => {
+        ResourceSubCommand::Set { resource, input, file: path, output_format } => {
             dsc.find_resources(&[resource.to_string()]);
-            let parsed_input = get_input(input, path);
-            resource_command::set(&dsc, resource, parsed_input, format);
+            let parsed_input = get_input(input.as_ref(), path.as_ref());
+            resource_command::set(&dsc, resource, parsed_input, output_format.as_ref());
         },
-        ResourceSubCommand::Test { resource, input, file: path, output_format: format } => {
+        ResourceSubCommand::Test { resource, input, file: path, output_format } => {
             dsc.find_resources(&[resource.to_string()]);
-            let parsed_input = get_input(input, path);
-            resource_command::test(&dsc, resource, parsed_input, format);
+            let parsed_input = get_input(input.as_ref(), path.as_ref());
+            resource_command::test(&dsc, resource, parsed_input, output_format.as_ref());
         },
         ResourceSubCommand::Delete { resource, input, file: path } => {
             dsc.find_resources(&[resource.to_string()]);
-            let parsed_input = get_input(input, path);
+            let parsed_input = get_input(input.as_ref(), path.as_ref());
             resource_command::delete(&dsc, resource, parsed_input);
         },
     }
 }
 
-fn list_resources(dsc: &mut DscManager, resource_name: &Option<String>, adapter_name: &Option<String>, description: &Option<String>, tags: &Option<Vec<String>>, format: &Option<OutputFormat>) {
+fn list_resources(dsc: &mut DscManager, resource_name: Option<&String>, adapter_name: Option<&String>, description: Option<&String>, tags: Option<&Vec<String>>, format: Option<&OutputFormat>) {
     let mut write_table = false;
     let mut table = Table::new(&["Type", "Kind", "Version", "Caps", "RequireAdapter", "Description"]);
     if format.is_none() && io::stdout().is_terminal() {
         // write as table if format is not specified and interactive
         write_table = true;
     }
-    for resource in dsc.list_available_resources(&resource_name.clone().unwrap_or("*".to_string()), &adapter_name.clone().unwrap_or_default()) {
+    for resource in dsc.list_available_resources(resource_name.unwrap_or(&String::from("*")), adapter_name.unwrap_or(&String::new())) {
         let mut capabilities = "--------".to_string();
         let capability_types = [
             (Capability::Get, "g"),
@@ -606,7 +606,7 @@ fn list_resources(dsc: &mut DscManager, resource_name: &Option<String>, adapter_
 
             // if description is specified, skip if resource description does not contain it
             if description.is_some() &&
-                (manifest.description.is_none() | !manifest.description.unwrap_or_default().to_lowercase().contains(&description.as_ref().unwrap_or(&String::new()).to_lowercase())) {
+                (manifest.description.is_none() | !manifest.description.unwrap_or_default().to_lowercase().contains(&description.as_ref().unwrap_or(&&String::new()).to_lowercase())) {
                 continue;
             }
 

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -606,7 +606,7 @@ fn list_resources(dsc: &mut DscManager, resource_name: Option<&String>, adapter_
 
             // if description is specified, skip if resource description does not contain it
             if description.is_some() &&
-                (manifest.description.is_none() | !manifest.description.unwrap_or_default().to_lowercase().contains(&description.as_ref().unwrap_or(&&String::new()).to_lowercase())) {
+                (manifest.description.is_none() | !manifest.description.unwrap_or_default().to_lowercase().contains(&description.unwrap_or(&String::new()).to_lowercase())) {
                 continue;
             }
 

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -213,18 +213,18 @@ pub fn get_schema(dsc_type: DscType) -> RootSchema {
 ///
 /// * `json` - The JSON to write
 /// * `format` - The format to use
-pub fn write_output(json: &str, format: &Option<OutputFormat>) {
+pub fn write_output(json: &str, format: Option<&OutputFormat>) {
     let mut is_json = true;
-    let mut output_format = format.clone();
+    let mut output_format = format;
     let mut syntax_color = false;
     if std::io::stdout().is_terminal() {
         syntax_color = true;
         if output_format.is_none() {
-            output_format = Some(OutputFormat::Yaml);
+            output_format = Some(&OutputFormat::Yaml);
         }
     }
     else if output_format.is_none() {
-        output_format = Some(OutputFormat::Json);
+        output_format = Some(&OutputFormat::Json);
     }
 
     let output = match output_format {
@@ -292,7 +292,7 @@ pub fn write_output(json: &str, format: &Option<OutputFormat>) {
 }
 
 #[allow(clippy::too_many_lines)]
-pub fn enable_tracing(trace_level_arg: &Option<TraceLevel>, trace_format_arg: &Option<TraceFormat>) {
+pub fn enable_tracing(trace_level_arg: Option<&TraceLevel>, trace_format_arg: Option<&TraceFormat>) {
 
     let mut policy_is_used = false;
     let mut tracing_setting = TracingSetting::default();
@@ -453,7 +453,7 @@ pub fn validate_json(source: &str, schema: &Value, json: &Value) -> Result<(), D
     Ok(())
 }
 
-pub fn get_input(input: &Option<String>, file: &Option<String>) -> String {
+pub fn get_input(input: Option<&String>, file: Option<&String>) -> String {
     trace!("Input: {input:?}, File: {file:?}");
     let value = if let Some(input) = input {
         debug!("Reading input from command line parameter");

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -306,7 +306,7 @@ impl ResourceDiscovery for CommandDiscovery {
                 let mut adapter_resources_count = 0;
                 // invoke the list command
                 let list_command = manifest.adapter.unwrap().list;
-                let (exit_code, stdout, stderr) = match invoke_command(&list_command.executable, list_command.args, None, Some(&adapter.directory), None, &manifest.exit_codes)
+                let (exit_code, stdout, stderr) = match invoke_command(&list_command.executable, list_command.args, None, Some(&adapter.directory), None, manifest.exit_codes.as_ref())
                 {
                     Ok((exit_code, stdout, stderr)) => (exit_code, stdout, stderr),
                     Err(e) => {

--- a/dsc_lib/src/dscresources/command_resource.rs
+++ b/dsc_lib/src/dscresources/command_resource.rs
@@ -30,14 +30,14 @@ pub fn invoke_get(resource: &ResourceManifest, cwd: &str, filter: &str) -> Resul
     let Some(get) = &resource.get else {
         return Err(DscError::NotImplemented("get".to_string()));
     };
-    let args = process_args(&get.args, filter);
+    let args = process_args(get.args.as_ref(), filter);
     if !filter.is_empty() {
         verify_json(resource, cwd, filter)?;
-        command_input = get_command_input(&get.input, filter)?;
+        command_input = get_command_input(get.input.as_ref(), filter)?;
     }
 
     info!("Invoking get '{}' using '{}'", &resource.resource_type, &get.executable);
-    let (_exit_code, stdout, stderr) = invoke_command(&get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (_exit_code, stdout, stderr) = invoke_command(&get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
     if resource.kind == Some(Kind::Resource) {
         debug!("Verifying output of get '{}' using '{}'", &resource.resource_type, &get.executable);
         verify_json(resource, cwd, &stdout)?;
@@ -134,11 +134,11 @@ pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str, skip_te
     let Some(get) = &resource.get else {
         return Err(DscError::NotImplemented("get".to_string()));
     };
-    let args = process_args(&get.args, desired);
-    let command_input = get_command_input(&get.input, desired)?;
+    let args = process_args(get.args.as_ref(), desired);
+    let command_input = get_command_input(get.input.as_ref(), desired)?;
 
     info!("Getting current state for set by invoking get '{}' using '{}'", &resource.resource_type, &get.executable);
-    let (exit_code, stdout, stderr) = invoke_command(&get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (exit_code, stdout, stderr) = invoke_command(&get.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
 
     if resource.kind == Some(Kind::Resource) {
         debug!("Verifying output of get '{}' using '{}'", &resource.resource_type, &get.executable);
@@ -154,7 +154,7 @@ pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str, skip_te
 
     let mut env: Option<HashMap<String, String>> = None;
     let mut input_desired: Option<&str> = None;
-    let args = process_args(&set.args, desired);
+    let args = process_args(set.args.as_ref(), desired);
     match &set.input {
         Some(InputKind::Env) => {
             env = Some(json_to_hashmap(desired)?);
@@ -168,7 +168,7 @@ pub fn invoke_set(resource: &ResourceManifest, cwd: &str, desired: &str, skip_te
     }
 
     info!("Invoking {} '{}' using '{}'", operation_type, &resource.resource_type, &set.executable);
-    let (exit_code, stdout, stderr) = invoke_command(&set.executable, args, input_desired, Some(cwd), env, &resource.exit_codes)?;
+    let (exit_code, stdout, stderr) = invoke_command(&set.executable, args, input_desired, Some(cwd), env, resource.exit_codes.as_ref())?;
 
     match set.returns {
         Some(ReturnKind::State) => {
@@ -256,11 +256,11 @@ pub fn invoke_test(resource: &ResourceManifest, cwd: &str, expected: &str) -> Re
 
     verify_json(resource, cwd, expected)?;
 
-    let args = process_args(&test.args, expected);
-    let command_input = get_command_input(&test.input, expected)?;
+    let args = process_args(test.args.as_ref(), expected);
+    let command_input = get_command_input(test.input.as_ref(), expected)?;
 
     info!("Invoking test '{}' using '{}'", &resource.resource_type, &test.executable);
-    let (exit_code, stdout, stderr) = invoke_command(&test.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (exit_code, stdout, stderr) = invoke_command(&test.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
 
     if resource.kind == Some(Kind::Resource) {
         debug!("Verifying output of test '{}' using '{}'", &resource.resource_type, &test.executable);
@@ -376,11 +376,11 @@ pub fn invoke_delete(resource: &ResourceManifest, cwd: &str, filter: &str) -> Re
 
     verify_json(resource, cwd, filter)?;
 
-    let args = process_args(&delete.args, filter);
-    let command_input = get_command_input(&delete.input, filter)?;
+    let args = process_args(delete.args.as_ref(), filter);
+    let command_input = get_command_input(delete.input.as_ref(), filter)?;
 
     info!("Invoking delete '{}' using '{}'", &resource.resource_type, &delete.executable);
-    let (_exit_code, _stdout, _stderr) = invoke_command(&delete.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (_exit_code, _stdout, _stderr) = invoke_command(&delete.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
 
     Ok(())
 }
@@ -407,11 +407,11 @@ pub fn invoke_validate(resource: &ResourceManifest, cwd: &str, config: &str) -> 
         return Err(DscError::NotImplemented("validate".to_string()));
     };
 
-    let args = process_args(&validate.args, config);
-    let command_input = get_command_input(&validate.input, config)?;
+    let args = process_args(validate.args.as_ref(), config);
+    let command_input = get_command_input(validate.input.as_ref(), config)?;
 
     info!("Invoking validate '{}' using '{}'", &resource.resource_type, &validate.executable);
-    let (_exit_code, stdout, _stderr) = invoke_command(&validate.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (_exit_code, stdout, _stderr) = invoke_command(&validate.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
     let result: ValidateResult = serde_json::from_str(&stdout)?;
     Ok(result)
 }
@@ -432,7 +432,7 @@ pub fn get_schema(resource: &ResourceManifest, cwd: &str) -> Result<String, DscE
 
     match schema_kind {
         SchemaKind::Command(ref command) => {
-            let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, command.args.clone(), None, Some(cwd), None, &resource.exit_codes)?;
+            let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, command.args.clone(), None, Some(cwd), None, resource.exit_codes.as_ref())?;
             Ok(stdout)
         },
         SchemaKind::Embedded(ref schema) => {
@@ -468,15 +468,15 @@ pub fn invoke_export(resource: &ResourceManifest, cwd: &str, input: Option<&str>
         if !input.is_empty() {
             verify_json(resource, cwd, input)?;
 
-            command_input = get_command_input(&export.input, input)?;
+            command_input = get_command_input(export.input.as_ref(), input)?;
         }
 
-        args = process_args(&export.args, input);
+        args = process_args(export.args.as_ref(), input);
     } else {
-        args = process_args(&export.args, "");
+        args = process_args(export.args.as_ref(), "");
     }
 
-    let (_exit_code, stdout, stderr) = invoke_command(&export.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (_exit_code, stdout, stderr) = invoke_command(&export.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
     let mut instances: Vec<Value> = Vec::new();
     for line in stdout.lines()
     {
@@ -518,11 +518,11 @@ pub fn invoke_resolve(resource: &ResourceManifest, cwd: &str, input: &str) -> Re
         return Err(DscError::Operation(format!("Resolve is not supported by resource {}", &resource.resource_type)));
     };
 
-    let args = process_args(&resolve.args, input);
-    let command_input = get_command_input(&resolve.input, input)?;
+    let args = process_args(resolve.args.as_ref(), input);
+    let command_input = get_command_input(resolve.input.as_ref(), input)?;
 
     info!("Invoking resolve '{}' using '{}'", &resource.resource_type, &resolve.executable);
-    let (_exit_code, stdout, _stderr) = invoke_command(&resolve.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, &resource.exit_codes)?;
+    let (_exit_code, stdout, _stderr) = invoke_command(&resolve.executable, args, command_input.stdin.as_deref(), Some(cwd), command_input.env, resource.exit_codes.as_ref())?;
     let result: ResolveResult = serde_json::from_str(&stdout)?;
     Ok(result)
 }
@@ -542,7 +542,7 @@ pub fn invoke_resolve(resource: &ResourceManifest, cwd: &str, input: &str) -> Re
 ///
 /// Error is returned if the command fails to execute or stdin/stdout/stderr cannot be opened.
 ///
-async fn run_process_async(executable: &str, args: Option<Vec<String>>, input: Option<&str>, cwd: Option<&str>, env: Option<HashMap<String, String>>, exit_codes: &Option<HashMap<i32, String>>) -> Result<(i32, String, String), DscError> {
+async fn run_process_async(executable: &str, args: Option<Vec<String>>, input: Option<&str>, cwd: Option<&str>, env: Option<HashMap<String, String>>, exit_codes: Option<&HashMap<i32, String>>) -> Result<(i32, String, String), DscError> {
 
     // use somewhat large initial buffer to avoid early string reallocations;
     // the value is based on list result of largest of built-in adapters - WMI adapter ~500KB
@@ -659,7 +659,7 @@ async fn run_process_async(executable: &str, args: Option<Vec<String>>, input: O
 /// Will panic if tokio runtime can't be created.
 ///
 #[allow(clippy::implicit_hasher)]
-pub fn invoke_command(executable: &str, args: Option<Vec<String>>, input: Option<&str>, cwd: Option<&str>, env: Option<HashMap<String, String>>, exit_codes: &Option<HashMap<i32, String>>) -> Result<(i32, String, String), DscError> {
+pub fn invoke_command(executable: &str, args: Option<Vec<String>>, input: Option<&str>, cwd: Option<&str>, env: Option<HashMap<String, String>>, exit_codes: Option<&HashMap<i32, String>>) -> Result<(i32, String, String), DscError> {
     debug!("Invoking command '{}' with args {:?}", executable, args);
 
     tokio::runtime::Builder::new_multi_thread()
@@ -669,7 +669,7 @@ pub fn invoke_command(executable: &str, args: Option<Vec<String>>, input: Option
         .block_on(run_process_async(executable, args, input, cwd, env, exit_codes))
 }
 
-fn process_args(args: &Option<Vec<ArgKind>>, value: &str) -> Option<Vec<String>> {
+fn process_args(args: Option<&Vec<ArgKind>>, value: &str) -> Option<Vec<String>> {
     let Some(arg_values) = args else {
         debug!("No args to process");
         return None;
@@ -700,7 +700,7 @@ struct CommandInput {
     stdin: Option<String>,
 }
 
-fn get_command_input(input_kind: &Option<InputKind>, input: &str) -> Result<CommandInput, DscError> {
+fn get_command_input(input_kind: Option<&InputKind>, input: &str) -> Result<CommandInput, DscError> {
     let mut env: Option<HashMap<String, String>> = None;
     let mut stdin: Option<String> = None;
     match input_kind {

--- a/dsc_lib/src/parser/functions.rs
+++ b/dsc_lib/src/parser/functions.rs
@@ -51,7 +51,7 @@ impl Function {
         let Some(name) = function_name else {
             return Err(DscError::Parser("Function name node not found".to_string()));
         };
-        let args = convert_args_node(statement_bytes, &function_args)?;
+        let args = convert_args_node(statement_bytes, function_args.as_ref())?;
         let name = name.utf8_text(statement_bytes)?;
         debug!("Function name: {0}", name);
         Ok(Function{
@@ -87,7 +87,7 @@ impl Function {
     }
 }
 
-fn convert_args_node(statement_bytes: &[u8], args: &Option<Node>) -> Result<Option<Vec<FunctionArg>>, DscError> {
+fn convert_args_node(statement_bytes: &[u8], args: Option<&Node>) -> Result<Option<Vec<FunctionArg>>, DscError> {
     let Some(args) = args else {
         return Ok(None);
     };


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Clippy had a new rule where it's idiomatic to use `Option<&Type>` instead of `&Option<Type>` so that the contents of the Option are passed by reference instead of the Option wrapper.

The counter part of this is that you now need to use `.as_ref()` with an Option so that the contents are referenced.

Also fixed one missed arg from `--format` to `--output-format`