### PR TITLE
Fix built-in resource and settings discovery when dsc is invoked using a symlink

### DIFF
--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -24,6 +24,7 @@ use tracing::{debug, info, trace, warn, warn_span};
 use tracing_indicatif::span_ext::IndicatifSpanExt;
 
 use crate::util::get_setting;
+use crate::util::get_exe_path;
 
 pub struct CommandDiscovery {
     // use BTreeMap so that the results are sorted by the typename, the Vec is sorted by version
@@ -135,7 +136,7 @@ impl CommandDiscovery {
 
         // if exe home is not already in PATH env var then add it to env var and list of searched paths
         if !using_custom_path {
-            if let Some(exe_home) = env::current_exe()?.parent() {
+            if let Some(exe_home) = get_exe_path()?.parent() {
                 let exe_home_pb = exe_home.to_path_buf();
                 if paths.contains(&exe_home_pb) {
                     trace!("Exe home is already in path: {}", exe_home.to_string_lossy());

--- a/dsc_lib/src/util.rs
+++ b/dsc_lib/src/util.rs
@@ -142,14 +142,19 @@ fn load_value_from_json(path: &PathBuf, value_name: &str) -> Result<serde_json::
     Err(DscError::NotSupported(value_name.to_string()))
 }
 
+/// Gets path to the current dsc process.
+/// If dsc is started using a symlink, this functon returns target of the symlink.
+///
+/// # Errors
+///
+/// Will return `Err` if path to the current exe can't be retrived.
 pub fn get_exe_path() -> Result<PathBuf, DscError> {
     if let Ok(exe) = env::current_exe() {
         if let Ok(target_path) = fs::read_link(exe.clone()) {
             return Ok(target_path);
-        }
-        else {
-            return Ok(exe);
-        }
+        };
+
+        return Ok(exe);
     }
 
     Err(DscError::NotSupported("Can't get the path to dsc executable".to_string()))


### PR DESCRIPTION
# PR Summary

Fix #618 

Winget creates a symlink at its own location `C:\Users\Andrew\AppData\Local\Microsoft\WinGet\Links` and adds that to the PATH instead of the real target, so built-in resources/settings discovery finds nothing.

This PR updates code to use the target path if invoked `dsc.exe` is a symlink.

Fix verified on a Winget deployment of DSC.