### PR TITLE
Fix allowing no properties to resource in config

### DIFF
--- a/dsc/tests/dsc_config_get.tests.ps1
+++ b/dsc/tests/dsc_config_get.tests.ps1
@@ -166,4 +166,20 @@ Describe 'dsc config get tests' {
         $result.results[0].result.actualState.output | Should -Be 'hello'
         $LASTEXITCODE | Should -Be 0
     }
+
+    It 'no properties is supported' {
+        $config_yaml = @'
+            $schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+            resources:
+            - name: OS
+              type: Microsoft/OSInfo
+'@
+        $result = dsc config get -i $config_yaml | ConvertFrom-Json
+        $result.hadErrors | Should -BeFalse
+        $result.results.Count | Should -Be 1
+        $result.results[0].Name | Should -Be 'OS'
+        $result.results[0].type | Should -BeExactly 'Microsoft/OSInfo'
+        $result.results[0].result.actualState.family | Should -BeIn @('Windows', 'Linux', 'macOS')
+        $LASTEXITCODE | Should -Be 0
+    }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -151,7 +151,14 @@ fn add_metadata(kind: &Kind, mut properties: Option<Map<String, Value>> ) -> Res
         return Ok(serde_json::to_string(&properties)?);
     }
 
-    Ok(serde_json::to_string(&properties)?)
+    match properties {
+        Some(properties) => {
+            Ok(serde_json::to_string(&properties)?)
+        },
+        _ => {
+            Ok(String::new())
+        }
+    }
 }
 
 fn check_security_context(metadata: Option<&Metadata>) -> Result<(), DscError> {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There was a bug in the code where if `properties` was not present (as it is optional), then the hashmap gets serialized to JSON which ends up as `null` value.  This then is used to valdiate against the resource JSONSchema which would fail.

Fix is to handle the case where there are no properties and instead pass it as an empty string which is already handled by the code.
