### PR TITLE
Fix `registry` resource to allow setting value with no data

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -354,6 +354,7 @@ if (!$SkipBuild) {
 
             if ($IsWindows) {
                 Copy-Item "$path/$binary.exe" $target -ErrorAction Ignore -Verbose
+                Copy-Item "$path/$binary.pdb" $target -ErrorAction Ignore -Verbose
             }
             else {
                 Copy-Item "$path/$binary" $target -ErrorAction Ignore -Verbose

--- a/registry/locales/en-us.toml
+++ b/registry/locales/en-us.toml
@@ -44,9 +44,9 @@ unsupportedValueDataType = "Unsupported registry value data type"
 tracingInitError = "Unable to set global default tracing subscriber. Tracing is disabled."
 debugAttach = "attach debugger to pid %{pid} and press any key to continue"
 debugEventReadError = "Error: Failed to read event: %{err}"
-debugEventUnexpectedError = "Unexpected event: %{e:?}"
+debugEventUnexpectedError = "Unexpected event: %{e}"
 
 [registry_helper]
-whatIfCreateKey = "key: %{subkey} not found, would create it"
+whatIfCreateKey = "Key '%{subkey}' not found, would create it"
 removeErrorKeyNotExist = "Key already does not exist"
 removeDeletingSubKey = "Deleting subkey '%{name}' using %{parent}"

--- a/registry/src/config.rs
+++ b/registry/src/config.rs
@@ -12,6 +12,7 @@ pub enum RegistryValueData {
     DWord(u32),
     MultiString(Vec<String>),
     QWord(u64),
+    None,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]

--- a/registry/src/registry_helper.rs
+++ b/registry/src/registry_helper.rs
@@ -72,10 +72,7 @@ impl RegistryHelper {
             Ok(Registry {
                 key_path: self.config.key_path.clone(),
                 value_name: Some(value_name.clone()),
-                value_data: match value {
-                    Data::None => None,
-                    _ => Some(convert_reg_value(&value)?)
-                },
+                value_data: convert_reg_value(&value)?,
                 ..Default::default()
             })
         } else {
@@ -169,10 +166,7 @@ impl RegistryHelper {
             if self.what_if {
                 return Ok(Some(Registry {
                     key_path: self.config.key_path.clone(),
-                    value_data: match data {
-                        Data::None => None,
-                        _ => Some(convert_reg_value(&data)?),
-                    },
+                    value_data: convert_reg_value(&data)?,
                     value_name: self.config.value_name.clone(),
                     metadata: if what_if_metadata.is_empty() { None } else { Some(Metadata { what_if: Some(what_if_metadata) })},
                     ..Default::default()
@@ -323,18 +317,18 @@ fn get_parent_key_path(key_path: &str) -> &str {
     }
 }
 
-fn convert_reg_value(value: &Data) -> Result<RegistryValueData, RegistryError> {
+fn convert_reg_value(value: &Data) -> Result<Option<RegistryValueData>, RegistryError> {
     match value {
-        Data::String(s) => Ok(RegistryValueData::String(s.to_string_lossy())),
-        Data::ExpandString(s) => Ok(RegistryValueData::ExpandString(s.to_string_lossy())),
-        Data::Binary(b) => Ok(RegistryValueData::Binary(b.clone())),
-        Data::U32(d) => Ok(RegistryValueData::DWord(*d)),
+        Data::String(s) => Ok(Some(RegistryValueData::String(s.to_string_lossy()))),
+        Data::ExpandString(s) => Ok(Some(RegistryValueData::ExpandString(s.to_string_lossy()))),
+        Data::Binary(b) => Ok(Some(RegistryValueData::Binary(b.clone()))),
+        Data::U32(d) => Ok(Some(RegistryValueData::DWord(*d))),
         Data::MultiString(m) => {
             let m: Vec<String> = m.iter().map(|s| s.to_string_lossy()).collect();
-            Ok(RegistryValueData::MultiString(m))
+            Ok(Some(RegistryValueData::MultiString(m)))
         },
-        Data::U64(q) => Ok(RegistryValueData::QWord(*q)),
-        Data::None => Ok(RegistryValueData::None),
+        Data::U64(q) => Ok(Some(RegistryValueData::QWord(*q))),
+        Data::None => Ok(None),
         _ => Err(RegistryError::UnsupportedValueDataType)
     }
 }

--- a/registry/src/registry_helper.rs
+++ b/registry/src/registry_helper.rs
@@ -125,7 +125,7 @@ impl RegistryHelper {
                 None => &RegistryValueData::None,
             };
 
-            let Ok(value_name) = U16CString::from_str(&value_name) else {
+            let Ok(value_name) = U16CString::from_str(value_name) else {
                 return self.handle_error_or_what_if(RegistryError::Utf16Conversion("valueName".to_string()));
             };
 

--- a/registry/tests/registry.config.set.tests.ps1
+++ b/registry/tests/registry.config.set.tests.ps1
@@ -91,6 +91,12 @@ Describe 'registry config set tests' {
         $out.results[0].result.afterState.valueName | Should -BeExactly 'Test'
         $out.results[0].result.afterState.valueData | Should -BeNullOrEmpty
 
+        $out = dsc config get -i $configYaml | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].result.actualState.keyPath | Should -BeExactly 'HKCU\1'
+        $out.results[0].result.actualState.valueName | Should -BeExactly 'Test'
+        $out.results[0].result.actualState.valueData | Should -BeNullOrEmpty
+
         Remove-Item -Path 'HKCU:\1' -Recurse -ErrorAction Ignore
     }
 }

--- a/registry/tests/registry.config.set.tests.ps1
+++ b/registry/tests/registry.config.set.tests.ps1
@@ -72,4 +72,25 @@ Describe 'registry config set tests' {
 
         Get-Item -Path 'HKCU:\1\2' -ErrorAction Ignore | Should -BeNullOrEmpty
     }
+
+    It 'Can set value without data' -Skip:(!$IsWindows) {
+        $configYaml = @'
+            $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+            resources:
+            - name: Key
+              type: Microsoft.Windows/Registry
+              properties:
+                keyPath: 'HKCU\1'
+                valueName: Test
+                _exist: true            
+'@
+
+        $out = dsc config set -i $configYaml | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results[0].result.afterState.keyPath | Should -BeExactly 'HKCU\1'
+        $out.results[0].result.afterState.valueName | Should -BeExactly 'Test'
+        $out.results[0].result.afterState.valueData | Should -BeNullOrEmpty
+
+        Remove-Item -Path 'HKCU:\1' -Recurse -ErrorAction Ignore
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Allow setting registry value without data by using RZ_NONE type, however, the `valueData` member that is returned won't be present when RZ_NONE is used.
- Fix issue in build script that doesn't copy symbols to bin folder making it so you can't debug
- Fix small issues in i18n text so that it gets rendered correctly
- Fixed issue in helper function where if you have just the hive and one subkey (that doesn't exist yet), it incorrectly returns nothing for subkeys and thus doesn't get created
- Add tests

## PR Context

Fix https://github.com/PowerShell/DSC/issues/683