### PR TITLE
Fix exporting an adapted resource

### DIFF
--- a/powershell-adapter/Tests/TestAdapter/testadapter.resource.ps1
+++ b/powershell-adapter/Tests/TestAdapter/testadapter.resource.ps1
@@ -59,8 +59,8 @@ switch ($Operation) {
     }
     'Export' {
         @{result = @(
-            @{name = $inputobj.resources.name; type = $inputobj.resources.type; properties = @{'TestCaseId' = 1; 'Input' = ''}},
-            @{name = $inputobj.resources.name; type = $inputobj.resources.type; properties = @{'TestCaseId' = 2; 'Input' = ''}}
+            @{'TestCaseId' = 1; 'Input' = ''},
+            @{'TestCaseId' = 2; 'Input' = ''}
         )} | ConvertTo-Json -Depth 10 -Compress
     }
     'Validate' {

--- a/powershell-adapter/Tests/TestAdapter/testadapter.resource.ps1
+++ b/powershell-adapter/Tests/TestAdapter/testadapter.resource.ps1
@@ -58,8 +58,10 @@ switch ($Operation) {
 
     }
     'Export' {
-        @(@{name = $inputobj.resources.name; type = $inputobj.resources.type; properties = @{'TestCaseId' = 1; 'Input' = ''}}) | ConvertTo-Json -Depth 10 -Compress
-        @(@{name = $inputobj.resources.name; type = $inputobj.resources.type; properties = @{'TestCaseId' = 2; 'Input' = ''}}) | ConvertTo-Json -Depth 10 -Compress
+        @{result = @(
+            @{name = $inputobj.resources.name; type = $inputobj.resources.type; properties = @{'TestCaseId' = 1; 'Input' = ''}},
+            @{name = $inputobj.resources.name; type = $inputobj.resources.type; properties = @{'TestCaseId' = 2; 'Input' = ''}}
+        )} | ConvertTo-Json -Depth 10 -Compress
     }
     'Validate' {
         @{ valid = $true } | ConvertTo-Json


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As part of the change to support implicit use of adapted resources, `export` was using an incorrectly written test adapter which didn't match what is actually expected.  Fix is to align the `export` functionality to be consistent with the other operations where the output is within a `result` property.  The test adapter was fixed to return the correct exported result.

Validated against a working version of https://github.com/microsoft/winget-dsc/tree/main/resources/Microsoft.Windows.Settings

## PR Context

Fix https://github.com/PowerShell/DSC/issues/782