### PR TITLE
Add format option to resource and extension list to not truncate table

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -15,6 +15,14 @@ pub enum OutputFormat {
     Yaml,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+pub enum ListOutputFormat {
+    Json,
+    PrettyJson,
+    Yaml,
+    TableNoTruncate,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum, Deserialize)]
 pub enum TraceFormat {
     Default,
@@ -156,7 +164,7 @@ pub enum ExtensionSubCommand {
         /// Optional filter to apply to the list of extensions
         extension_name: Option<String>,
         #[clap(short = 'o', long, help = t!("args.outputFormat").to_string())]
-        output_format: Option<OutputFormat>,
+        output_format: Option<ListOutputFormat>,
     },
 }
 
@@ -174,7 +182,7 @@ pub enum ResourceSubCommand {
         #[clap(short, long, help = t!("args.tags").to_string())]
         tags: Option<Vec<String>>,
         #[clap(short = 'o', long, help = t!("args.outputFormat").to_string())]
-        output_format: Option<OutputFormat>,
+        output_format: Option<ListOutputFormat>,
     },
     #[clap(name = "get", about = t!("args.resourceGet").to_string(), arg_required_else_help = true)]
     Get {

--- a/dsc/src/tablewriter.rs
+++ b/dsc/src/tablewriter.rs
@@ -48,8 +48,12 @@ impl Table {
     }
 
     /// Print the table to the console.
+    ///
+    /// # Arguments
+    ///
+    /// * `truncate` - Whether to truncate the table if it is too wide for the console
     #[allow(clippy::format_push_string)]
-    pub fn print(&self) {
+    pub fn print(&self, truncate: bool) {
         let (width, _) = size().unwrap_or((80, 25));
         // make header bright green
         println!("\x1b[1;32m");
@@ -62,7 +66,7 @@ impl Table {
             }
         }
         // if header row is too wide, truncate
-        if header_row.len() > width as usize {
+        if truncate && header_row.len() > width as usize {
             header_row.truncate(width as usize);
         }
 
@@ -80,7 +84,7 @@ impl Table {
             }
 
             // if row is too wide and last character is not a space, truncate and add ellipsis unicode character
-            if row_str.len() > width as usize {
+            if truncate && row_str.len() > width as usize {
                 row_str.truncate(width as usize);
                 if !row_str.ends_with(' ') {
                     row_str.pop();

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -90,4 +90,16 @@ Describe 'Discover extension tests' {
             $env:DSC_RESOURCE_PATH = $null
         }
     }
+
+    It 'Table can be not truncated' {
+        $output = dsc extension list --output-format table-no-truncate
+        $LASTEXITCODE | Should -Be 0
+        $foundWideLine = $false
+        foreach ($line in $output) {
+            if ($line.Length -gt [Console]::WindowWidth) {
+                $foundWideLine = $true
+            }
+        }
+        $foundWideLine | Should -BeTrue
+    }
 }

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -88,4 +88,17 @@ Describe 'Tests for listing resources' {
         $LASTEXITCODE | Should -Be 0
         $out | Should -BeLike "*ERROR*Adapter not found: foo`*"
     }
+
+    It 'Table is not truncated' {
+        $output = dsc resource list --output-format table-no-truncate
+        $LASTEXITCODE | Should -Be 0
+        $foundWideLine = $false
+        foreach ($line in $output) {
+            if ($line.Length -gt [Console]::WindowWidth) {
+                $foundWideLine = $true
+                break
+            }
+        }
+        $foundWideLine | Should -BeTrue
+    }
 }

--- a/extensions/test/discover/testDiscover.dsc.extension.json
+++ b/extensions/test/discover/testDiscover.dsc.extension.json
@@ -2,7 +2,7 @@
     "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
     "type": "Test/Discover",
     "version": "0.1.0",
-    "description": "Test discover resource",
+    "description": "Test discover resource, this is a really long description to test that the table can be rendered without truncating the description text from this extension.",
     "discover": {
         "executable": "pwsh",
         "args": [


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add new `table-no-truncate` as option to `dsc resource list` and `dsc extension list` such that the table does not get truncated due to width of the console.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/763