### PR TITLE
Use only `tar` to create tar.gz archive

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -716,20 +716,21 @@ if ($packageType -eq 'msixbundle') {
         $architecture
     }
 
-    $packageName = "DSC-$productVersion-$productArchitecture.tar"
+    Write-Verbose -Verbose "Creating tar.gz file"
+    $packageName = "DSC-$productVersion-$productArchitecture.tar.gz"
     $tarFile = Join-Path $PSScriptRoot 'bin' $packageName
-    tar cvf $tarFile -C $tgzTarget .
+    tar -czvf $tarFile -C $tgzTarget .
     if ($LASTEXITCODE -ne 0) {
-        throw "Failed to create tar file"
+        throw "Failed to create tar.gz file"
     }
-    Write-Host -ForegroundColor Green "`nTar file is created at $tarFile"
 
-    $gzFile = "$tarFile.gz"
-    gzip -c $tarFile > $gzFile
-    if ($LASTEXITCODE -ne 0) {
-        throw "Failed to create gz file"
+    # check it's valid
+    $out = file $tarFile
+    if ($out -notmatch 'gzip compressed data') {
+        throw "Invalid tar.gz file"
     }
-    Write-Host -ForegroundColor Green "`nGz file is created at $gzFile"
+
+    Write-Host -ForegroundColor Green "`ntar.gz file is created at $tarFile"
 }
 
 $env:RUST_BACKTRACE=1


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Previously, the build script used tar and gzip separately to create the tar.gz archive. However, for some reason on Linux ARM64 this results in an invalid archive.

Change to just using tar to also perform the gzip compression and add a test afterwards to verify.