### PR TITLE
(SCHEMA) Update recognized schema URIs

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -270,4 +270,6 @@ pub enum DscType {
     ConfigurationGetResult,
     ConfigurationSetResult,
     ConfigurationTestResult,
+    ExtensionManifest,
+    ExtensionDiscoverResult
 }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -4,6 +4,8 @@
 use crate::args::{DscType, OutputFormat, TraceFormat};
 use crate::resolve::Include;
 use dsc_lib::configure::config_result::ResourceTestResult;
+use dsc_lib::extensions::discover::DiscoverResult;
+use dsc_lib::extensions::extension_manifest::ExtensionManifest;
 use dsc_lib::{
     configure::{
         config_doc::Configuration,
@@ -175,6 +177,12 @@ pub fn get_schema(dsc_type: DscType) -> RootSchema {
         },
         DscType::ConfigurationTestResult => {
             schema_for!(ConfigurationTestResult)
+        },
+        DscType::ExtensionManifest => {
+            schema_for!(ExtensionManifest)
+        },
+        DscType::ExtensionDiscoverResult => {
+            schema_for!(DiscoverResult)
         },
     }
 }

--- a/dsc_lib/src/extensions/extension_manifest.rs
+++ b/dsc_lib/src/extensions/extension_manifest.rs
@@ -99,18 +99,16 @@ pub fn validate_semver(version: &str) -> Result<(), semver::Error> {
 #[cfg(test)]
 mod test {
     use crate::{
-        dscerror::DscError,
-        dscresources::resource_manifest::ResourceManifest,
-        schemas::DscRepoSchema
+        dscerror::DscError, extensions::extension_manifest::ExtensionManifest, schemas::DscRepoSchema
     };
 
     #[test]
     fn test_validate_schema_uri_with_invalid_uri() {
         let invalid_uri = "https://invalid.schema.uri".to_string();
 
-        let manifest = ResourceManifest{
+        let manifest = ExtensionManifest{
             schema_version: invalid_uri.clone(),
-            resource_type: "Microsoft.Dsc.Test/InvalidSchemaUri".to_string(),
+            r#type: "Microsoft.Dsc.Test/InvalidSchemaUri".to_string(),
             version: "0.1.0".to_string(),
             ..Default::default()
         };
@@ -122,7 +120,7 @@ mod test {
         match result.as_ref().unwrap_err() {
             DscError::UnrecognizedSchemaUri(actual, recognized) => {
                 assert_eq!(actual, &invalid_uri);
-                assert_eq!(recognized, &ResourceManifest::recognized_schema_uris())
+                assert_eq!(recognized, &ExtensionManifest::recognized_schema_uris())
             },
             _ => {
                 panic!("Expected validate_schema_uri() to error on unrecognized schema uri, but was {:?}", result.as_ref().unwrap_err())
@@ -132,9 +130,9 @@ mod test {
 
     #[test]
     fn test_validate_schema_uri_with_valid_uri() {
-        let manifest = ResourceManifest{
-            schema_version: ResourceManifest::default_schema_id_uri(),
-            resource_type: "Microsoft.Dsc.Test/ValidSchemaUri".to_string(),
+        let manifest = ExtensionManifest{
+            schema_version: ExtensionManifest::default_schema_id_uri(),
+            r#type: "Microsoft.Dsc.Test/ValidSchemaUri".to_string(),
             version: "0.1.0".to_string(),
             ..Default::default()
         };

--- a/dsc_lib/src/schemas/mod.rs
+++ b/dsc_lib/src/schemas/mod.rs
@@ -133,8 +133,16 @@ pub enum RecognizedSchemaVersion {
     /// Represents `v3` schema folder.
     #[default]
     V3,
+    /// Represents the `v3.1` schema folder.
+    V3_1,
+    /// Represents the `v3.1.0` schema folder.
+    V3_1_0,
     /// Represents the `v3.0` schema folder.
     V3_0,
+    /// Represents the `v3.0.2` schema folder.
+    V3_0_2,
+    /// Represents the `v3.0.1` schema folder.
+    V3_0_1,
     /// Represents the `v3.0.0` schema folder.
     V3_0_0,
 }
@@ -143,7 +151,11 @@ impl std::fmt::Display for RecognizedSchemaVersion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::V3 => write!(f, "v3"),
+            Self::V3_1 => write!(f, "v3.1"),
+            Self::V3_1_0 => write!(f, "v3.1.0"),
             Self::V3_0 => write!(f, "v3.0"),
+            Self::V3_0_2 => write!(f, "v3.0.2"),
+            Self::V3_0_1 => write!(f, "v3.0.1"),
             Self::V3_0_0 => write!(f, "v3.0.0"),
         }
     }
@@ -155,7 +167,11 @@ impl RecognizedSchemaVersion {
     pub fn all() -> Vec<RecognizedSchemaVersion> {
         vec![
             Self::V3,
+            Self::V3_1,
+            Self::V3_1_0,
             Self::V3_0,
+            Self::V3_0_2,
+            Self::V3_0_1,
             Self::V3_0_0,
         ]
     }
@@ -163,13 +179,13 @@ impl RecognizedSchemaVersion {
     //// Returns the latest version with major, minor, and patch segments, like `3.0.0`.
     #[must_use]
     pub fn latest() -> RecognizedSchemaVersion {
-        Self::V3_0_0
+        Self::V3_1_0
     }
 
     /// Returns the latest minor version for the latest major version, like `3.0`.
     #[must_use]
     pub fn latest_minor() -> RecognizedSchemaVersion {
-        Self::V3_0
+        Self::V3_1
     }
 
     /// Returns the latest major version, like `3`
@@ -519,22 +535,46 @@ mod test {
     fn test_get_recognized_schema_uris() {
         let expected: Vec<String> = vec![
             "https://aka.ms/dsc/schemas/v3/bundled/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.1/bundled/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.1.0/bundled/config/document.json".to_string(),
             "https://aka.ms/dsc/schemas/v3.0/bundled/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.0.2/bundled/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.0.1/bundled/config/document.json".to_string(),
             "https://aka.ms/dsc/schemas/v3.0.0/bundled/config/document.json".to_string(),
             "https://aka.ms/dsc/schemas/v3/bundled/config/document.vscode.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.1/bundled/config/document.vscode.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.1.0/bundled/config/document.vscode.json".to_string(),
             "https://aka.ms/dsc/schemas/v3.0/bundled/config/document.vscode.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.0.2/bundled/config/document.vscode.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.0.1/bundled/config/document.vscode.json".to_string(),
             "https://aka.ms/dsc/schemas/v3.0.0/bundled/config/document.vscode.json".to_string(),
             "https://aka.ms/dsc/schemas/v3/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.1/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.1.0/config/document.json".to_string(),
             "https://aka.ms/dsc/schemas/v3.0/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.0.2/config/document.json".to_string(),
+            "https://aka.ms/dsc/schemas/v3.0.1/config/document.json".to_string(),
             "https://aka.ms/dsc/schemas/v3.0.0/config/document.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/bundled/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.1/bundled/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.1.0/bundled/config/document.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0/bundled/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.2/bundled/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.1/bundled/config/document.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.0/bundled/config/document.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/bundled/config/document.vscode.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.1/bundled/config/document.vscode.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.1.0/bundled/config/document.vscode.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0/bundled/config/document.vscode.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.2/bundled/config/document.vscode.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.1/bundled/config/document.vscode.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.0/bundled/config/document.vscode.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.1/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.1.0/config/document.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.2/config/document.json".to_string(),
+            "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.1/config/document.json".to_string(),
             "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3.0.0/config/document.json".to_string(),
         ];
 
@@ -544,7 +584,10 @@ mod test {
             true
         );
 
-        assert_eq!(expected, actual)
+        for (index, expected_uri) in expected.iter().enumerate() {
+            assert_eq!(*expected_uri, actual[index]);
+        }
+        // assert_eq!(expected, actual)
     }
 
     #[test]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This change:

- Updates the recognized schema URIs to include schemas for each released version of DSC.
- Fixes the tests for the extension manifest schema URIs.
- Adds the schemas for extension manifests and the **Discover** extension operation result output to the `dsc schema` command.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
