### PR TITLE
Add `exporter` kind of resource

### DIFF
--- a/dsc/tests/dsc_args.tests.ps1
+++ b/dsc/tests/dsc_args.tests.ps1
@@ -97,7 +97,7 @@ actualState:
             $resource = $obj | y2j | ConvertFrom-Json
             $resource | Should -Not -BeNullOrEmpty
             $resource.Type | Should -BeLike '*/*'
-            $resource.Kind | Should -BeIn ('resource', 'group', 'importer', 'adapter')
+            $resource.Kind | Should -BeIn ('resource', 'group', 'exporter', 'importer', 'adapter')
         }
     }
 

--- a/dsc/tests/dsc_export.tests.ps1
+++ b/dsc/tests/dsc_export.tests.ps1
@@ -135,4 +135,30 @@ Describe 'resource export tests' {
         $out.metadata.hello | Should -BeExactly 'world'
         $out.metadata.'Microsoft.DSC'.operation | Should -BeExactly 'export'
     }
+
+    It 'Works with Exporter resource' {
+      $yaml = @'
+$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
+resources:
+  - name: export this
+    type: Test/Exporter
+    properties:
+      typeNames:
+        - Test/Foo
+        - Test/Bar
+'@
+      $out = dsc config export -i $yaml | ConvertFrom-Json
+      $LASTEXITCODE | Should -Be 0
+      $out.resources | Should -HaveCount 2
+      $out.resources[0].type | Should -BeExactly 'Test/Foo'
+      $out.resources[0].name | Should -BeExactly 'test'
+      $out.resources[0].properties.psobject.properties | Should -HaveCount 2
+      $out.resources[0].properties.foo | Should -BeExactly 'bar'
+      $out.resources[0].properties.hello | Should -BeExactly 'world'
+      $out.resources[1].type | Should -BeExactly 'Test/Bar'
+      $out.resources[1].name | Should -BeExactly 'test'
+      $out.resources[1].properties.psobject.properties | Should -HaveCount 2
+      $out.resources[1].properties.foo | Should -BeExactly 'bar'
+      $out.resources[1].properties.hello | Should -BeExactly 'world'
+    }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -63,7 +63,7 @@ pub fn add_resource_export_results_to_configuration(resource: &DscResource, adap
     };
 
     if resource.kind == Kind::Exporter {
-        for instance in export_result.actual_state.iter() {
+        for instance in &export_result.actual_state {
             let resource = serde_json::from_value::<Resource>(instance.clone())?;
             conf.resources.push(resource);
         }

--- a/dsc_lib/src/dscresources/resource_manifest.rs
+++ b/dsc_lib/src/dscresources/resource_manifest.rs
@@ -14,6 +14,7 @@ use crate::{dscerror::DscError, schemas::DscRepoSchema};
 #[serde(rename_all = "camelCase")]
 pub enum Kind {
     Adapter,
+    Exporter,
     Group,
     Importer,
     Resource,

--- a/tools/dsctest/dscexporter.dsc.resource.json
+++ b/tools/dsctest/dscexporter.dsc.resource.json
@@ -1,0 +1,26 @@
+{
+    "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+    "type": "Test/Exporter",
+    "version": "0.1.0",
+    "kind": "exporter",
+    "export": {
+        "executable": "dsctest",
+        "args": [
+            "exporter",
+            {
+                "jsonInputArg": "--input",
+                "mandatory": true
+            }
+        ]
+    },
+    "schema": {
+        "command": {
+            "executable": "dsctest",
+            "args": [
+                "schema",
+                "-s",
+                "exporter"
+            ]
+        }
+    }
+}

--- a/tools/dsctest/src/args.rs
+++ b/tools/dsctest/src/args.rs
@@ -10,6 +10,7 @@ pub enum Schemas {
     ExitCode,
     InDesiredState,
     Export,
+    Exporter,
     Sleep,
     Trace,
     WhatIf,
@@ -51,6 +52,11 @@ pub enum SubCommand {
     #[clap(name = "export", about = "Export instances")]
     Export {
         #[clap(name = "input", short, long, help = "The input to the export command as JSON")]
+        input: String,
+    },
+    #[clap(name = "exporter", about = "Exports different types of resources")]
+    Exporter {
+        #[clap(name = "input", short, long, help = "The input to the exit code command as JSON")]
         input: String,
     },
 

--- a/tools/dsctest/src/args.rs
+++ b/tools/dsctest/src/args.rs
@@ -56,7 +56,7 @@ pub enum SubCommand {
     },
     #[clap(name = "exporter", about = "Exports different types of resources")]
     Exporter {
-        #[clap(name = "input", short, long, help = "The input to the exit code command as JSON")]
+        #[clap(name = "input", short, long, help = "The input to the exporter command as JSON")]
         input: String,
     },
 

--- a/tools/dsctest/src/exporter.rs
+++ b/tools/dsctest/src/exporter.rs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct Resource {
+    pub name: String,
+    pub r#type: String,
+    pub properties: Map<String, Value>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Exporter {
+    #[serde(rename = "typeNames")]
+    pub type_names: Vec<String>,
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add a new kind of resource called `exporter` kind.  This resource should only implement `export` method and returns JSONLines that would be a complete instance of a `resource` in the `resources` member of a configuration.

The test exporter resource would emit:

```console
PS> dsctest exporter --input '{"typeNames":["Test/foo","Test/bar"]}'
{"name":"test","type":"Test/foo","properties":{"foo":"bar","hello":"world"}}
{"name":"test","type":"Test/bar","properties":{"foo":"bar","hello":"world"}}
```

This configuration:

```yaml
$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2023/08/config/document.json
resources:
  - name: export this
    type: Test/Exporter
    properties:
      typeNames:
        - Test/Foo
        - Test/Bar
```

results in:

```yaml
$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
contentVersion: 1.0.0
resources:
- type: Test/Foo
  name: test
  properties:
    foo: bar
    hello: world
- type: Test/Bar
  name: test
  properties:
    foo: bar
    hello: world
metadata:
  Microsoft.DSC:
    version: 3.0.0
    operation: export
    executionType: actual
    startDatetime: 2025-03-07T11:48:49.888301-08:00
    endDatetime: 2025-03-07T11:48:49.930490-08:00
    duration: PT0.042189S
    securityContext: restricted
```

A normal `export` from a resource would only provide the contents of `properties`, but an `exporter` needs to fill in the entire resource (and optionally include things like `dependsOn`.

Only the input to an exporter is validated, the output only needs to conform to a proper `resource` within a configuration (so none of the properties are validated against a schema).

## PR Context

Fix https://github.com/PowerShell/DSC/issues/515