### PR TITLE
Add support for `contentVersion` property

### DIFF
--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -55,4 +55,23 @@ Describe 'dsc config get tests' {
         $result.metadata.'Microsoft.DSC'.securityContext | Should -Not -BeNullOrEmpty
         $LASTEXITCODE | Should -Be 0
     }
+
+    It 'contentVersion is ignored' {
+        $config_yaml = @"
+            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+            contentVersion: 1.0.0.0
+            resources:
+            - name: Echo
+              type: Microsoft.DSC.Debug/Echo
+              properties:
+                output: hello
+"@
+        $result = $config_yaml | dsc config get -f - | ConvertFrom-Json
+        $result.hadErrors | Should -BeFalse
+        $result.results.Count | Should -Be 1
+        $result.results[0].Name | Should -Be 'Echo'
+        $result.results[0].type | Should -BeExactly 'Microsoft.DSC.Debug/Echo'
+        $result.results[0].result.actualState.output | Should -Be 'hello'
+        $LASTEXITCODE | Should -Be 0
+    }
 }

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -26,6 +26,7 @@ Describe 'resource export tests' {
 
         $yaml = @'
             $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+            contentVersion: 1.2.3
             resources:
             - name: Processes
               type: Microsoft/Process
@@ -39,6 +40,8 @@ Describe 'resource export tests' {
         $config_with_process_list.'resources' | Should -Not -BeNullOrEmpty
         $config_with_process_list.resources.count | Should -BeGreaterThan 1
         $config_with_process_list.metadata.'Microsoft.DSC'.operation | Should -BeExactly 'Export'
+        # contentVersion on export is always 1.0.0
+        $config_with_process_list.contentVersion | Should -BeExactly '1.0.0'
     }
 
     It 'Configuration Export can be piped to configuration Set' -Skip:(!$IsWindows) {

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -72,7 +72,8 @@ pub struct Metadata {
 pub struct Configuration {
     #[serde(rename = "$schema")]
     pub schema: DocumentSchemaUri,
-    // `contentVersion` is required by ARM, but doesn't serve a purpose here
+    #[serde(rename = "contentVersion")]
+    pub content_version: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub parameters: Option<HashMap<String, Parameter>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -164,13 +165,7 @@ pub enum DocumentSchemaUri {
 
 impl Default for Configuration {
     fn default() -> Self {
-        Self {
-            schema: DocumentSchemaUri::Version2024_04,
-            parameters: None,
-            variables: None,
-            resources: Vec::new(),
-            metadata: None,
-        }
+        Self::new()
     }
 }
 
@@ -179,6 +174,7 @@ impl Configuration {
     pub fn new() -> Self {
         Self {
             schema: DocumentSchemaUri::Version2024_04,
+            content_version: Some("1.0.0".to_string()),
             parameters: None,
             variables: None,
             resources: Vec::new(),


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- if exists in input, the value is not validated and ignored
- if configuration is generated (like for `export`), it is set to `1.0.0` (which is semver compatible) even though ARM docs use the example `1.0.0.0` which likely comes from .NET Version class

## PR Context

Needed for Bicep integration which expects `contentVersion` for both input and output
