### PR TITLE
Enable `Include` resource to take configuration and parameters as string content

### DIFF
--- a/dsc/examples/osinfo.parameters.json
+++ b/dsc/examples/osinfo.parameters.json
@@ -1,0 +1,5 @@
+{
+  "parameters": {
+    "osFamily": "macOS"
+  }
+}

--- a/dsc/examples/osinfo_parameters.dsc.json
+++ b/dsc/examples/osinfo_parameters.dsc.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json",
+  "parameters": {
+    "osFamily": {
+      "type": "string",
+      "defaultValue": "[concat('Win','dows')]",
+      "allowedValues": [
+        "Windows",
+        "Linux",
+        "macOS"
+      ]
+    }
+  },
+  "resources": [
+    {
+      "name": "os",
+      "type": "Microsoft/OSInfo",
+      "properties": {
+        "family": "[parameters('osFamily')]"
+      }
+    },
+    {
+      "name": "another os instance",
+      "type": "Microsoft/OSInfo",
+      "properties": {
+        "family": "macOS"
+      }
+    },
+    {
+      "name": "path",
+      "type": "Microsoft.DSC.Debug/Echo",
+      "properties": {
+        "output": "[envvar('PATH')]"
+      }
+    }
+  ]
+}

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -157,7 +157,7 @@ fn check_store() {
     };
 
     // MS Store runs app using `sihost.exe`
-    if parent_process.name().to_ascii_lowercase() == "sihost.exe" || parent_process.name().to_ascii_lowercase() == "explorer.exe"{
+    if parent_process.name().eq_ignore_ascii_case("sihost.exe") || parent_process.name().eq_ignore_ascii_case("explorer.exe") {
         eprintln!("{}", t!("main.storeMessage"));
         // wait for keypress
         let _ = io::stdin().read(&mut [0u8]).unwrap();

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -102,7 +102,7 @@ fn ctrlc_handler() {
 
 fn terminate_subprocesses(sys: &System, process: &Process) {
     info!("{}: {:?} {}", t!("main.terminatingSubprocess"), process.name(), process.pid());
-    for subprocess in sys.processes().values().filter(|p| p.parent().map_or(false, |parent| parent == process.pid())) {
+    for subprocess in sys.processes().values().filter(|p| p.parent().is_some_and(|parent| parent == process.pid())) {
         terminate_subprocesses(sys, subprocess);
     }
 

--- a/dsc/src/resolve.rs
+++ b/dsc/src/resolve.rs
@@ -99,27 +99,6 @@ pub fn get_contents(input: &str) -> Result<(Option<String>, String), String> {
                     return Err(format!("{} '{include_path:?}': {err}", t!("resolve.invalidFile")));
                 }
             }
-            // // try to deserialize the Include content as YAML first
-            // let configuration: Configuration = match serde_yaml::from_str(&include_content) {
-            //     Ok(configuration) => configuration,
-            //     Err(_err) => {
-            //         // if that fails, try to deserialize it as JSON
-            //         match serde_json::from_str(&include_content) {
-            //             Ok(configuration) => configuration,
-            //             Err(err) => {
-            //                 return Err(format!("{} '{include_path:?}': {err}", t!("resolve.invalidFile")));
-            //             }
-            //         }
-            //     }
-            // };
-
-            // // serialize the Configuration as JSON
-            // match serde_json::to_string(&configuration) {
-            //     Ok(json) => json,
-            //     Err(err) => {
-            //         return Err(format!("JSON: {err}"));
-            //     }
-            // }
         },
         IncludeKind::Content(text) => {
             match parse_input_to_json(&text) {

--- a/dsc/src/resolve.rs
+++ b/dsc/src/resolve.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use dsc_lib::configure::config_doc::Configuration;
 use dsc_lib::util::parse_input_to_json;
 use rust_i18n::t;
 use schemars::JsonSchema;

--- a/dsc/src/resolve.rs
+++ b/dsc/src/resolve.rs
@@ -18,17 +18,17 @@ pub enum IncludeKind {
     /// and not allowed to reference parent directories.  If a configuration document is used
     /// instead of a file, then the path is relative to the current working directory.
     #[serde(rename = "configurationFile")]
-    FilePath(String),
+    ConfigurationFile(String),
     #[serde(rename = "configurationContent")]
-    Content(String),
+    ConfigurationContent(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub enum IncludeParametersKind {
     #[serde(rename = "parametersFile")]
-    FilePath(String),
+    ParametersFile(String),
     #[serde(rename = "parametersContent")]
-    Content(String),
+    ParametersContent(String),
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -67,7 +67,7 @@ pub fn get_contents(input: &str) -> Result<(Option<String>, String), String> {
     };
 
     let config_json = match include.configuration {
-        IncludeKind::FilePath(file_path) => {
+        IncludeKind::ConfigurationFile(file_path) => {
             let include_path = normalize_path(Path::new(&file_path))?;
 
             // read the file specified in the Include input
@@ -100,7 +100,7 @@ pub fn get_contents(input: &str) -> Result<(Option<String>, String), String> {
                 }
             }
         },
-        IncludeKind::Content(text) => {
+        IncludeKind::ConfigurationContent(text) => {
             match parse_input_to_json(&text) {
                 Ok(json) => json,
                 Err(err) => {
@@ -111,7 +111,7 @@ pub fn get_contents(input: &str) -> Result<(Option<String>, String), String> {
     };
 
     let parameters = match include.parameters {
-        Some(IncludeParametersKind::FilePath(file_path)) => {
+        Some(IncludeParametersKind::ParametersFile(file_path)) => {
             // combine the path with DSC_CONFIG_ROOT
             let parameters_file = normalize_path(Path::new(&file_path))?;
             info!("{} '{parameters_file:?}'", t!("resolve.resolvingParameters"));
@@ -130,7 +130,7 @@ pub fn get_contents(input: &str) -> Result<(Option<String>, String), String> {
                 }
             }
         },
-        Some(IncludeParametersKind::Content(text)) => {
+        Some(IncludeParametersKind::ParametersContent(text)) => {
             let parameters_json = match parse_input_to_json(&text) {
                 Ok(json) => json,
                 Err(err) => {

--- a/dsc/src/resolve.rs
+++ b/dsc/src/resolve.rs
@@ -14,14 +14,30 @@ use tracing::{debug, info};
 use crate::util::DSC_CONFIG_ROOT;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
-pub struct Include {
+pub enum IncludeKind {
     /// The path to the file to include.  Path is relative to the file containing the include
     /// and not allowed to reference parent directories.  If a configuration document is used
     /// instead of a file, then the path is relative to the current working directory.
     #[serde(rename = "configurationFile")]
-    pub configuration_file: String,
+    FilePath(String),
+    #[serde(rename = "configurationContent")]
+    Content(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum IncludeParametersKind {
     #[serde(rename = "parametersFile")]
-    pub parameters_file: Option<String>,
+    FilePath(String),
+    #[serde(rename = "parametersContent")]
+    Content(String),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct Include {
+    #[serde(flatten)]
+    pub configuration: IncludeKind,
+    #[serde(flatten)]
+    pub parameters: Option<IncludeParametersKind>,
 }
 
 /// Read the file specified in the Include input and return the content as a JSON string.
@@ -51,74 +67,104 @@ pub fn get_contents(input: &str) -> Result<(Option<String>, String), String> {
         }
     };
 
-    let include_path = normalize_path(Path::new(&include.configuration_file))?;
+    let config_json = match include.configuration {
+        IncludeKind::FilePath(file_path) => {
+            let include_path = normalize_path(Path::new(&file_path))?;
 
-    // read the file specified in the Include input
-    let mut buffer: Vec<u8> = Vec::new();
-    match File::open(&include_path) {
-        Ok(mut file) => {
-            match file.read_to_end(&mut buffer) {
-                Ok(_) => (),
+            // read the file specified in the Include input
+            let mut buffer: Vec<u8> = Vec::new();
+            match File::open(&include_path) {
+                Ok(mut file) => {
+                    match file.read_to_end(&mut buffer) {
+                        Ok(_) => (),
+                        Err(err) => {
+                            return Err(format!("{} '{include_path:?}': {err}", t!("resolve.failedToReadFile")));
+                        }
+                    }
+                },
                 Err(err) => {
-                    return Err(format!("{} '{include_path:?}': {err}", t!("resolve.failedToReadFile")));
+                    return Err(format!("{} '{include_path:?}': {err}", t!("resolve.failedToOpenFile")));
                 }
             }
-        },
-        Err(err) => {
-            return Err(format!("{} '{include_path:?}': {err}", t!("resolve.failedToOpenFile")));
-        }
-    }
-    // convert the buffer to a string
-    let include_content = match String::from_utf8(buffer) {
-        Ok(input) => input,
-        Err(err) => {
-            return Err(format!("{} '{include_path:?}': {err}", t!("resolve.invalidFileContent")));
-        }
-    };
+            // convert the buffer to a string
+            let include_content = match String::from_utf8(buffer) {
+                Ok(input) => input,
+                Err(err) => {
+                    return Err(format!("{} '{include_path:?}': {err}", t!("resolve.invalidFileContent")));
+                }
+            };
 
-    // try to deserialize the Include content as YAML first
-    let configuration: Configuration = match serde_yaml::from_str(&include_content) {
-        Ok(configuration) => configuration,
-        Err(_err) => {
-            // if that fails, try to deserialize it as JSON
-            match serde_json::from_str(&include_content) {
-                Ok(configuration) => configuration,
+            match parse_input_to_json(&include_content) {
+                Ok(json) => json,
                 Err(err) => {
                     return Err(format!("{} '{include_path:?}': {err}", t!("resolve.invalidFile")));
                 }
             }
-        }
-    };
+            // // try to deserialize the Include content as YAML first
+            // let configuration: Configuration = match serde_yaml::from_str(&include_content) {
+            //     Ok(configuration) => configuration,
+            //     Err(_err) => {
+            //         // if that fails, try to deserialize it as JSON
+            //         match serde_json::from_str(&include_content) {
+            //             Ok(configuration) => configuration,
+            //             Err(err) => {
+            //                 return Err(format!("{} '{include_path:?}': {err}", t!("resolve.invalidFile")));
+            //             }
+            //         }
+            //     }
+            // };
 
-    // serialize the Configuration as JSON
-    let config_json = match serde_json::to_string(&configuration) {
-        Ok(json) => json,
-        Err(err) => {
-            return Err(format!("JSON: {err}"));
-        }
-    };
-
-    let parameters = if let Some(parameters_file) = include.parameters_file {
-        // combine the path with DSC_CONFIG_ROOT
-        let parameters_file = normalize_path(Path::new(&parameters_file))?;
-        info!("{} '{parameters_file:?}'", t!("resolve.resolvingParameters"));
-        match std::fs::read_to_string(&parameters_file) {
-            Ok(parameters) => {
-                let parameters_json = match parse_input_to_json(&parameters) {
-                    Ok(json) => json,
-                    Err(err) => {
-                        return Err(format!("{} '{parameters_file:?}': {err}", t!("resolve.failedParseParametersFile")));
-                    }
-                };
-                Some(parameters_json)
-            },
-            Err(err) => {
-                return Err(format!("{} '{parameters_file:?}': {err}", t!("resolve.failedResolveParametersFile")));
+            // // serialize the Configuration as JSON
+            // match serde_json::to_string(&configuration) {
+            //     Ok(json) => json,
+            //     Err(err) => {
+            //         return Err(format!("JSON: {err}"));
+            //     }
+            // }
+        },
+        IncludeKind::Content(text) => {
+            match parse_input_to_json(&text) {
+                Ok(json) => json,
+                Err(err) => {
+                    return Err(format!("{}: {err}", t!("resolve.invalidFile")));
+                }
             }
         }
-    } else {
-        debug!("{}", t!("resolve.noParametersFile"));
-        None
+    };
+
+    let parameters = match include.parameters {
+        Some(IncludeParametersKind::FilePath(file_path)) => {
+            // combine the path with DSC_CONFIG_ROOT
+            let parameters_file = normalize_path(Path::new(&file_path))?;
+            info!("{} '{parameters_file:?}'", t!("resolve.resolvingParameters"));
+            match std::fs::read_to_string(&parameters_file) {
+                Ok(parameters) => {
+                    let parameters_json = match parse_input_to_json(&parameters) {
+                        Ok(json) => json,
+                        Err(err) => {
+                            return Err(format!("{} '{parameters_file:?}': {err}", t!("resolve.failedParseParametersFile")));
+                        }
+                    };
+                    Some(parameters_json)
+                },
+                Err(err) => {
+                    return Err(format!("{} '{parameters_file:?}': {err}", t!("resolve.failedResolveParametersFile")));
+                }
+            }
+        },
+        Some(IncludeParametersKind::Content(text)) => {
+            let parameters_json = match parse_input_to_json(&text) {
+                Ok(json) => json,
+                Err(err) => {
+                    return Err(format!("{}: {err}", t!("resolve.invalidParametersContent")));
+                }
+            };
+            Some(parameters_json)
+        },
+        None => {
+            debug!("{}", t!("resolve.noParameters"));
+            None
+        }
     };
 
     Ok((parameters, config_json))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The `Include` resource currently only takes the configuration to include and parameters as external files.  This change enables a choice of either a file path `configurationFile`, `parametersFile` or the content as a string `configurationContent`, `parametersContent` (can be mixed).  This is useful where another resource might generate a configuration that is used later within a larger configuration without needing to save it to a file first.

@michaeltlombardi for docs, it's important that the nested JSON/YAML is a text string and NOT a nested object this is why the tests have embedded YAML as a multi-line string and the JSON in quotes.

There is future work to allow a nested object for configuration and parameters that can be added to the enum but not part of this PR.

Seems like there is a new clippy rule for unnecessary `map` use so fixed that as well although unrelated to my changes.