### PR TITLE
fix: win_psDscAdapter targeted module cache refreshes

### DIFF
--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -75,7 +75,7 @@ function Invoke-DscCacheRefresh {
             else {
                 "Checking cache for stale PSModulePath" | Write-DscTrace
 
-                $m = $env:PSModulePath -split [IO.Path]::PathSeparator | % { Get-ChildItem -Directory -Path $_ -Depth 1 -ea SilentlyContinue }
+                $m = $env:PSModulePath -split [IO.Path]::PathSeparator | ForEach-Object { Get-ChildItem -Directory -Path $_ -Depth 1 -ErrorAction Ignore }
 
                 $hs_cache = [System.Collections.Generic.HashSet[string]]($cache.PSModulePaths)
                 $hs_live = [System.Collections.Generic.HashSet[string]]($m.FullName)
@@ -106,20 +106,15 @@ function Invoke-DscCacheRefresh {
 
                                 if (-not ($file_LastWriteTime.Equals($cache_LastWriteTime))) {
                                     "Detected stale cache entry '$($_.Name)'" | Write-DscTrace
-                                    $refreshCache = $true
+                                    $namedModules.Add($cacheEntry.DscResourceInfo.ModuleName)
                                     break
                                 }
                             }
                             else {
                                 "Detected non-existent cache entry '$($_.Name)'" | Write-DscTrace
-                                $refreshCache = $true
+                                $namedModules.Add($cacheEntry.DscResourceInfo.ModuleName)
                                 break
                             }
-                        }
-
-                        if ($refreshCache) {
-                            $namedModules.Add($cacheEntry.DscResourceInfo.ModuleName)
-                            $refreshCache = $false
                         }
                     }
                 }


### PR DESCRIPTION
# PR Summary

Fixes #745 by ensuring a full `Get-DscResource` refresh is triggered when `$env:PSModulePath` changes.

Also reorders the cache staleness checks to prioritize detecting `PSModulePath` differences before evaluating stale resource entries.

Fixes #807 by ensuring a full cache refresh is triggered when cache is cold. It now builds a list `$namedModules` which determines whether targeted module refresh occurs, using this list if it does.

## PR Context

When `$env:PSModulePath` changes, the cache may be rebuilt incorrectly if `$Module` remains set. The module environment may have changed outside the scope defined by `$Module`, but the refresh will only consider the provided modules.

When a module is deleted, the stale entries check will detect the change and initiate a cache refresh, skipping the check for stale paths. If the removed module is not in `$Module`, the stale entries get captured in `$existingDscResourceCacheEntries` and remain in the refreshed cache.

A change in `PSModulePath` should result in a full cache refresh and take priority over stale resource entries.
