### PR TITLE
update version to rc.1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -544,7 +544,12 @@ if ($packageType -eq 'msixbundle') {
             $productName += "-Preview"
         }
         # save preview number
-        $previewNumber = $productVersion -replace '.*?-[a-z]+\.([0-9]+)', '$1'
+        $previewNumber = [int]($productVersion -replace '.*?-[a-z]+\.([0-9]+)', '$1' | Out-String)
+        $productLabel = $productVersion.Split('-')[1]
+        if ($productLabel.StartsWith('rc')) {
+            # if RC, we increment by 100 to ensure it's newer than the last preview
+            $previewNumber += 100
+        }
         # remove label from version
         $productVersion = $productVersion.Split('-')[0]
         # replace revision number with preview number

--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -504,7 +504,7 @@ dependencies = [
 
 [[package]]
 name = "dsc"
-version = "3.0.0-rc"
+version = "3.0.0-rc.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/dsc/Cargo.toml
+++ b/dsc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dsc"
-version = "3.0.0-rc"
+version = "3.0.0-rc.1"
 edition = "2021"
 
 [profile.release]

--- a/dsc/tests/dsc_tracing.tests.ps1
+++ b/dsc/tests/dsc_tracing.tests.ps1
@@ -83,7 +83,7 @@ Describe 'tracing tests' {
 "@
 
         $out = (dsc -l $level config get -i $configYaml 2> $null) | ConvertFrom-Json
-        $out.results[0].result.actualState.level | Should -BeExactly $level
+        $out.results[0].result.actualState.level | Should -BeExactly $level -Because ($out | Out-String)
     }
 
     It 'Pass-through tracing should only emit JSON for child processes' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- For msix packaging to work correctly, need the version to be `rc.1` instead of just `rc`
- Build script for msix package updated so that an `rc` release gets the rc version + 100 so that the resulting version a.b.c is larger than previous preview releases as required to publish to Store