### PR TITLE
Add `json-array` as supported format to `get --all`

### DIFF
--- a/dsc/locales/en-us.toml
+++ b/dsc/locales/en-us.toml
@@ -73,6 +73,7 @@ implementedAs = "implemented as"
 invalidOperationOnAdapter = "Can not perform this operation on the adapter itself"
 setInputEmpty = "Desired input is empty"
 testInputEmpty = "Expected input is required"
+jsonError = "JSNO: %{err}"
 
 [subcommand]
 actualStateNotObject = "actual_state is not an object"
@@ -108,6 +109,7 @@ tableHeader_capabilities = "Capabilities"
 tableHeader_adapter = "RequireAdapter"
 tableHeader_description = "Description"
 invalidManifest = "Error in manifest for"
+jsonArrayNotSupported = "JSON array output format is only supported for `--all'"
 
 [util]
 failedToConvertJsonToString = "Failed to convert JSON to string"

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -16,6 +16,14 @@ pub enum OutputFormat {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
+pub enum GetOutputFormat {
+    Json,
+    JsonArray,
+    PrettyJson,
+    Yaml,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, ValueEnum)]
 pub enum ListOutputFormat {
     Json,
     PrettyJson,
@@ -195,7 +203,7 @@ pub enum ResourceSubCommand {
         #[clap(short = 'f', long, help = t!("args.file").to_string(), conflicts_with = "input")]
         file: Option<String>,
         #[clap(short = 'o', long, help = t!("args.outputFormat").to_string())]
-        output_format: Option<OutputFormat>,
+        output_format: Option<GetOutputFormat>,
     },
     #[clap(name = "set", about = "Invoke the set operation to a resource", arg_required_else_help = true)]
     Set {

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::args::{ConfigSubCommand, DscType, ExtensionSubCommand, ListOutputFormat, OutputFormat, ResourceSubCommand};
+use crate::args::{ConfigSubCommand, DscType, ExtensionSubCommand, GetOutputFormat, ListOutputFormat, OutputFormat, ResourceSubCommand};
 use crate::resolve::{get_contents, Include};
 use crate::resource_command::{get_resource, self};
 use crate::tablewriter::Table;
@@ -590,7 +590,17 @@ pub fn resource(subcommand: &ResourceSubCommand, progress_format: ProgressFormat
             if *all { resource_command::get_all(&dsc, resource, output_format.as_ref()); }
             else {
                 let parsed_input = get_input(input.as_ref(), path.as_ref());
-                resource_command::get(&dsc, resource, &parsed_input, output_format.as_ref());
+                let format = match output_format {
+                    Some(GetOutputFormat::Json) => Some(OutputFormat::Json),
+                    Some(GetOutputFormat::JsonArray) => {
+                        error!("{}", t!("subcommand.jsonArrayNotSupported"));
+                        exit(EXIT_INVALID_ARGS);
+                    },
+                    Some(GetOutputFormat::PrettyJson) => Some(OutputFormat::PrettyJson),
+                    Some(GetOutputFormat::Yaml) => Some(OutputFormat::Yaml),
+                    None => None,
+                };
+                resource_command::get(&dsc, resource, &parsed_input, format.as_ref());
             }
         },
         ResourceSubCommand::Set { resource, input, file: path, output_format } => {

--- a/dsc/tests/dsc_resource_get.tests.ps1
+++ b/dsc/tests/dsc_resource_get.tests.ps1
@@ -48,4 +48,10 @@ Describe 'resource get tests' {
         $testError[0] | SHould -match 'error:'
         $LASTEXITCODE | Should -Be 2
     }
+
+    It '--output-format json-array returns single object' {
+        $out = dsc resource get -r Microsoft/Process --all --output-format json-array
+        $LASTEXITCODE | Should -Be 0
+        ($out | Measure-Object).Count | Should -Be 1
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When using `dsc resource get --all`, `--format-output` now has a `json-array` option.  This is only valid when used with `--all` which returns the results as a single json array rather than multiple JSONLines.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/813