### PR TITLE
Fix ClearCache example

### DIFF
--- a/docs/reference/resources/Microsoft/DSC/PowerShell/index.md
+++ b/docs/reference/resources/Microsoft/DSC/PowerShell/index.md
@@ -86,7 +86,7 @@ set to `ClearCache`:
 $adapterScript = dsc resource list Microsoft.DSC/PowerShell |
     ConvertFrom-Json |
     Select-Object -ExpandProperty directory |
-    Join-Path
+    Join-Path -ChildPath ([System.IO.Path]::Combine("psDscAdapter", "powershell.resource.ps1"))
 
 & $adapterScript -Operation ClearCache
 ```

--- a/docs/reference/resources/Microsoft/Windows/WindowsPowerShell/index.md
+++ b/docs/reference/resources/Microsoft/Windows/WindowsPowerShell/index.md
@@ -83,7 +83,7 @@ set to `ClearCache`:
 $adapterScript = dsc resource list Microsoft.Windows/WindowsPowerShell |
     ConvertFrom-Json |
     Select-Object -ExpandProperty directory |
-    Join-Path
+    Join-Path -ChildPath ([System.IO.Path]::Combine("psDscAdapter", "powershell.resource.ps1"))
 
 & $adapterScript -Operation ClearCache
 ```


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This fixes the ClearCache example in the reference documentation for both PowerShell adapters. It uses the .NET type to support cross-platform, rather than using "\" or "/". Also implemented the same on WindowsPowerShell to keep it identical.

## PR Context

Resolves #909 
