### PR TITLE
Set bypass execution policy for appx discovery extension

### DIFF
--- a/extensions/appx/appx.dsc.extension.json
+++ b/extensions/appx/appx.dsc.extension.json
@@ -8,6 +8,8 @@
         "args": [
             "-NoLogo",
             "-NonInteractive",
+            "-ExecutionPolicy",
+            "Bypass",
             "-NoProfile",
             "-Command",
             "./appx-discover.ps1"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

On systems where ExecutionPolicy is restricted, this will cause this extension to fail, since we own this extension, we can set it to bypass to allow it to run on all systems