### PR TITLE
Fix auth to CFS for release build

### DIFF
--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -168,6 +168,14 @@ extends:
           displayName: Install Rust
           env:
             ob_restore_phase: true
+        - task: AzureCLI@2
+          displayName: Azure CLI
+          inputs:
+            azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+            scriptType: core
+            scriptLocation: inlineScript
+            inlineScript: |
+              az account show
         - pwsh: |
             apt update
             apt -y install musl-tools
@@ -196,6 +204,14 @@ extends:
           displayName: Install Rust
           env:
             ob_restore_phase: true
+        - task: AzureCLI@2
+          displayName: Azure CLI
+          inputs:
+            azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+            scriptType: core
+            scriptLocation: inlineScript
+            inlineScript: |
+              az account show
         - pwsh: |
             $env:CC_aarch64_unknown_linux_musl='clang'
             $env:AR_aarch64_unknown_linux_musl='llvm-ar'
@@ -243,6 +259,14 @@ extends:
           displayName: Install Rust
           env:
             ob_restore_phase: true
+        - task: AzureCLI@2
+          displayName: Azure CLI
+          inputs:
+            azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+            scriptType: core
+            scriptLocation: inlineScript
+            inlineScript: |
+              az account show
         - pwsh: |
             ./build.ps1 -Release -Architecture $(buildName)
             ./build.ps1 -PackageType tgz -Architecture $(buildName) -Release

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -172,7 +172,7 @@ extends:
           displayName: Azure CLI
           inputs:
             azureSubscription: az-blob-cicd-infra
-            scriptType: core
+            scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
               az account show
@@ -208,7 +208,7 @@ extends:
           displayName: Azure CLI
           inputs:
             azureSubscription: az-blob-cicd-infra
-            scriptType: core
+            scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
               az account show
@@ -263,7 +263,7 @@ extends:
           displayName: Azure CLI
           inputs:
             azureSubscription: az-blob-cicd-infra
-            scriptType: core
+            scriptType: pscore
             scriptLocation: inlineScript
             inlineScript: |
               az account show

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -75,6 +75,17 @@ extends:
             Write-Host ("sending " + $vstsCommandString)
             Write-Host "##$vstsCommandString"
           name: Package
+        - task: AzureCLI@2
+          displayName: Get Az Token
+          inputs:
+            azureSubscription: az-blob-cicd-infra
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
+              $vstsCommandString = "vso[task.setvariable variable=AzToken;]$token"
+              Write-Host "Setting token"
+              Write-Host "##$vstsCommandString"
 
       - job: BuildWin_x64
         dependsOn: SetPackageVersion
@@ -82,6 +93,7 @@ extends:
           ob_sdl_tsa_configFile: '$(Build.SourcesDirectory)\DSC\.config\tsaoptions.json'
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
           signSrcPath: '$(Build.SourcesDirectory)\out'
+          AzToken: $[ dependencies.SetPackageVersion.outputs['AzToken'] ]
           ob_sdl_sbom_enabled: true
           ob_signing_setup_enabled: true
           ob_sdl_codeql_compiled_enabled: true
@@ -93,6 +105,7 @@ extends:
             buildName: x86_64-pc-windows-msvc
             signSrcPath: '$(signSrcPath)'
             PackageRoot: '$(PackageRoot)'
+            token: '$(AzToken)'
 
       - job: BuildWin_arm64
         dependsOn: SetPackageVersion
@@ -111,6 +124,7 @@ extends:
             buildName: aarch64-pc-windows-msvc
             signSrcPath: '$(signSrcPath)'
             PackageRoot: '$(PackageRoot)'
+            token: '$(AzToken)'
 
       - job: CreateMsixBundle
         dependsOn:
@@ -155,6 +169,7 @@ extends:
         variables:
           LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2204:latest'
           PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
+          AzToken: $[ dependencies.SetPackageVersion.outputs['AzToken'] ]
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         displayName: Linux-x64-musl
         pool:
@@ -168,17 +183,12 @@ extends:
           displayName: Install Rust
           env:
             ob_restore_phase: true
-        - task: AzureCLI@2
-          displayName: Azure CLI
-          inputs:
-            azureSubscription: az-blob-cicd-infra
-            scriptType: pscore
-            scriptLocation: inlineScript
-            inlineScript: |
-              az account show
         - pwsh: |
             apt update
             apt -y install musl-tools
+            $header = "Bearer $accessToken"
+            $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
+            $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
             ./build.ps1 -Release -Architecture x86_64-unknown-linux-musl
             ./build.ps1 -PackageType tgz -Architecture x86_64-unknown-linux-musl -Release
             Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
@@ -190,6 +200,7 @@ extends:
         variables:
           LinuxContainerImage: 'onebranch.azurecr.io/linux/ubuntu-2004-arm64:latest'
           PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
+          AzToken: $[ dependencies.SetPackageVersion.outputs['AzToken'] ]
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         displayName: Linux-ARM64-musl
         pool:
@@ -227,6 +238,9 @@ extends:
             if ((openssl version -d) -match 'OPENSSLDIR: "(?<dir>.*?)"') {
               $env:OPENSSL_LIB_DIR = $matches['dir']
             }
+            $header = "Bearer $accessToken"
+            $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
+            $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
             ./build.ps1 -Release -Architecture aarch64-unknown-linux-musl
             ./build.ps1 -PackageType tgz -Architecture aarch64-unknown-linux-musl -Release
             Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"
@@ -237,6 +251,7 @@ extends:
         dependsOn: SetPackageVersion
         variables:
           PackageVersion: $[ dependencies.SetPackageVersion.outputs['Package.Version'] ]
+          AzToken: $[ dependencies.SetPackageVersion.outputs['AzToken'] ]
           ob_outputDirectory: '$(Build.ArtifactStagingDirectory)'
         displayName: BuildMac
         pool:
@@ -268,6 +283,9 @@ extends:
             inlineScript: |
               az account show
         - pwsh: |
+            $header = "Bearer $accessToken"
+            $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
+            $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
             ./build.ps1 -Release -Architecture $(buildName)
             ./build.ps1 -PackageType tgz -Architecture $(buildName) -Release
             Copy-Item ./bin/*.tar.gz "$(ob_outputDirectory)"

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -83,7 +83,7 @@ extends:
             scriptLocation: inlineScript
             inlineScript: |
               $token = az account get-access-token --query accessToken --resource 499b84ac-1321-427f-aa17-267ca6975798 -o tsv
-              $vstsCommandString = "vso[task.setvariable variable=AzToken;]$token"
+              $vstsCommandString = "vso[task.setvariable variable=AzToken;isoutput=true]$token"
               Write-Host "Setting token"
               Write-Host "##$vstsCommandString"
 

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -171,7 +171,7 @@ extends:
         - task: AzureCLI@2
           displayName: Azure CLI
           inputs:
-            azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+            azureSubscription: az-blob-cicd-infra
             scriptType: core
             scriptLocation: inlineScript
             inlineScript: |
@@ -207,7 +207,7 @@ extends:
         - task: AzureCLI@2
           displayName: Azure CLI
           inputs:
-            azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+            azureSubscription: az-blob-cicd-infra
             scriptType: core
             scriptLocation: inlineScript
             inlineScript: |
@@ -262,7 +262,7 @@ extends:
         - task: AzureCLI@2
           displayName: Azure CLI
           inputs:
-            azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+            azureSubscription: az-blob-cicd-infra
             scriptType: core
             scriptLocation: inlineScript
             inlineScript: |

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -7,14 +7,6 @@ pr:
     - onebranch
     - release/v*
 
-schedules:
-- cron: '0 3 * * 1'
-  displayName: Weekly Build
-  branches:
-    include:
-    - main
-  always: true
-
 variables:
   BuildConfiguration: 'release'
   PackageRoot: '$(System.ArtifactsDirectory)/Packages'
@@ -149,6 +141,14 @@ extends:
             Copy-Item ./bin/*.msixbundle "$(ob_outputDirectory)"
           displayName: 'Create msixbundle'
           condition: succeeded()
+        - task: onebranch.pipeline.signing@1
+          displayName: Sign MsixBundle
+          condition: succeeded()
+          inputs:
+            command: 'sign'
+            signing_profile: $(MSIXProfile)
+            files_to_sign: '*.msixbundle'
+            search_root: '$(ob_outputDirectory)'
 
       - job: BuildLinuxMusl
         dependsOn: SetPackageVersion

--- a/.pipelines/DSC-Windows.yml
+++ b/.pipelines/DSC-Windows.yml
@@ -38,7 +38,7 @@ steps:
   displayName: Azure CLI
   inputs:
     azureSubscription: az-blob-cicd-infra
-    scriptType: core
+    scriptType: pscore
     scriptLocation: inlineScript
     inlineScript: |
       az account show

--- a/.pipelines/DSC-Windows.yml
+++ b/.pipelines/DSC-Windows.yml
@@ -8,6 +8,8 @@ parameters:
   - name: BuildConfiguration
     type: string
     default: Release
+  - name: token
+    type: string
 
 steps:
 - checkout: self
@@ -34,15 +36,10 @@ steps:
   displayName: Install Rust
   env:
     ob_restore_phase: true
-- task: AzureCLI@2
-  displayName: Azure CLI
-  inputs:
-    azureSubscription: az-blob-cicd-infra
-    scriptType: pscore
-    scriptLocation: inlineScript
-    inlineScript: |
-      az account show
 - pwsh: |
+    $header = "Bearer ${ parameters.token }"
+    $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
+    $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
     Set-Location "$(Build.SourcesDirectory)/DSC"
     $LLVMBIN = "$($env:PROGRAMFILES)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin"
     if (!(Test-Path $LLVMBIN)) {

--- a/.pipelines/DSC-Windows.yml
+++ b/.pipelines/DSC-Windows.yml
@@ -34,6 +34,14 @@ steps:
   displayName: Install Rust
   env:
     ob_restore_phase: true
+- task: AzureCLI@2
+  displayName: Azure CLI
+  inputs:
+    azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+    scriptType: core
+    scriptLocation: inlineScript
+    inlineScript: |
+      az account show
 - pwsh: |
     Set-Location "$(Build.SourcesDirectory)/DSC"
     $LLVMBIN = "$($env:PROGRAMFILES)\Microsoft Visual Studio\2022\Enterprise\VC\Tools\Llvm\bin"

--- a/.pipelines/DSC-Windows.yml
+++ b/.pipelines/DSC-Windows.yml
@@ -37,7 +37,7 @@ steps:
 - task: AzureCLI@2
   displayName: Azure CLI
   inputs:
-    azureSubscription: azDO-Cargo-PowerShell-feed-Ingestion
+    azureSubscription: az-blob-cicd-infra
     scriptType: core
     scriptLocation: inlineScript
     inlineScript: |

--- a/build.ps1
+++ b/build.ps1
@@ -238,7 +238,7 @@ if (!$SkipBuild) {
         ${env:CARGO_SOURCE_crates-io_REPLACE_WITH} = $null
         $env:CARGO_REGISTRIES_CRATESIO_INDEX = $null
 
-        if ($UseCFSAuth) {
+        if ($UseCFSAuth -or $null -ne $env:TF_BUILD) {
             if ($null -eq (Get-Command 'az' -ErrorAction Ignore)) {
                 throw "Azure CLI not found"
             }

--- a/build.ps1
+++ b/build.ps1
@@ -237,8 +237,9 @@ if (!$SkipBuild) {
         Write-Host "Using CFS for cargo source replacement"
         ${env:CARGO_SOURCE_crates-io_REPLACE_WITH} = $null
         $env:CARGO_REGISTRIES_CRATESIO_INDEX = $null
+        $env:CARGO_REGISTRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell~force-auth/Cargo/index/"
 
-        if ($UseCFSAuth -or $null -ne $env:TF_BUILD) {
+        if ($UseCFSAuth) {
             if ($null -eq (Get-Command 'az' -ErrorAction Ignore)) {
                 throw "Azure CLI not found"
             }
@@ -250,13 +251,12 @@ if (!$SkipBuild) {
                     Write-Warning "Failed to get access token, use 'az login' first, or use '-useCratesIO' to use crates.io.  Proceeding with anonymous access."
                 } else {
                     $header = "Bearer $accessToken"
-                    $env:CARGO_REGISTRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell~force-auth/Cargo/index/"
                     $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
                     $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
                 }
             }
             else {
-                Write-Warning "Azure CLI not found, proceeding with anonymous access."
+                Write-Warning "Azure CLI not found or running in ADO, proceeding with anonymous access."
             }
         }
     }

--- a/build.ps1
+++ b/build.ps1
@@ -237,7 +237,6 @@ if (!$SkipBuild) {
         Write-Host "Using CFS for cargo source replacement"
         ${env:CARGO_SOURCE_crates-io_REPLACE_WITH} = $null
         $env:CARGO_REGISTRIES_CRATESIO_INDEX = $null
-        $env:CARGO_REGISTRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell~force-auth/Cargo/index/"
 
         if ($UseCFSAuth) {
             if ($null -eq (Get-Command 'az' -ErrorAction Ignore)) {
@@ -253,6 +252,7 @@ if (!$SkipBuild) {
                     $header = "Bearer $accessToken"
                     $env:CARGO_REGISTRIES_POWERSHELL_TOKEN = $header
                     $env:CARGO_REGISTRIES_POWERSHELL_CREDENTIAL_PROVIDER = 'cargo:token'
+                    $env:CARGO_REGISTRIES_POWERSHELL_INDEX = "sparse+https://pkgs.dev.azure.com/powershell/PowerShell/_packaging/powershell~force-auth/Cargo/index/"
                 }
             }
             else {

--- a/build.ps1
+++ b/build.ps1
@@ -256,7 +256,7 @@ if (!$SkipBuild) {
                 }
             }
             else {
-                Write-Warning "Azure CLI not found or running in ADO, proceeding with anonymous access."
+                Write-Warning "Azure CLI not found, proceeding with anonymous access."
             }
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

azcli isn't available during the release pipeline, instead use the `AzureCLI@2` task to run the az command which will logon the subscription and get the token needed for cargo as an output value.