### PR TITLE
Fix default output to YAML when used interactively

### DIFF
--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -55,6 +55,7 @@ pub fn get(dsc: &DscManager, resource_type: &str, input: &str, format: Option<&G
             let format = match format {
                 Some(&GetOutputFormat::PrettyJson) => Some(&OutputFormat::PrettyJson),
                 Some(&GetOutputFormat::Yaml) => Some(&OutputFormat::Yaml),
+                None => None,
                 _ => Some(&OutputFormat::Json),
             };
             write_object(&json, format, false);


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Missed one change to allow for `None` to be passed through instead of becoming JSON for output of get on a resource

## PR Context

Fix https://github.com/PowerShell/DSC/issues/918