### PR TITLE
Add `format()` experimental function

### DIFF
--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -559,7 +559,7 @@ dependencies = [
  "ctrlc",
  "dsc_lib",
  "indicatif",
- "jsonschema",
+ "jsonschema 0.29.0",
  "path-absolutize",
  "rust-i18n",
  "schemars",
@@ -584,10 +584,11 @@ dependencies = [
  "clap",
  "derive_builder",
  "indicatif",
- "jsonschema",
+ "jsonschema 0.30.0",
  "linked-hash-map",
  "num-traits",
  "regex",
+ "rt-format",
  "rust-i18n",
  "schemars",
  "security_context_lib",
@@ -1066,7 +1067,33 @@ dependencies = [
  "num-cmp",
  "once_cell",
  "percent-encoding",
- "referencing",
+ "referencing 0.29.0",
+ "regex-syntax 0.8.5",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+dependencies = [
+ "ahash",
+ "base64",
+ "bytecount",
+ "email_address",
+ "fancy-regex 0.14.0",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing 0.30.0",
+ "regex",
  "regex-syntax 0.8.5",
  "serde",
  "serde_json",
@@ -1493,6 +1520,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "referencing"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1535,6 +1576,16 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rt-format"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45087cee619d316fa4bd1675494acff4a5eaa0892fa53bc364bd246f13e452e2"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "rust-i18n"
@@ -2262,9 +2313,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
 ]

--- a/dsc_lib/Cargo.lock
+++ b/dsc_lib/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "linked-hash-map",
  "num-traits",
  "regex",
+ "rt-format",
  "rust-i18n",
  "schemars",
  "security_context_lib",
@@ -879,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c59cb1733c34377b6067a0419befd7f25073c5249ec3b0614a482bf499e1df5"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
 dependencies = [
  "ahash",
  "base64",
@@ -892,9 +893,11 @@ dependencies = [
  "idna",
  "itoa",
  "num-cmp",
+ "num-traits",
  "once_cell",
  "percent-encoding",
  "referencing",
+ "regex",
  "regex-syntax",
  "serde",
  "serde_json",
@@ -1216,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce52678d53e5ee37e4af0a9036ca834d0cd34b33c82457c6b06a24f8d783344"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -1256,6 +1259,16 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rt-format"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45087cee619d316fa4bd1675494acff4a5eaa0892fa53bc364bd246f13e452e2"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "rust-i18n"
@@ -1605,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.1"
+version = "1.44.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "492a604e2fd7f814268a378409e6c92b5525d747d10db9a229723f55a417958c"
+checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
 dependencies = [
  "backtrace",
  "bytes",
@@ -1840,9 +1853,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
 ]

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -16,10 +16,11 @@ chrono = "0.4"
 clap = { version = "4.5", features = ["derive"] }
 derive_builder ="0.20"
 indicatif = "0.17"
-jsonschema = { version = "0.29", default-features = false }
+jsonschema = { version = "0.30", default-features = false }
 linked-hash-map = "0.5"
 num-traits = "0.2"
 regex = "1.11"
+rt-format = "0.3"
 rust-i18n = { version = "3.1" }
 # reqwest = { version = "0.12.8", features = ["native-tls"], default-features = false }
 schemars = { version = "0.8", features = ["preserve_order"] }
@@ -29,13 +30,13 @@ serde_yaml = { version = "0.9" }
 thiserror = "2.0"
 security_context_lib = { path = "../security_context_lib" }
 semver = "1.0"
-tokio = { version = "1.43", features = ["full"] }
+tokio = { version = "1.44", features = ["full"] }
 tracing = "0.1"
 tracing-indicatif = { version = "0.3" }
 tree-sitter = "0.25"
 tree-sitter-rust = "0.24"
 tree-sitter-dscexpression = { path = "../tree-sitter-dscexpression" }
-uuid = { version = "1.15", features = ["v4"] }
+uuid = { version = "1.16", features = ["v4"] }
 which = "7.0"
 
 [dev-dependencies]

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -201,6 +201,7 @@ notFound = "Environment variable not found"
 conditionNotBoolean = "Condition is not a boolean"
 
 [functions.format]
+experimental = "`format()` function is experimental"
 formatInvalid = "First `format()` argument must be a string"
 numberTooLarge = "Number is too large"
 invalidArgType = "Unsupported argument type"

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -200,6 +200,12 @@ notFound = "Environment variable not found"
 [functions.if]
 conditionNotBoolean = "Condition is not a boolean"
 
+[functions.format]
+formatInvalid = "First `format()` argument must be a string"
+numberTooLarge = "Number is too large"
+invalidArgType = "Unsupported argument type"
+invalidFormatString = "Invalid format string"
+
 [functions.int]
 invalidInput = "invalid input string"
 parseStringError = "unable to parse string to int"

--- a/dsc_lib/src/functions/format.rs
+++ b/dsc_lib/src/functions/format.rs
@@ -4,9 +4,10 @@
 use crate::DscError;
 use crate::configure::context::Context;
 use crate::functions::{AcceptedArgKind, Function};
-use rt_format::{Format, FormatArgument, ParsedFormat, Specifier};
+use rt_format::{Format as RtFormat, FormatArgument, ParsedFormat, Specifier};
 use rust_i18n::t;
 use serde_json::Value;
+use std::fmt;
 use std::fmt::{Error, Formatter, Write};
 
 impl FormatArgument for Value {
@@ -108,51 +109,10 @@ mod tests {
     }
 
     #[test]
-    fn strings_with_spaces() {
+    fn numbers_as_hex() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a ', ' ', ' b')]", &Context::new()).unwrap();
-        assert_eq!(result, "a   b");
+        let result = parser.parse_and_execute("[format('{0:x} {0:X}', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "c D");
     }
 
-    #[test]
-    fn arrays() {
-        let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat(createArray('a','b'), createArray('c','d'))]", &Context::new()).unwrap();
-        assert_eq!(result.to_string(), r#"["a","b","c","d"]"#);
-    }
-
-    #[test]
-    fn string_and_numbers() {
-        let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a', 1)]", &Context::new());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn nested() {
-        let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]", &Context::new()).unwrap();
-        assert_eq!(result, "abcd");
-    }
-
-    #[test]
-    fn invalid_one_parameter() {
-        let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a')]", &Context::new());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn string_and_array() {
-        let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat('a', createArray('b','c'))]", &Context::new());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn array_and_string() {
-        let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[concat(createArray('a','b'), 'c')]", &Context::new());
-        assert!(result.is_err());
-    }
 }

--- a/dsc_lib/src/functions/format.rs
+++ b/dsc_lib/src/functions/format.rs
@@ -1,0 +1,158 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::DscError;
+use crate::configure::context::Context;
+use crate::functions::{AcceptedArgKind, Function};
+use rt_format::{Format, FormatArgument, ParsedFormat, Specifier};
+use rust_i18n::t;
+use serde_json::Value;
+use std::fmt::{Error, Formatter, Write};
+
+impl FormatArgument for Value {
+    fn supports_format(&self, spec: &Specifier) -> bool {
+        match self {
+            Value::Boolean(_) | Value::String(_) | Value::Number(_) => true,
+            _ => false,
+        }
+    }
+
+    fn fmt_display(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Value::Boolean(b) => write!(f, "{}", b),
+            Value::String(s) => write!(f, "{}", s),
+            Value::Number(n) => write!(f, "{}", n),
+            _ => Err(fmt::Error),
+        }
+    }
+
+    fn fmt_lower_hex(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Value::Number(n) => write!(f, "{:x}", n.as_i64().unwrap_or_default()),
+            _ => Err(fmt::Error),
+        }
+    }
+
+    fn fmt_upper_hex(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Value::Number(n) => write!(f, "{:X}", n.as_i64().unwrap_or_default()),
+            _ => Err(fmt::Error),
+        }
+    }
+
+    fn fmt_binary(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Value::Number(n) => write!(f, "{:b}", n.as_i64().unwrap_or_default()),
+            _ => Err(fmt::Error),
+        }
+    }
+
+    fn fmt_octal(&self, f: &mut Formatter) -> std::fmt::Result {
+        match self {
+            Value::Number(n) => write!(f, "{:o}", n.as_i64().unwrap_or_default()),
+            _ => Err(fmt::Error),
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct Format {}
+
+impl Function for Format {
+    fn min_args(&self) -> usize {
+        2
+    }
+
+    fn max_args(&self) -> usize {
+        usize::MAX
+    }
+
+    fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
+        vec![AcceptedArgKind::Boolean, AcceptedArgKind::String, AcceptedArgKind::Number]
+    }
+
+    fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
+        let mut string_result = String::new();
+        let Ok(format_string) = args[0].as_str() else {
+            return Err(DscError::Parser("First `format()` argument must be a string".to_string()));
+        };
+        for value in &args[1..] {
+            if let Some(parsed_format) = ParsedFormat::parse(format_string) {
+                let mut formatted_string = String::new();
+                for specifier in parsed_format.specifiers() {
+                    if let Some(arg) = args.get(specifier.index()) {
+                        formatted_string.push_str(&arg.to_string());
+                    } else {
+                        return Err(DscError::Parser("Invalid format specifier".to_string()));
+                    }
+                }
+                string_result.push_str(&formatted_string);
+            } else {
+                return Err(DscError::Parser("Invalid format string".to_string()));
+            }
+        }
+        Ok(Value::String(string_result))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::configure::context::Context;
+    use crate::parser::Statement;
+
+    #[test]
+    fn position() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0} - {1}', 'hello', 2)]", &Context::new()).unwrap();
+        assert_eq!(result, "hello - 2");
+    }
+
+    #[test]
+    fn strings_with_spaces() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a ', ' ', ' b')]", &Context::new()).unwrap();
+        assert_eq!(result, "a   b");
+    }
+
+    #[test]
+    fn arrays() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat(createArray('a','b'), createArray('c','d'))]", &Context::new()).unwrap();
+        assert_eq!(result.to_string(), r#"["a","b","c","d"]"#);
+    }
+
+    #[test]
+    fn string_and_numbers() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a', 1)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn nested() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a', concat('b', 'c'), 'd')]", &Context::new()).unwrap();
+        assert_eq!(result, "abcd");
+    }
+
+    #[test]
+    fn invalid_one_parameter() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a')]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn string_and_array() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat('a', createArray('b','c'))]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn array_and_string() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[concat(createArray('a','b'), 'c')]", &Context::new());
+        assert!(result.is_err());
+    }
+}

--- a/dsc_lib/src/functions/format.rs
+++ b/dsc_lib/src/functions/format.rs
@@ -7,6 +7,7 @@ use crate::functions::{AcceptedArgKind, Function};
 use rt_format::{Format as RtFormat, FormatArgument, ParsedFormat, argument::NoNamedArguments};
 use rust_i18n::t;
 use serde_json::Value;
+use tracing::warn;
 
 #[derive(Debug, PartialEq)]
 enum Variant {
@@ -95,6 +96,7 @@ impl Function for Format {
     }
 
     fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
+        warn!("{}", t!("functions.format.experimental"));
         let Some(format_string) = args[0].as_str() else {
             return Err(DscError::Parser(t!("functions.format.formatInvalid").to_string()));
         };

--- a/dsc_lib/src/functions/format.rs
+++ b/dsc_lib/src/functions/format.rs
@@ -4,54 +4,76 @@
 use crate::DscError;
 use crate::configure::context::Context;
 use crate::functions::{AcceptedArgKind, Function};
-use rt_format::{Format as RtFormat, FormatArgument, ParsedFormat, Specifier};
+use rt_format::{Format as RtFormat, FormatArgument, ParsedFormat, argument::NoNamedArguments};
 use rust_i18n::t;
 use serde_json::Value;
-use std::fmt;
-use std::fmt::{Error, Formatter, Write};
 
-impl FormatArgument for Value {
-    fn supports_format(&self, spec: &Specifier) -> bool {
+#[derive(Debug, PartialEq)]
+enum Variant {
+    Boolean(bool),
+    Number(i64),
+    String(String),
+}
+
+impl FormatArgument for Variant {
+    fn supports_format(&self, specifier: &rt_format::Specifier) -> bool {
         match self {
-            Value::Boolean(_) | Value::String(_) | Value::Number(_) => true,
-            _ => false,
+            Variant::Boolean(_) | Variant::String(_)=> matches!(specifier.format, RtFormat::Display),
+            Variant::Number(_) => matches!(specifier.format, RtFormat::Display | RtFormat::Binary | RtFormat::Octal | RtFormat::LowerHex | RtFormat::UpperHex | RtFormat::Debug | RtFormat::LowerExp | RtFormat::UpperExp),
         }
     }
 
-    fn fmt_display(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt_display(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Value::Boolean(b) => write!(f, "{}", b),
-            Value::String(s) => write!(f, "{}", s),
-            Value::Number(n) => write!(f, "{}", n),
-            _ => Err(fmt::Error),
+            Variant::Boolean(value) => write!(f, "{value}"),
+            Variant::Number(value) => write!(f, "{value}"),
+            Variant::String(value) => write!(f, "{value}"),
         }
     }
 
-    fn fmt_lower_hex(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt_octal(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Value::Number(n) => write!(f, "{:x}", n.as_i64().unwrap_or_default()),
-            _ => Err(fmt::Error),
+            Variant::Number(value) => write!(f, "{value:o}"),
+            _ => Err(std::fmt::Error),
         }
     }
 
-    fn fmt_upper_hex(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt_lower_hex(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Value::Number(n) => write!(f, "{:X}", n.as_i64().unwrap_or_default()),
-            _ => Err(fmt::Error),
+            Variant::Number(value) => write!(f, "{value:x}"),
+            _ => Err(std::fmt::Error),
         }
     }
 
-    fn fmt_binary(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt_upper_hex(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Value::Number(n) => write!(f, "{:b}", n.as_i64().unwrap_or_default()),
-            _ => Err(fmt::Error),
+            Variant::Number(value) => write!(f, "{value:X}"),
+            _ => Err(std::fmt::Error),
         }
     }
 
-    fn fmt_octal(&self, f: &mut Formatter) -> std::fmt::Result {
+    fn fmt_binary(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
-            Value::Number(n) => write!(f, "{:o}", n.as_i64().unwrap_or_default()),
-            _ => Err(fmt::Error),
+            Variant::Number(value) => write!(f, "{value:b}"),
+            _ => Err(std::fmt::Error),
+        }
+    }
+
+    fn fmt_debug(&self, _f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        Err(std::fmt::Error)
+    }
+
+    fn fmt_lower_exp(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Variant::Number(value) => write!(f, "{value:e}"),
+            _ => Err(std::fmt::Error),
+        }
+    }
+
+    fn fmt_upper_exp(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Variant::Number(value) => write!(f, "{value:E}"),
+            _ => Err(std::fmt::Error),
         }
     }
 }
@@ -69,29 +91,33 @@ impl Function for Format {
     }
 
     fn accepted_arg_types(&self) -> Vec<AcceptedArgKind> {
-        vec![AcceptedArgKind::Boolean, AcceptedArgKind::String, AcceptedArgKind::Number]
+        vec![AcceptedArgKind::Boolean, AcceptedArgKind::Number, AcceptedArgKind::String]
     }
 
     fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
-        let mut string_result = String::new();
-        let Ok(format_string) = args[0].as_str() else {
-            return Err(DscError::Parser("First `format()` argument must be a string".to_string()));
+        let Some(format_string) = args[0].as_str() else {
+            return Err(DscError::Parser(t!("functions.format.formatInvalid").to_string()));
         };
+        let mut position_args =     Vec::new();
         for value in &args[1..] {
-            if let Some(parsed_format) = ParsedFormat::parse(format_string) {
-                let mut formatted_string = String::new();
-                for specifier in parsed_format.specifiers() {
-                    if let Some(arg) = args.get(specifier.index()) {
-                        formatted_string.push_str(&arg.to_string());
+            let arg = match value {
+                Value::Bool(b) => Variant::Boolean(*b),
+                Value::Number(n) => {
+                    if let Some(i) = n.as_i64() {
+                        Variant::Number(i)
                     } else {
-                        return Err(DscError::Parser("Invalid format specifier".to_string()));
+                        return Err(DscError::Parser(t!("functions.format.numberTooLarge").to_string()));
                     }
                 }
-                string_result.push_str(&formatted_string);
-            } else {
-                return Err(DscError::Parser("Invalid format string".to_string()));
-            }
+                Value::String(s) => Variant::String(s.clone()),
+                _ => return Err(DscError::Parser(t!("functions.format.invalidArgType").to_string())),
+            };
+            position_args.push(arg);
         }
+        let string_result = match ParsedFormat::parse(format_string, &position_args, &NoNamedArguments) {
+            Ok(parsed_format) => format!("{parsed_format}"),
+            Err(_e) => return Err(DscError::Parser(t!("functions.format.invalidFormatString").to_string())),
+        };
         Ok(Value::String(string_result))
     }
 }
@@ -104,15 +130,154 @@ mod tests {
     #[test]
     fn position() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[format('{0} - {1}', 'hello', 2)]", &Context::new()).unwrap();
-        assert_eq!(result, "hello - 2");
+        let result = parser.parse_and_execute("[format('world {0} - {1}', 'hello', 2)]", &Context::new()).unwrap();
+        assert_eq!(result, "world hello - 2");
+    }
+
+    #[test]
+    fn reverse_position() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('two{1} - {0}world', 'hello', 2)]", &Context::new()).unwrap();
+        assert_eq!(result, "two2 - helloworld");
+    }
+
+    #[test]
+    fn repeated_position() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0} - {0}{1}', 'hello', 2)]", &Context::new()).unwrap();
+        assert_eq!(result, "hello - hello2");
     }
 
     #[test]
     fn numbers_as_hex() {
         let mut parser = Statement::new().unwrap();
-        let result = parser.parse_and_execute("[format('{0:x} {0:X}', 12, 13)]", &Context::new()).unwrap();
-        assert_eq!(result, "c D");
+        let result = parser.parse_and_execute("[format('{0:x} = {1:X}', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "c = D");
     }
 
+    #[test]
+    fn numbers_as_octal() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:o} == {1:o}', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "14 == 15");
+    }
+
+    #[test]
+    fn numbers_as_binary() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:b} = {1:b}', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "1100 = 1101");
+    }
+
+    #[test]
+    fn numbers_as_exp() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:e} = {1:E}', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "1.2e1 = 1.3E1");
+    }
+
+    #[test]
+    fn numbers_as_display_just_one() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello {0} there', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "hello 12 there");
+    }
+
+    #[test]
+    fn string_as_octal() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:o} = {1:O}', 'hello', 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bool_as_octal() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:o} = {1:O}', true, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn string_as_hex() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:x} = {1:X}', 'hello', 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bool_as_hex() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{0:x} = {1:X}', true, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn string_as_binary() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{1:b} = {0:B}', 'hello', 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bool_as_binary() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{1:b} = {0:B}', true, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn string_as_exp() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{1:e} = {0:E}', 'hello', 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn bool_as_exp() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('{1:e} = {0:E}', true, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn args_out_of_bounds() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello {1} {2} there', 12, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_closing_brace() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello {0 there', 12, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_opening_brace() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello 0} there', 12, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_format_option() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello {0:invalid} there', 12, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn invalid_index_syntax() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello {0;x} there', 12, 13)]", &Context::new());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn missing_format_type() {
+        let mut parser = Statement::new().unwrap();
+        let result = parser.parse_and_execute("[format('hello {0:} there', 12, 13)]", &Context::new()).unwrap();
+        assert_eq!(result, "hello 12 there");
+    }
 }

--- a/dsc_lib/src/functions/mod.rs
+++ b/dsc_lib/src/functions/mod.rs
@@ -16,6 +16,7 @@ pub mod div;
 pub mod envvar;
 pub mod equals;
 pub mod r#if;
+pub mod format;
 pub mod int;
 pub mod max;
 pub mod min;
@@ -77,6 +78,7 @@ impl FunctionDispatcher {
         functions.insert("envvar".to_string(), Box::new(envvar::Envvar{}));
         functions.insert("equals".to_string(), Box::new(equals::Equals{}));
         functions.insert("if".to_string(), Box::new(r#if::If{}));
+        functions.insert("format".to_string(), Box::new(format::Format{}));
         functions.insert("int".to_string(), Box::new(int::Int{}));
         functions.insert("max".to_string(), Box::new(max::Max{}));
         functions.insert("min".to_string(), Box::new(min::Min{}));

--- a/tools/test_group_resource/Cargo.lock
+++ b/tools/test_group_resource/Cargo.lock
@@ -436,6 +436,7 @@ dependencies = [
  "linked-hash-map",
  "num-traits",
  "regex",
+ "rt-format",
  "rust-i18n",
  "schemars",
  "security_context_lib",
@@ -879,9 +880,9 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c59cb1733c34377b6067a0419befd7f25073c5249ec3b0614a482bf499e1df5"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
 dependencies = [
  "ahash",
  "base64",
@@ -892,9 +893,11 @@ dependencies = [
  "idna",
  "itoa",
  "num-cmp",
+ "num-traits",
  "once_cell",
  "percent-encoding",
  "referencing",
+ "regex",
  "regex-syntax",
  "serde",
  "serde_json",
@@ -1216,9 +1219,9 @@ dependencies = [
 
 [[package]]
 name = "referencing"
-version = "0.29.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce52678d53e5ee37e4af0a9036ca834d0cd34b33c82457c6b06a24f8d783344"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
 dependencies = [
  "ahash",
  "fluent-uri",
@@ -1256,6 +1259,16 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rt-format"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45087cee619d316fa4bd1675494acff4a5eaa0892fa53bc364bd246f13e452e2"
+dependencies = [
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "rust-i18n"
@@ -1851,9 +1864,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
  "getrandom 0.3.1",
 ]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add experimental `format()` function.  Use of this function will emit a warning as it doesn't currently support all the same format options as dotnet which is what ARM is based on.

Also updated versions of some crates.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/767