### PR TITLE
Fix progress display when using JSON, add None option; exhance progress schema

### DIFF
--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.15",
  "once_cell",
  "serde",
  "version_check",
@@ -551,6 +551,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-dscexpression",
  "tree-sitter-rust",
+ "uuid",
 ]
 
 [[package]]
@@ -668,7 +669,19 @@ checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
 ]
 
 [[package]]
@@ -1098,7 +1111,7 @@ dependencies = [
  "hermit-abi",
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -2172,9 +2185,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.10.0"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "uuid-simd"
@@ -2253,6 +2269,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -2491,6 +2516,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -4,7 +4,7 @@
 use clap::{Parser, Subcommand, ValueEnum};
 use clap_complete::Shell;
 use dsc_lib::dscresources::command_resource::TraceLevel;
-use dsc_lib::util::ProgressFormat;
+use dsc_lib::progress::ProgressFormat;
 use rust_i18n::t;
 use serde::Deserialize;
 

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -8,7 +8,7 @@ use rust_i18n::{i18n, t};
 use std::{io, process::exit};
 use sysinfo::{Process, RefreshKind, System, get_current_pid, ProcessRefreshKind};
 use tracing::{error, info, warn, debug};
-use dsc_lib::util::ProgressFormat;
+use dsc_lib::progress::ProgressFormat;
 
 #[cfg(debug_assertions)]
 use crossterm::event;

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -25,7 +25,7 @@ use dsc_lib::{
     },
     dscresources::dscresource::{Capability, ImplementedAs, Invoke},
     dscresources::resource_manifest::{import_manifest, ResourceManifest},
-    util::ProgressFormat,
+    progress::ProgressFormat,
 };
 use rust_i18n::t;
 use std::{
@@ -288,15 +288,13 @@ pub fn config(subcommand: &ConfigSubCommand, parameters: &Option<String>, mounte
         }
     };
 
-    let mut configurator = match Configurator::new(&json_string) {
+    let mut configurator = match Configurator::new(&json_string, progress_format) {
         Ok(configurator) => configurator,
         Err(err) => {
             error!("Error: {err}");
             exit(EXIT_DSC_ERROR);
         }
     };
-
-    configurator.set_progress_format(progress_format);
 
     if let ConfigSubCommand::Set { what_if , .. } = subcommand {
         if *what_if {

--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -303,4 +303,10 @@ resources:
         $LASTEXITCODE | Should -Be 1
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Target path does not exist: '/invalid/path'"
     }
+
+    It '--progress-format can be None' {
+        dsc -p none resource list 2> $TestDrive/tracing.txt
+        $LASTEXITCODE | Should -Be 0
+        (Get-Content $TestDrive/tracing.txt -Raw) | Should -BeNullOrEmpty
+    }
 }

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -74,11 +74,11 @@ Describe 'dsc config get tests' {
             $jp = $line | ConvertFrom-Json
             if ($jp.activity) { # if line is a progress message
                 $jp.id | Should -Not -BeNullOrEmpty
-                $jp.percent_complete | Should -BeIn (0..100)
+                $jp.percentComplete | Should -BeIn (0..100)
                 $ProgressMessagesFound = $true
             }
 
-            if ($jp.percent_complete -eq 100 -and $jp.resourceType -eq 'Microsoft.DSC.Debug/Echo') {
+            if ($jp.percentComplete -eq 100 -and $jp.resourceType -eq 'Microsoft.DSC.Debug/Echo') {
                 $ProgressResultFound = $true
                 $jp.resourceName | Should -BeExactly 'Echo'
                 $jp.result | Should -Not -BeNullOrEmpty

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -79,7 +79,8 @@ Describe 'dsc config get tests' {
             $jp = $line | ConvertFrom-Json
             if ($jp.activity) { # if line is a progress message
                 $jp.id | Should -Not -BeNullOrEmpty
-                $jp.percentComplete | Should -BeIn (0..100)
+                $jp.totalItems | Should -Not -BeNullOrEmpty
+                $jp.completedItems | Should -Not -BeNullOrEmpty
                 $ProgressMessagesFound = $true
             }
 
@@ -90,6 +91,53 @@ Describe 'dsc config get tests' {
                 } elseif ($jp.resourceName -eq 'Echo 2') {
                     $InstanceTwoFound = $true
                     $jp.result.actualState.output | Should -BeExactly 'world'
+                }
+            }
+        }
+        $ProgressMessagesFound | Should -BeTrue
+        $InstanceOneFound | Should -BeTrue
+        $InstanceTwoFound | Should -BeTrue
+    }
+
+    It 'json progress returns correctly for failed resource' {
+        $config_yaml = @'
+            $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+            resources:
+            - name: Echo 1
+              type: Microsoft.DSC.Debug/Echo
+              properties:
+                output: hello
+            - name: ErrorTest
+              type: Test/ExitCode
+              properties:
+                exitCode: 1
+'@
+        dsc --progress-format json --trace-format json config get -i $config_yaml 2> $TestDrive/ErrorStream.txt
+        $LASTEXITCODE | Should -Be 2
+        $lines = Get-Content $TestDrive/ErrorStream.txt
+        $ProgressMessagesFound = $false
+        $InstanceOneFound = $false
+        $InstanceTwoFound = $false
+        foreach ($line in $lines) {
+            $jp = $line | ConvertFrom-Json
+            if ($jp.activity) { # if line is a progress message
+                $jp.id | Should -Not -BeNullOrEmpty
+                $jp.totalItems | Should -Not -BeNullOrEmpty
+                $jp.completedItems | Should -Not -BeNullOrEmpty
+                $ProgressMessagesFound = $true
+            }
+
+            if ($null -ne $jp.result -and $jp.resourceType -eq 'Microsoft.DSC.Debug/Echo') {
+                if ($jp.resourceName -eq 'Echo 1') {
+                    $InstanceOneFound = $true
+                    $jp.result.actualState.output | Should -BeExactly 'hello'
+                    $jp.failed | Should -BeNullOrEmpty
+                }
+            }
+            elseif ($null -ne $jp.failed -and $jp.resourceType -eq 'Test/ExitCode') {
+                if ($jp.resourceName -eq 'ErrorTest') {
+                    $InstanceTwoFound = $true
+                    $jp.result | Should -BeNullOrEmpty
                 }
             }
         }

--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -110,7 +110,7 @@ Describe 'dsc config get tests' {
             - name: ErrorTest
               type: Test/ExitCode
               properties:
-                exitCode: 1
+                exitCode: 8
 '@
         dsc --progress-format json --trace-format json config get -i $config_yaml 2> $TestDrive/ErrorStream.txt
         $LASTEXITCODE | Should -Be 2
@@ -134,10 +134,12 @@ Describe 'dsc config get tests' {
                     $jp.failed | Should -BeNullOrEmpty
                 }
             }
-            elseif ($null -ne $jp.failed -and $jp.resourceType -eq 'Test/ExitCode') {
+            elseif ($null -ne $jp.failure -and $jp.resourceType -eq 'Test/ExitCode') {
                 if ($jp.resourceName -eq 'ErrorTest') {
                     $InstanceTwoFound = $true
                     $jp.result | Should -BeNullOrEmpty
+                    $jp.failure.exitCode | Should -Be 8
+                    $jp.failure.message | Should -Not -BeNullOrEmpty
                 }
             }
         }

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -66,6 +66,7 @@ Describe 'Tests for listing resources' {
         foreach ($line in $lines) {
             $jp = $line | ConvertFrom-Json
             if ($jp.activity) { # if line is a progress message
+                $jp.id | Should -Not -BeNullOrEmpty
                 $jp.percent_complete | Should -BeIn (0..100)
                 $ProgressMessagesFound = $True
             }

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -67,7 +67,7 @@ Describe 'Tests for listing resources' {
             $jp = $line | ConvertFrom-Json
             if ($jp.activity) { # if line is a progress message
                 $jp.id | Should -Not -BeNullOrEmpty
-                $jp.percent_complete | Should -BeIn (0..100)
+                $jp.percentComplete | Should -BeIn (0..100)
                 $ProgressMessagesFound = $True
             }
         }

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -67,7 +67,8 @@ Describe 'Tests for listing resources' {
             $jp = $line | ConvertFrom-Json
             if ($jp.activity) { # if line is a progress message
                 $jp.id | Should -Not -BeNullOrEmpty
-                $jp.percentComplete | Should -BeIn (0..100)
+                $jp.totalItems | Should -Not -BeNullOrEmpty
+                $jp.completedItems | Should -Not -BeNullOrEmpty
                 $ProgressMessagesFound = $True
             }
         }

--- a/dsc_lib/Cargo.lock
+++ b/dsc_lib/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-dscexpression",
  "tree-sitter-rust",
+ "uuid",
 ]
 
 [[package]]
@@ -1833,9 +1834,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "uuid-simd"

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -35,6 +35,7 @@ tracing-indicatif = { version = "0.3" }
 tree-sitter = "0.25"
 tree-sitter-rust = "0.23"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
+uuid = { version = "1.13", features = ["v4"] }
 
 [dev-dependencies]
 serde_yaml = "0.9"

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -314,6 +314,9 @@ unknown = "Unknown"
 validation = "Validation"
 setting = "Setting"
 
+[progress]
+failedToSerialize = "Failed to serialize progress JSON: %{json}"
+
 [util]
 foundSetting = "Found setting '%{name}' in %{path}"
 notFoundSetting = "Setting '%{name}' not found in %{path}"

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -798,13 +798,13 @@ fn get_failure_from_error(err: &DscError) -> Option<Failure> {
         DscError::CommandExit(_resource, exit_code, reason) => {
             Some(Failure {
                 message: reason.to_string(),
-                exit_code: exit_code.clone(),
+                exit_code: *exit_code,
             })
         },
         DscError::CommandExitFromManifest(_resource, exit_code, reason) => {
             Some(Failure {
                 message: reason.to_string(),
-                exit_code: exit_code.clone(),
+                exit_code: *exit_code,
             })
         },
         _ => None,

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -179,7 +179,7 @@ impl ResourceDiscovery for CommandDiscovery {
         };
 
         let mut progress = ProgressBar::new(1, progress_format)?;
-        progress.set_activity(t!("discovery.commandDiscovery.progressSearching").to_string().as_str());
+        progress.write_activity(t!("discovery.commandDiscovery.progressSearching").to_string().as_str());
 
         let mut resources = BTreeMap::<String, Vec<DscResource>>::new();
         let mut adapters = BTreeMap::<String, Vec<DscResource>>::new();
@@ -235,7 +235,7 @@ impl ResourceDiscovery for CommandDiscovery {
                 }
             }
         }
-        progress.increment(1);
+        progress.write_increment(1);
         debug!("Found {} matching non-adapter-based resources", resources.len());
         self.resources = resources;
         self.adapters = adapters;
@@ -268,14 +268,14 @@ impl ResourceDiscovery for CommandDiscovery {
         };
 
         let mut progress = ProgressBar::new(self.adapters.len() as u64, progress_format)?;
-        progress.set_activity("Searching for adapted resources");
+        progress.write_activity("Searching for adapted resources");
 
         let mut adapted_resources = BTreeMap::<String, Vec<DscResource>>::new();
 
         let mut found_adapter: bool = false;
         for (adapter_name, adapters) in &self.adapters {
             for adapter in adapters {
-                progress.increment(1);
+                progress.write_increment(1);
 
                 if !regex.is_match(adapter_name) {
                     continue;
@@ -284,7 +284,7 @@ impl ResourceDiscovery for CommandDiscovery {
                 found_adapter = true;
                 info!("Enumerating resources for adapter '{}'", adapter_name);
                 let mut adapter_progress = ProgressBar::new(1, progress_format)?;
-                adapter_progress.set_activity(format!("Enumerating resources for adapter '{adapter_name}'").as_str());
+                adapter_progress.write_activity(format!("Enumerating resources for adapter '{adapter_name}'").as_str());
                 let manifest = if let Some(manifest) = &adapter.manifest {
                     if let Ok(manifest) = import_manifest(manifest.clone()) {
                         manifest
@@ -336,7 +336,7 @@ impl ResourceDiscovery for CommandDiscovery {
                     };
                 }
 
-                adapter_progress.increment(1);
+                adapter_progress.write_increment(1);
                 debug!("Adapter '{}' listed {} resources", adapter_name, adapter_resources_count);
             }
         }

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -7,8 +7,7 @@ use crate::dscresources::dscresource::{Capability, DscResource, ImplementedAs};
 use crate::dscresources::resource_manifest::{import_manifest, validate_semver, Kind, ResourceManifest};
 use crate::dscresources::command_resource::invoke_command;
 use crate::dscerror::DscError;
-use crate::util::ProgressFormat;
-use indicatif::ProgressStyle;
+use crate::progress::{ProgressBar, ProgressFormat};
 use linked_hash_map::LinkedHashMap;
 use regex::RegexBuilder;
 use rust_i18n::t;
@@ -22,10 +21,9 @@ use std::fs::File;
 use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use tracing::{debug, info, trace, warn, warn_span};
-use tracing_indicatif::span_ext::IndicatifSpanExt;
+use tracing::{debug, info, trace, warn};
 
-use crate::util::{get_setting, ProgressBar};
+use crate::util::get_setting;
 use crate::util::get_exe_path;
 
 pub struct CommandDiscovery {
@@ -169,7 +167,7 @@ impl Default for CommandDiscovery {
 
 impl ResourceDiscovery for CommandDiscovery {
 
-    fn discover_resources(&mut self, filter: &str) -> Result<(), DscError> {
+    fn discover_resources(&mut self, filter: &str, progress_format: ProgressFormat) -> Result<(), DscError> {
         info!("{}", t!("discovery.commandDiscovery.discoverResources", filter = filter));
 
         let regex_str = convert_wildcard_to_regex(filter);
@@ -180,12 +178,8 @@ impl ResourceDiscovery for CommandDiscovery {
             return Err(DscError::Operation(t!("discovery.commandDiscovery.invalidAdapterFilter").to_string()));
         };
 
-        let pb_span = warn_span!("");
-        pb_span.pb_set_style(&ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
-        )?);
-        pb_span.pb_set_message(t!("discovery.commandDiscovery.progressSearching").to_string().as_str());
-        let _ = pb_span.enter();
+        let mut progress = ProgressBar::new(1, progress_format)?;
+        progress.set_activity(t!("discovery.commandDiscovery.progressSearching").to_string().as_str());
 
         let mut resources = BTreeMap::<String, Vec<DscResource>>::new();
         let mut adapters = BTreeMap::<String, Vec<DscResource>>::new();
@@ -241,6 +235,7 @@ impl ResourceDiscovery for CommandDiscovery {
                 }
             }
         }
+        progress.increment(1);
         debug!("Found {} matching non-adapter-based resources", resources.len());
         self.resources = resources;
         self.adapters = adapters;
@@ -249,7 +244,7 @@ impl ResourceDiscovery for CommandDiscovery {
 
     fn discover_adapted_resources(&mut self, name_filter: &str, adapter_filter: &str, progress_format: ProgressFormat) -> Result<(), DscError> {
         if self.resources.is_empty() && self.adapters.is_empty() {
-            self.discover_resources("*")?;
+            self.discover_resources("*", progress_format)?;
         }
 
         if self.adapters.is_empty() {
@@ -272,20 +267,15 @@ impl ResourceDiscovery for CommandDiscovery {
             return Err(DscError::Operation("Could not build Regex filter for resource name".to_string()));
         };
 
-        let mut pb_span = ProgressBar::new(progress_format == ProgressFormat::Json);
-        pb_span.pb_set_style(&ProgressStyle::with_template(
-            "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
-        )?);
-        pb_span.pb_set_message("Searching for adapted resources");
-        pb_span.pb_set_length(self.adapters.len() as u64);
-        pb_span.enter();
+        let mut progress = ProgressBar::new(self.adapters.len() as u64, progress_format)?;
+        progress.set_activity("Searching for adapted resources");
 
         let mut adapted_resources = BTreeMap::<String, Vec<DscResource>>::new();
 
         let mut found_adapter: bool = false;
         for (adapter_name, adapters) in &self.adapters {
             for adapter in adapters {
-                pb_span.pb_inc(1);
+                progress.increment(1);
 
                 if !regex.is_match(adapter_name) {
                     continue;
@@ -293,12 +283,8 @@ impl ResourceDiscovery for CommandDiscovery {
 
                 found_adapter = true;
                 info!("Enumerating resources for adapter '{}'", adapter_name);
-                let mut pb_adapter_span = ProgressBar::new(progress_format == ProgressFormat::Json);
-                pb_adapter_span.pb_set_style(&ProgressStyle::with_template(
-                    "{spinner:.green} [{elapsed_precise:.cyan}] {msg:.white}"
-                )?);
-                pb_adapter_span.pb_set_message(format!("Enumerating resources for adapter '{adapter_name}'").as_str());
-                pb_adapter_span.enter();
+                let mut adapter_progress = ProgressBar::new(1, progress_format)?;
+                adapter_progress.set_activity(format!("Enumerating resources for adapter '{adapter_name}'").as_str());
                 let manifest = if let Some(manifest) = &adapter.manifest {
                     if let Ok(manifest) = import_manifest(manifest.clone()) {
                         manifest
@@ -350,6 +336,7 @@ impl ResourceDiscovery for CommandDiscovery {
                     };
                 }
 
+                adapter_progress.increment(1);
                 debug!("Adapter '{}' listed {} resources", adapter_name, adapter_resources_count);
             }
         }
@@ -369,11 +356,11 @@ impl ResourceDiscovery for CommandDiscovery {
         let mut resources = BTreeMap::<String, Vec<DscResource>>::new();
 
         if adapter_name_filter.is_empty() {
-            self.discover_resources(type_name_filter)?;
+            self.discover_resources(type_name_filter, progress_format)?;
             resources.append(&mut self.resources);
             resources.append(&mut self.adapters);
         } else {
-            self.discover_resources("*")?;
+            self.discover_resources("*", progress_format)?;
             self.discover_adapted_resources(type_name_filter, adapter_name_filter, progress_format)?;
 
             // add/update found adapted resources to the lookup_table
@@ -390,7 +377,7 @@ impl ResourceDiscovery for CommandDiscovery {
     fn find_resources(&mut self, required_resource_types: &[String], progress_format: ProgressFormat) -> Result<BTreeMap<String, DscResource>, DscError>
     {
         debug!("Searching for resources: {:?}", required_resource_types);
-        self.discover_resources("*")?;
+        self.discover_resources("*", progress_format)?;
 
         // convert required_resource_types to lowercase to handle case-insentiive search
         let mut remaining_required_resource_types = required_resource_types.iter().map(|x| x.to_lowercase()).collect::<Vec<String>>();

--- a/dsc_lib/src/discovery/discovery_trait.rs
+++ b/dsc_lib/src/discovery/discovery_trait.rs
@@ -1,11 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{dscresources::dscresource::DscResource, dscerror::DscError, util::ProgressFormat};
+use crate::{dscresources::dscresource::DscResource, dscerror::DscError, progress::ProgressFormat};
 use std::collections::BTreeMap;
 
 pub trait ResourceDiscovery {
-    fn discover_resources(&mut self, filter: &str) -> Result<(), DscError>;
+    fn discover_resources(&mut self, filter: &str, progress_format: ProgressFormat) -> Result<(), DscError>;
     fn discover_adapted_resources(&mut self, name_filter: &str, adapter_filter: &str, progress_format: ProgressFormat) -> Result<(), DscError>;
     fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str, progress_format: ProgressFormat) -> Result<BTreeMap<String, Vec<DscResource>>, DscError>;
     fn find_resources(&mut self, required_resource_types: &[String], progress_format: ProgressFormat) -> Result<BTreeMap<String, DscResource>, DscError>;

--- a/dsc_lib/src/discovery/discovery_trait.rs
+++ b/dsc_lib/src/discovery/discovery_trait.rs
@@ -1,12 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{dscresources::dscresource::DscResource, dscerror::DscError, progress::ProgressFormat};
+use crate::{dscresources::dscresource::DscResource, dscerror::DscError};
 use std::collections::BTreeMap;
 
 pub trait ResourceDiscovery {
-    fn discover_resources(&mut self, filter: &str, progress_format: ProgressFormat) -> Result<(), DscError>;
-    fn discover_adapted_resources(&mut self, name_filter: &str, adapter_filter: &str, progress_format: ProgressFormat) -> Result<(), DscError>;
-    fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str, progress_format: ProgressFormat) -> Result<BTreeMap<String, Vec<DscResource>>, DscError>;
-    fn find_resources(&mut self, required_resource_types: &[String], progress_format: ProgressFormat) -> Result<BTreeMap<String, DscResource>, DscError>;
+    fn discover_resources(&mut self, filter: &str) -> Result<(), DscError>;
+    fn discover_adapted_resources(&mut self, name_filter: &str, adapter_filter: &str) -> Result<(), DscError>;
+    fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str) -> Result<BTreeMap<String, Vec<DscResource>>, DscError>;
+    fn find_resources(&mut self, required_resource_types: &[String]) -> Result<BTreeMap<String, DscResource>, DscError>;
 }

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -38,14 +38,14 @@ impl Discovery {
     /// A vector of `DscResource` instances.
     pub fn list_available_resources(&mut self, type_name_filter: &str, adapter_name_filter: &str, progress_format: ProgressFormat) -> Vec<DscResource> {
         let discovery_types: Vec<Box<dyn ResourceDiscovery>> = vec![
-            Box::new(command_discovery::CommandDiscovery::new()),
+            Box::new(command_discovery::CommandDiscovery::new(progress_format)),
         ];
 
         let mut resources: Vec<DscResource> = Vec::new();
 
         for mut discovery_type in discovery_types {
 
-            let discovered_resources = match discovery_type.list_available_resources(type_name_filter, adapter_name_filter, progress_format) {
+            let discovered_resources = match discovery_type.list_available_resources(type_name_filter, adapter_name_filter) {
                 Ok(value) => value,
                 Err(err) => {
                     error!("{err}");
@@ -75,12 +75,12 @@ impl Discovery {
     /// * `required_resource_types` - The required resource types.
     pub fn find_resources(&mut self, required_resource_types: &[String], progress_format: ProgressFormat) {
         let discovery_types: Vec<Box<dyn ResourceDiscovery>> = vec![
-            Box::new(command_discovery::CommandDiscovery::new()),
+            Box::new(command_discovery::CommandDiscovery::new(progress_format)),
         ];
         let mut remaining_required_resource_types = required_resource_types.to_owned();
         for mut discovery_type in discovery_types {
 
-            let discovered_resources = match discovery_type.find_resources(&remaining_required_resource_types, progress_format) {
+            let discovered_resources = match discovery_type.find_resources(&remaining_required_resource_types) {
                 Ok(value) => value,
                 Err(err) => {
                     error!("{err}");

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -5,7 +5,7 @@ mod command_discovery;
 mod discovery_trait;
 
 use crate::discovery::discovery_trait::ResourceDiscovery;
-use crate::{dscresources::dscresource::DscResource, dscerror::DscError, util::ProgressFormat};
+use crate::{dscresources::dscresource::DscResource, dscerror::DscError, progress::ProgressFormat};
 use std::collections::BTreeMap;
 use tracing::error;
 

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -1,7 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::util::ProgressFormat;
+use crate::progress::ProgressFormat;
+
 use configure::config_doc::ExecutionKind;
 use dscerror::DscError;
 use dscresources::{dscresource::{DscResource, Invoke}, invoke_result::{GetResult, SetResult, TestResult}};
@@ -13,6 +14,7 @@ pub mod dscerror;
 pub mod dscresources;
 pub mod functions;
 pub mod parser;
+pub mod progress;
 pub mod util;
 
 i18n!("locales", fallback = "en-us");

--- a/dsc_lib/src/progress.rs
+++ b/dsc_lib/src/progress.rs
@@ -116,13 +116,7 @@ impl ProgressBar {
 
         self.item_position += delta;
 
-        if self.item_count  > 0 {
-            self.progress_value.percent_complete = if self.item_position >= self.item_count {
-                100
-            } else {
-                u8::try_from((self.item_position * 100) / self.item_count).unwrap_or(100)
-            };
-        }
+        self.set_percent_complete();
 
         if self.format == ProgressFormat::Json {
             self.write_json();

--- a/dsc_lib/src/progress.rs
+++ b/dsc_lib/src/progress.rs
@@ -1,0 +1,192 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+
+use clap::ValueEnum;
+use indicatif::ProgressStyle;
+use rust_i18n::t;
+use serde::Serialize;
+use serde_json::Value;
+use tracing_indicatif::span_ext::IndicatifSpanExt;
+use tracing::{trace, warn_span};
+use tracing::span::Span;
+use uuid::Uuid;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum ProgressFormat {
+    /// If interactive, use a progress bar. If not interactive, no progress is shown.
+    Default,
+    /// No progress is shown.
+    None,
+    /// Show progress as JSON.
+    Json,
+}
+
+#[derive(Default, Debug, Clone, Serialize)]
+pub struct Progress {
+    /// The unique identifier for the operation.
+    pub id: String,
+    /// The activity being performed.
+    pub activity: Option<String>,
+    /// The percentage of the operation that is complete from 0 to 100.
+    #[serde(rename = "percentComplete")]
+    pub percent_complete: u8,
+    /// The status of the operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
+    /// The number of seconds remaining in the operation.
+    #[serde(rename = "secondsRemaining", skip_serializing_if = "Option::is_none")]
+    pub seconds_remaining: Option<u64>,
+    /// The name of the resource being operated on.
+    #[serde(rename = "resourceName", skip_serializing_if = "Option::is_none")]
+    pub resource_name: Option<String>,
+    /// The type of the resource being operated on.
+    #[serde(rename = "resourceType", skip_serializing_if = "Option::is_none")]
+    pub resource_type: Option<String>,
+    /// The result of the operation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result: Option<Value>,
+}
+
+impl Progress {
+    #[must_use]
+    pub fn new() -> Progress {
+        Progress {
+            id: Uuid::new_v4().to_string(),
+            ..Default::default()
+        }
+    }
+}
+
+pub struct ProgressBar {
+    progress_value:  Progress,
+    console_bar: Span,
+    item_count: u64,
+    item_position: u64,
+    format: ProgressFormat
+}
+
+impl ProgressBar {
+    /// Create a `ProgressBar` object to update progress
+    ///
+    /// # Arguments
+    ///
+    /// * `item_count` - Total number of steps to complete.  Use '1' if unknown and increment when complete.
+    /// * `format` - The `ProgressFormat` to render.
+    ///
+    /// # Returns
+    ///
+    /// A `ProgressBar` oject to update progress
+    ///
+    /// # Errors
+    ///
+    /// Fails if progress style for console rendering can't be set.
+    ///
+    pub fn new(item_count: u64, format: ProgressFormat) -> Result<ProgressBar, DscError> {
+        let bar = warn_span!("");
+        if format == ProgressFormat::Default {
+            bar.pb_set_style(&ProgressStyle::with_template(
+                "{spinner:.green} [{elapsed_precise:.cyan}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg:.yellow}"
+            )?);
+            bar.pb_set_length(item_count);
+            let _guard = bar.enter();
+        }
+
+        Ok(ProgressBar {
+            progress_value: Progress::new(),
+            console_bar: bar,
+            item_count,
+            item_position: 0,
+            format
+        })
+    }
+
+    pub fn increment(&mut self, delta: u64) {
+        if self.format == ProgressFormat::None {
+            return;
+        }
+
+        self.item_position += delta;
+
+        if self.item_count  > 0 {
+            self.progress_value.percent_complete = if self.item_position >= self.item_count {
+                100
+            } else {
+                u8::try_from((self.item_position * 100) / self.item_count).unwrap_or(100)
+            };
+        }
+
+        if self.format == ProgressFormat::Json {
+            self.write_json();
+        } else {
+            self.console_bar.pb_inc(delta);
+        }
+    }
+
+    pub fn set_resource(&mut self, name: &str, resource_type: &str, result: Option<&Value>) {
+        self.progress_value.resource_name = Some(name.to_string());
+        self.progress_value.resource_type = Some(resource_type.to_string());
+        self.progress_value.result = result.cloned();
+    }
+
+    pub fn set_activity(&mut self, activity: &str) {
+        match self.format {
+            ProgressFormat::Json => {
+                self.progress_value.activity = Some(activity.to_string());
+                self.write_json();
+            },
+            ProgressFormat::Default => {
+                self.console_bar.pb_set_message(activity);
+            },
+            ProgressFormat::None => {}
+        }
+    }
+
+    pub fn set_length(&mut self, len: u64) {
+        match self.format {
+            ProgressFormat::Json => {
+                self.item_count = len;
+                if self.item_count  > 0 {
+                    self.progress_value.percent_complete = if self.item_position >= self.item_count {
+                        100
+                    } else {
+                        u8::try_from((self.item_position * 100) / self.item_count).unwrap_or(100)
+                    };
+                }
+            },
+            ProgressFormat::Default => {
+                self.console_bar.pb_set_length(len);
+            },
+            ProgressFormat::None => {}
+        }
+    }
+
+    pub fn set_position(&mut self, pos: u64) {
+        match self.format {
+            ProgressFormat::Json => {
+                self.item_position = pos;
+                if self.item_count  > 0 {
+                    self.progress_value.percent_complete = if self.item_position >= self.item_count {
+                        100
+                    } else {
+                        u8::try_from((self.item_position * 100) / self.item_count).unwrap_or(100)
+                    };
+                    self.write_json();
+                }
+            },
+            ProgressFormat::Default => {
+                self.console_bar.pb_set_position(pos);
+            },
+            ProgressFormat::None => {}
+        }
+    }
+
+    fn write_json(&self) {
+        if let Ok(json) = serde_json::to_string(&self.progress_value) {
+            eprintln!("{json}");
+        } else {
+            trace!("{}", t!("progress.failedToSerialize", json = self.progress_value : {:?}));
+        }
+    }
+}

--- a/dsc_lib/src/progress.rs
+++ b/dsc_lib/src/progress.rs
@@ -25,6 +25,13 @@ pub enum ProgressFormat {
 
 #[derive(Default, Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
+pub struct Failure {
+    pub message: String,
+    pub exit_code: i32,
+}
+
+#[derive(Default, Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Progress {
     /// The unique identifier for the operation.
     pub id: String,
@@ -49,9 +56,9 @@ pub struct Progress {
     /// The result of the operation.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub result: Option<Value>,
-    /// Indicates if the operation failed.
+    /// Failure information.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub failed: Option<bool>,
+    pub failure: Option<Failure>,
 }
 
 impl Progress {
@@ -136,7 +143,7 @@ impl ProgressBar {
         self.progress_value.resource_name = Some(name.to_string());
         self.progress_value.resource_type = Some(resource_type.to_string());
         self.progress_value.result = None;
-        self.progress_value.failed = None;
+        self.progress_value.failure = None;
     }
 
     /// Set the result of the operation. This will clear any error.
@@ -146,15 +153,15 @@ impl ProgressBar {
     /// * `result` - The result of the operation
     ///
     pub fn set_result(&mut self, result: &Value) {
-        self.progress_value.failed = None;
+        self.progress_value.failure = None;
         self.progress_value.result = Some(result.clone());
     }
 
     /// Indicate that the operation failed.  This will clear any result.
     ///
-    pub fn set_failed(&mut self) {
+    pub fn set_failure(&mut self, failure: Option<Failure>) {
         self.progress_value.result = None;
-        self.progress_value.failed = Some(true);
+        self.progress_value.failure = failure;
     }
 
     /// Set the status of the operation and write the progress

--- a/dsc_lib/src/progress.rs
+++ b/dsc_lib/src/progress.rs
@@ -109,7 +109,7 @@ impl ProgressBar {
     ///
     /// * `delta` - The amount to increment the progress bar by
     ///
-    pub fn increment(&mut self, delta: u64) {
+    pub fn write_increment(&mut self, delta: u64) {
         if self.format == ProgressFormat::None {
             return;
         }
@@ -131,7 +131,7 @@ impl ProgressBar {
         }
     }
 
-    /// Set the resource being operated on and write the progress
+    /// Set the resource being operated on
     ///
     /// # Arguments
     ///
@@ -151,7 +151,7 @@ impl ProgressBar {
     ///
     /// * `status` - The status of the operation
     ///
-    pub fn set_activity(&mut self, activity: &str) {
+    pub fn write_activity(&mut self, activity: &str) {
         match self.format {
             ProgressFormat::Json => {
                 self.progress_value.activity = Some(activity.to_string());
@@ -178,26 +178,6 @@ impl ProgressBar {
             },
             ProgressFormat::Default => {
                 self.console_bar.pb_set_length(len);
-            },
-            ProgressFormat::None => {}
-        }
-    }
-
-    /// Set the position as progress through the items and write the progress
-    ///
-    /// # Arguments
-    ///
-    /// * `pos` - The position as progress through the items
-    ///
-    pub fn set_position(&mut self, pos: u64) {
-        match self.format {
-            ProgressFormat::Json => {
-                self.item_position = pos;
-                self.set_percent_complete();
-                self.write_json();
-            },
-            ProgressFormat::Default => {
-                self.console_bar.pb_set_position(pos);
             },
             ProgressFormat::None => {}
         }

--- a/dsc_lib/src/progress.rs
+++ b/dsc_lib/src/progress.rs
@@ -115,9 +115,6 @@ impl ProgressBar {
         }
 
         self.item_position += delta;
-
-        self.set_percent_complete();
-
         if self.format == ProgressFormat::Json {
             self.write_json();
         } else {
@@ -168,7 +165,6 @@ impl ProgressBar {
         match self.format {
             ProgressFormat::Json => {
                 self.item_count = len;
-                self.set_percent_complete();
             },
             ProgressFormat::Default => {
                 self.console_bar.pb_set_length(len);
@@ -177,21 +173,19 @@ impl ProgressBar {
         }
     }
 
-    fn write_json(&self) {
-        if let Ok(json) = serde_json::to_string(&self.progress_value) {
-            eprintln!("{json}");
-        } else {
-            trace!("{}", t!("progress.failedToSerialize", json = self.progress_value : {:?}));
-        }
-    }
-
-    fn set_percent_complete(&mut self) {
+    fn write_json(&mut self) {
         if self.item_count  > 0 {
             self.progress_value.percent_complete = if self.item_position >= self.item_count {
                 100
             } else {
                 u8::try_from((self.item_position * 100) / self.item_count).unwrap_or(100)
             };
+        }
+
+        if let Ok(json) = serde_json::to_string(&self.progress_value) {
+            eprintln!("{json}");
+        } else {
+            trace!("{}", t!("progress.failedToSerialize", json = self.progress_value : {:?}));
         }
     }
 }

--- a/tools/test_group_resource/Cargo.lock
+++ b/tools/test_group_resource/Cargo.lock
@@ -444,6 +444,7 @@ dependencies = [
  "tree-sitter",
  "tree-sitter-dscexpression",
  "tree-sitter-rust",
+ "uuid",
 ]
 
 [[package]]
@@ -1844,9 +1845,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.12.1"
+version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
+checksum = "ced87ca4be083373936a67f8de945faa23b6b42384bd5b64434850802c6dccd0"
+dependencies = [
+ "getrandom 0.3.1",
+]
 
 [[package]]
 name = "uuid-simd"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Based on discussion with WinGet team, they needed more information in the progress JSON.  Changes:

- Moved all progress code into a single file
- Created `ProgressBar` struct that is used to provide progress instead of calling the crate APIs directly
- Added `None` option to `--progress-format`
- Fixed so that when `json` option is used, no progress is written even when interactive
- Fixed use of writing progress so when undetermined number of items, set to 1 and also ensure it gets incremented so that progress is shown
- Rename some methods and fields to be more clear
- Enhanced `Progress` struct to have a unique `id` which is only useful for JSON representation, but since nested progress is allowed, enables tool consuming the progress to know which one is being updated
- Added `resourceName`, `resourceType`, and `result` optional members to `Progress` so consuming tool can present it to user
- Added `failed` member to `Progress` which is mutually exclusive to `result` if the resource failed
- Removed progress_format parameter from every Discovery function and move to constructor

Example:

`$config_yaml` contains:

```yaml
$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
resources:
- name: Echo 1
  type: Microsoft.DSC.Debug/Echo
  properties:
    output: hello
- name: ErrorTest
  type: Test/ExitCode
  properties:
    exitCode: 8
```

```console
PS> dsc -p json config get -i $config_yaml
{"id":"427c7d5f-0440-4b6a-afb2-01827be21506","activity":"Searching for resources","totalItems":1,"completedItems":0}
{"id":"427c7d5f-0440-4b6a-afb2-01827be21506","activity":"Searching for resources","totalItems":1,"completedItems":1}
{"id":"25aeebd7-a1fd-44c4-847c-d123767cd4db","activity":"Get 'Echo 1'","totalItems":2,"completedItems":0,"resourceName":"Echo 1","resourceType":"Microsoft.DSC.Debug/Echo"}
{"id":"25aeebd7-a1fd-44c4-847c-d123767cd4db","activity":"Get 'Echo 1'","totalItems":2,"completedItems":1,"resourceName":"Echo 1","resourceType":"Microsoft.DSC.Debug/Echo","result":{"actualState":{"output":"hello"}}}
{"id":"25aeebd7-a1fd-44c4-847c-d123767cd4db","activity":"Get 'ErrorTest'","totalItems":2,"completedItems":1,"resourceName":"ErrorTest","resourceType":"Test/ExitCode"}
{"id":"25aeebd7-a1fd-44c4-847c-d123767cd4db","activity":"Get 'ErrorTest'","totalItems":2,"completedItems":2,"resourceName":"ErrorTest","resourceType":"Test/ExitCode","failure":{"message":"Placeholder from manifest for exit code 8","exitCode":8}}
2025-02-20T21:55:07.627550Z ERROR Command: Resource 'dsctest' [exit code 8] manifest description: Placeholder from manifest for exit code 8
```