### PR TITLE
Ensure `systemRoot()` always has trailing separator character

### DIFF
--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -341,7 +341,12 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
             exit(EXIT_INVALID_ARGS);
         }
 
-        configurator.set_system_root(path);
+        // make sure path has a trailing separator if it's a drive letter
+        if path.len() == 2 && path.chars().nth(1).unwrap_or(' ') == ':' {
+            configurator.set_system_root(&format!("{path}\\"));
+        } else {
+            configurator.set_system_root(path);
+        }
     }
 
     if let Err(err) = configurator.set_context(parameters.as_ref()) {

--- a/dsc/tests/dsc_functions.tests.ps1
+++ b/dsc/tests/dsc_functions.tests.ps1
@@ -54,7 +54,7 @@ Describe 'tests for function expressions' {
 '@
 
         $expected = if ($IsWindows) {
-            $env:SYSTEMDRIVE
+            $env:SYSTEMDRIVE + '\'
         } else {
             '/'
         }

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -45,9 +45,9 @@ impl Default for Context {
 
 #[cfg(target_os = "windows")]
 fn get_default_os_system_root() -> PathBuf {
-    // use SYSTEMDRIVE env var to get the default target path
+    // use SYSTEMDRIVE env var to get the default target path, append trailing separator
     let system_drive = std::env::var("SYSTEMDRIVE").unwrap_or_else(|_| "C:".to_string());
-    PathBuf::from(system_drive)
+    PathBuf::from(system_drive + "\\")
 }
 
 #[cfg(not(target_os = "windows"))]

--- a/dsc_lib/src/functions/path.rs
+++ b/dsc_lib/src/functions/path.rs
@@ -54,7 +54,12 @@ mod tests {
     fn start_with_drive_letter() {
         let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[path('C:\\','test')]", &Context::new()).unwrap();
+
+        #[cfg(target_os = "windows")]
         assert_eq!(result, format!("C:{SEPARATOR}test"));
+
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(result, format!("C:\\{SEPARATOR}test"));
     }
 
     #[test]
@@ -68,7 +73,7 @@ mod tests {
 
         // non-Windows, the colon is a valid character in a path
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(result, format!("a{SEPARATOR}C:{SEPARATOR}test"));
+        assert_eq!(result, format!("a{SEPARATOR}C:\\{SEPARATOR}test"));
     }
 
     #[test]
@@ -82,7 +87,7 @@ mod tests {
 
         // non-Windows, the colon is a valid character in a path
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(result, format!("C:{SEPARATOR}D:{SEPARATOR}test"));
+        assert_eq!(result, format!("C:\\{SEPARATOR}D:\\{SEPARATOR}test"));
     }
 
     #[test]

--- a/dsc_lib/src/functions/path.rs
+++ b/dsc_lib/src/functions/path.rs
@@ -31,15 +31,8 @@ impl Function for Path {
         debug!("Executing path function with args: {:?}", args);
 
         let mut path = PathBuf::new();
-        let mut first = true;
         for arg in args {
             if let Value::String(s) = arg {
-                // if first argument is a drive letter, add it with a separator suffix as PathBuf.push() doesn't add it
-                if first && s.len() == 2 && s.chars().nth(1).unwrap() == ':' {
-                    path.push(s.to_owned() + std::path::MAIN_SEPARATOR.to_string().as_str());
-                    first = false;
-                    continue;
-                }
                 path.push(s);
             } else {
                 return Err(DscError::Parser("Arguments must all be strings".to_string()));
@@ -60,14 +53,14 @@ mod tests {
     #[test]
     fn start_with_drive_letter() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[path('C:','test')]", &Context::new()).unwrap();
+        let result = parser.parse_and_execute("[path('C:\\','test')]", &Context::new()).unwrap();
         assert_eq!(result, format!("C:{SEPARATOR}test"));
     }
 
     #[test]
     fn drive_letter_in_middle() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[path('a','C:','test')]", &Context::new()).unwrap();
+        let result = parser.parse_and_execute("[path('a','C:\\','test')]", &Context::new()).unwrap();
 
         // if any part of the path is absolute, it replaces it instead of appending on Windows
         #[cfg(target_os = "windows")]
@@ -81,11 +74,11 @@ mod tests {
     #[test]
     fn multiple_drive_letters() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[path('C:','D:','test')]", &Context::new()).unwrap();
+        let result = parser.parse_and_execute("[path('C:\\','D:\\','test')]", &Context::new()).unwrap();
 
         // if any part of the path is absolute, it replaces it instead of appending on Windows
         #[cfg(target_os = "windows")]
-        assert_eq!(result, format!("D:test"));
+        assert_eq!(result, format!("D:\\test"));
 
         // non-Windows, the colon is a valid character in a path
         #[cfg(not(target_os = "windows"))]

--- a/dsc_lib/src/functions/path.rs
+++ b/dsc_lib/src/functions/path.rs
@@ -68,6 +68,11 @@ mod tests {
         let mut parser = Statement::new().unwrap();
         let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('a','C:','test')]", &Context::new()).unwrap();
+
+        // if any part of the path is absolute, it replaces it instead of appending
+        #[cfg(target_os = "windows")]
+        assert_eq!(result, format!("C:{separator}test"));
+        #[cfg(not(target_os = "windows"))]
         assert_eq!(result, format!("a{separator}C:{separator}test"));
     }
 

--- a/dsc_lib/src/functions/path.rs
+++ b/dsc_lib/src/functions/path.rs
@@ -55,48 +55,75 @@ mod tests {
     use crate::configure::context::Context;
     use crate::parser::Statement;
 
+    const SEPARATOR: char = std::path::MAIN_SEPARATOR;
+
     #[test]
     fn start_with_drive_letter() {
         let mut parser = Statement::new().unwrap();
-        let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('C:','test')]", &Context::new()).unwrap();
-        assert_eq!(result, format!("C:{separator}test"));
+        assert_eq!(result, format!("C:{SEPARATOR}test"));
     }
 
     #[test]
     fn drive_letter_in_middle() {
         let mut parser = Statement::new().unwrap();
-        let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('a','C:','test')]", &Context::new()).unwrap();
 
-        // if any part of the path is absolute, it replaces it instead of appending
+        // if any part of the path is absolute, it replaces it instead of appending on Windows
         #[cfg(target_os = "windows")]
-        assert_eq!(result, format!("C:{separator}test"));
+        assert_eq!(result, format!("C:{SEPARATOR}test"));
+
+        // non-Windows, the colon is a valid character in a path
         #[cfg(not(target_os = "windows"))]
-        assert_eq!(result, format!("a{separator}C:{separator}test"));
+        assert_eq!(result, format!("a{SEPARATOR}C:{SEPARATOR}test"));
+    }
+
+    #[test]
+    fn multiple_drive_letters() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[path('C:','D:','test')]", &Context::new()).unwrap();
+
+        // if any part of the path is absolute, it replaces it instead of appending on Windows
+        #[cfg(target_os = "windows")]
+        assert_eq!(result, format!("D:{SEPARATOR}test"));
+
+        // non-Windows, the colon is a valid character in a path
+        #[cfg(not(target_os = "windows"))]
+        assert_eq!(result, format!("C:{SEPARATOR}D:{SEPARATOR}test"));
+    }
+
+    #[test]
+    fn relative_path() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[path('a','..','b')]", &Context::new()).unwrap();
+        assert_eq!(result, format!("a{SEPARATOR}..{SEPARATOR}b"));
+    }
+
+    #[test]
+    fn path_segement_with_separator() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute(format!("[path('a','b{SEPARATOR}c')]").as_str(), &Context::new()).unwrap();
+        assert_eq!(result, format!("a{SEPARATOR}b{SEPARATOR}c"));
     }
 
     #[test]
     fn unix_absolute_path() {
         let mut parser = Statement::new().unwrap();
-        let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('/','a','b')]", &Context::new()).unwrap();
-        assert_eq!(result, format!("/a{separator}b"));
+        assert_eq!(result, format!("/a{SEPARATOR}b"));
     }
 
     #[test]
     fn two_args() {
         let mut parser = Statement::new().unwrap();
-        let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('a','b')]", &Context::new()).unwrap();
-        assert_eq!(result, format!("a{separator}b"));
+        assert_eq!(result, format!("a{SEPARATOR}b"));
     }
 
     #[test]
     fn three_args() {
         let mut parser = Statement::new().unwrap();
-        let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('a','b','c')]", &Context::new()).unwrap();
-        assert_eq!(result, format!("a{separator}b{separator}c"));
+        assert_eq!(result, format!("a{SEPARATOR}b{SEPARATOR}c"));
     }
 }

--- a/dsc_lib/src/functions/path.rs
+++ b/dsc_lib/src/functions/path.rs
@@ -39,9 +39,8 @@ impl Function for Path {
                     path.push(s.to_owned() + std::path::MAIN_SEPARATOR.to_string().as_str());
                     first = false;
                     continue;
-                } else {
-                    path.push(s);
                 }
+                path.push(s);
             } else {
                 return Err(DscError::Parser("Arguments must all be strings".to_string()));
             }
@@ -70,6 +69,14 @@ mod tests {
         let separator = std::path::MAIN_SEPARATOR;
         let result = parser.parse_and_execute("[path('a','C:','test')]", &Context::new()).unwrap();
         assert_eq!(result, format!("a{separator}C:{separator}test"));
+    }
+
+    #[test]
+    fn unix_absolute_path() {
+        let mut parser = Statement::new().unwrap();
+        let separator = std::path::MAIN_SEPARATOR;
+        let result = parser.parse_and_execute("[path('/','a','b')]", &Context::new()).unwrap();
+        assert_eq!(result, format!("/a{separator}b"));
     }
 
     #[test]

--- a/dsc_lib/src/functions/path.rs
+++ b/dsc_lib/src/functions/path.rs
@@ -85,7 +85,7 @@ mod tests {
 
         // if any part of the path is absolute, it replaces it instead of appending on Windows
         #[cfg(target_os = "windows")]
-        assert_eq!(result, format!("D:{SEPARATOR}test"));
+        assert_eq!(result, format!("D:test"));
 
         // non-Windows, the colon is a valid character in a path
         #[cfg(not(target_os = "windows"))]

--- a/dsc_lib/src/functions/system_root.rs
+++ b/dsc_lib/src/functions/system_root.rs
@@ -44,7 +44,7 @@ mod tests {
         let result = parser.parse_and_execute("[systemRoot()]", &Context::new()).unwrap();
         // on windows, the default is SYSTEMDRIVE env var
         #[cfg(target_os = "windows")]
-        assert_eq!(result, std::env::var("SYSTEMDRIVE").unwrap());
+        assert_eq!(result, format!("{}\\", std::env::var("SYSTEMDRIVE").unwrap()));
         // on linux/macOS, the default is /
         #[cfg(not(target_os = "windows"))]
         assert_eq!(result, "/");


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Change so that `systemRoot()` always includes a trailing separator.  This is due to how `PathBuf.push()` works on Windows vs non-Windows and `path()` adopts this behavior:

- On Windows, if you join a drive letter `c:` and `windows`, you get `c:windows` which is a relative path to the current `c:` drive location
- On Windows, if you join a drive letter in the middle, it's treated as absolute and replaces the previous path segments: `'a', 'c:', 'b'` will be `c:b`, you would use `c:\` to make sure it's absolute
- On non-Windows, the colon is valid directory character, so nothing special happens and is allowed

Added extra tests to `path()` that aren't needed for this PR, but good to have.
