### PR TITLE
fix: Check Type instance has DscResource attribute

### DIFF
--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -225,7 +225,8 @@ function Invoke-DscCacheRefresh {
 
             # workaround: Use GetTypeInstanceFromModule to get the type instance from the module and validate if it is a class-based resource
             $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name -ErrorAction Ignore
-            if (-not ([string]::IsNullOrEmpty($classBased))) {
+            if ($classBased -and ($classBased.CustomAttributes.AttributeType.Name -eq 'DscResourceAttribute')) {
+                "Detected class-based resource: $($dscResource.Name) => Type: $($classBased.BaseType.FullName)" | Write-DscTrace
                 $dscResourceInfo.ImplementationDetail = 'ClassBased'
             }
 


### PR DESCRIPTION
# PR Summary

PR #797 introduced a workaround to detect if DSC resources were `ClassBased`. This PR adds an additional validation by checking the instance has the `DscResource` attribute. 

## PR Context

The workaround incorrectly sets `ImplementationDetail` to `ClassBased` when there is another type with the same name, like `TimeZone` or `Environment`.