### PR TITLE
Fix regression in get-all default output

### DIFF
--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -116,6 +116,7 @@ pub fn get_all(dsc: &DscManager, resource_type: &str, format: Option<&GetOutputF
         let format = match format {
             Some(&GetOutputFormat::PrettyJson) => Some(&OutputFormat::PrettyJson),
             Some(&GetOutputFormat::Yaml) => Some(&OutputFormat::Yaml),
+            None => None,
             _ => Some(&OutputFormat::Json),
         };
         write_object(&json, format, include_separator);

--- a/process/src/main.rs
+++ b/process/src/main.rs
@@ -13,12 +13,18 @@ fn get_task_list() -> Vec<ProcessInfo>
     let mut result = Vec::new();
     let mut s = System::new();
     s.refresh_processes(ProcessesToUpdate::All, true);
+    let mut count = 0;
     for (pid, process) in s.processes() {
         let mut p = ProcessInfo::new();
         p.pid = pid.as_u32();
         p.name = process.name().to_string_lossy().to_string();
         p.cmdline = format!("{:?}", process.cmd());
         result.push(p);
+        count += 1;
+        if count > 3 {
+            // limit to 3 processes as this is just for testing
+            break;
+        }
     }
 
     result


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the original change to support `json-array` output, the conversion from `GetOutputFormat` to `OutputFormat` didn't correctly handle `None` which ended up in the anything else default to JSON format whereas `None` should return YAML when used interactively.  The fix is to make sure `None` gets propagated correctly.

Also updated the `Process` resource, which is only used for testing, to only emit 3 instances rather than having it scroll off the terminal.

Finally, fixed a non-blocking test issue in the WinPS test that would fail on non-Windows during cleanup.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/866