### PR TITLE
Fix not parsing expressions for Group resources

### DIFF
--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -248,9 +248,18 @@ impl Configurator {
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Get '{}'", resource.name).as_str());
-            let properties = self.invoke_property_expressions(resource.properties.as_ref())?;
-            let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type) else {
+            let discovery = &self.discovery.clone();
+            let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
+            };
+            let properties = match &dsc_resource.kind {
+                Kind::Group => {
+                    // if Group resource, we leave it to the resource to handle expressions
+                    resource.properties.clone()
+                },
+                _ => {
+                    self.invoke_property_expressions(resource.properties.as_ref())?
+                },
             };
             debug!("resource_type {}", &resource.resource_type);
             let filter = add_metadata(&dsc_resource.kind, properties)?;
@@ -325,9 +334,18 @@ impl Configurator {
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Set '{}'", resource.name).as_str());
-            let properties = self.invoke_property_expressions(resource.properties.as_ref())?;
-            let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type) else {
+            let discovery = &self.discovery.clone();
+            let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
+            };
+            let properties = match &dsc_resource.kind {
+                Kind::Group => {
+                    // if Group resource, we leave it to the resource to handle expressions
+                    resource.properties.clone()
+                },
+                _ => {
+                    self.invoke_property_expressions(resource.properties.as_ref())?
+                },
             };
             debug!("resource_type {}", &resource.resource_type);
 
@@ -469,9 +487,18 @@ impl Configurator {
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Test '{}'", resource.name).as_str());
-            let properties = self.invoke_property_expressions(resource.properties.as_ref())?;
-            let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type) else {
+            let discovery = &self.discovery.clone();
+            let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
+            };
+            let properties = match &dsc_resource.kind {
+                Kind::Group => {
+                    // if Group resource, we leave it to the resource to handle expressions
+                    resource.properties.clone()
+                },
+                _ => {
+                    self.invoke_property_expressions(resource.properties.as_ref())?
+                },
             };
             debug!("resource_type {}", &resource.resource_type);
             let expected = add_metadata(&dsc_resource.kind, properties)?;
@@ -544,9 +571,18 @@ impl Configurator {
         for resource in &resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Export '{}'", resource.name).as_str());
-            let properties = self.invoke_property_expressions(resource.properties.as_ref())?;
-            let Some(dsc_resource) = self.discovery.find_resource(&resource.resource_type) else {
+            let discovery = &self.discovery.clone();
+            let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type.clone()));
+            };
+            let properties = match &dsc_resource.kind {
+                Kind::Group => {
+                    // if Group resource, we leave it to the resource to handle expressions
+                    resource.properties.clone()
+                },
+                _ => {
+                    self.invoke_property_expressions(resource.properties.as_ref())?
+                },
             };
             let input = add_metadata(&dsc_resource.kind, properties)?;
             trace!("{}", t!("configure.mod.exportInput", input = input));

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -245,10 +245,10 @@ impl Configurator {
         let mut result = ConfigurationGetResult::new();
         let resources = get_resource_invocation_order(&self.config, &mut self.statement_parser, &self.context)?;
         let mut progress = ProgressBar::new(resources.len() as u64, self.progress_format)?;
+        let discovery = &self.discovery.clone();
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Get '{}'", resource.name).as_str());
-            let discovery = &self.discovery.clone();
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
@@ -331,10 +331,10 @@ impl Configurator {
         let mut result = ConfigurationSetResult::new();
         let resources = get_resource_invocation_order(&self.config, &mut self.statement_parser, &self.context)?;
         let mut progress = ProgressBar::new(resources.len() as u64, self.progress_format)?;
+        let discovery = &self.discovery.clone();
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Set '{}'", resource.name).as_str());
-            let discovery = &self.discovery.clone();
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
@@ -484,10 +484,10 @@ impl Configurator {
         let mut result = ConfigurationTestResult::new();
         let resources = get_resource_invocation_order(&self.config, &mut self.statement_parser, &self.context)?;
         let mut progress = ProgressBar::new(resources.len() as u64, self.progress_format)?;
+        let discovery = &self.discovery.clone();
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Test '{}'", resource.name).as_str());
-            let discovery = &self.discovery.clone();
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
@@ -568,10 +568,10 @@ impl Configurator {
 
         let mut progress = ProgressBar::new(self.config.resources.len() as u64, self.progress_format)?;
         let resources = self.config.resources.clone();
+        let discovery = &self.discovery.clone();
         for resource in &resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Export '{}'", resource.name).as_str());
-            let discovery = &self.discovery.clone();
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type.clone()));
             };

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -9,6 +9,7 @@ use crate::{dscresources::dscresource::DscResource, dscerror::DscError, progress
 use std::collections::BTreeMap;
 use tracing::error;
 
+#[derive(Clone)]
 pub struct Discovery {
     pub resources: BTreeMap<String, DscResource>,
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

THe previous logic was to recursively parse and invoke expressions to handle the case of a deeply nested object that used an expression.  The problem is that when a Group resource is encountered, this logic would still apply and fail because execution had not happened yet.

The fix is for the configuration to NOT parse and invoke expressions if the resource kind is a Group as when that Group resource is invoked, it will handle parsing and invoking expressions it contains within its scope.

As part of the fix, need to clone the `discovery` member to invoke it to get the `DscResource` to find out the kind as this would be an immutable borrow of `self` which would cause the later mutable borrow of `self` to fail.  So need to derive `clone()` for `Discovery` for this to work.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/692