### PR TITLE
Add reference documentation for Microsoft.DSC.Transitional/RunCommandOnSet

### DIFF
--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
@@ -14,16 +14,20 @@ execute a simple command during the **Set** operation.
 
 ## Test whether the command would run
 
-The following snippet shows how you can use the resource with the [dsc resource test][01] command to check whether the command would run.
+The following snippet shows how you can use the resource with the [dsc resource test][00] command to check whether
+the command would run.
 
 > [!NOTE]
 > The `dsc resource test` command performs a synthetic test on this resource. `Microsoft.DSC.Transitional/RunCommandOnSet` doesn't have
-> the `test` capability defined in the [resource manifest][02]
+> the `test` capability defined in the [resource manifest][01]
 
 ```powershell
 $instance = @{
-  executable = "echo"
-  arguments  = @("Configuration applied successfully")
+    executable = "C:\Windows\system32\cmd.exe"
+    arguments = @(
+        '/C',
+        'echo Hello world'
+    )
 } | ConvertTo-Json
 
 dsc resource test --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
@@ -34,30 +38,26 @@ When testing the resource, DSC returns a result indicating the desired state:
 ```yaml
 desiredState:
   arguments:
-  - Configuration applied successfully
-  executable: echo
+  - /C
+  - echo Hello world
+  executable: C:\Windows\system32\cmd.exe
 actualState:
-  executable: echo
+  executable: C:\Windows\system32\cmd.exe
   arguments:
-  - Configuration applied successfully
+  - /C
+  - echo Hello world
 inDesiredState: true
 differingProperties: []
 ```
 
-The `inDesiredState` field of the result object is set to `true`, indicating that the command would be executed during a **Set** operation.
+The `inDesiredState` field always returns `true` because of [pretest][02] is supported.
+This means the command is always executed during the **Set** operation.
 
 ## Run the command
 
 To execute the command, use the [dsc resource set][03] command.
 
 ```powershell
-$instance = @{
-    executable = "C:\Windows\system32\cmd.exe"
-    arguments = @(
-        '/C',
-        'echo Hello world'
-    )
-} | ConvertTo-Json
 dsc resource set --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
 ```
 
@@ -84,6 +84,7 @@ changedProperties: []
 > If you want to capture the output, you should redirect it to a file.
 
 <!-- Link reference definitions -->
-[01]: ../../../../../cli/resource/test.md
-[02]: ../../../../../../schemas/resource/manifest/test.md
+[00]: ../../../../../cli/resource/test.md
+[01]: ../../../../../../schemas/resource/manifest/test.md
+[02]: ../../../../../../../reference/cli/resource/set.md
 [03]: ../../../../../cli/resource/set.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
@@ -12,14 +12,9 @@ title: Run a simple command
 This example shows how you can use the `Microsoft.DSC.Transitional/RunCommandOnSet` resource to
 execute a simple command during the **Set** operation.
 
-## Test whether the command would run
+## Run the command
 
-The following snippet shows how you can use the resource with the [dsc resource test][00] command to check whether
-the command would run.
-
-> [!NOTE]
-> The `dsc resource test` command performs a synthetic test on this resource. `Microsoft.DSC.Transitional/RunCommandOnSet` doesn't have
-> the `test` capability defined in the [resource manifest][01]
+The following snippet shows how you can invoke the resource to execute a custom command with [dsc resource set][00].
 
 ```powershell
 $instance = @{
@@ -29,35 +24,6 @@ $instance = @{
         'echo Hello world'
     )
 } | ConvertTo-Json
-
-dsc resource test --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
-```
-
-When testing the resource, DSC returns a result indicating the desired state:
-
-```yaml
-desiredState:
-  arguments:
-  - /C
-  - echo Hello world
-  executable: C:\Windows\system32\cmd.exe
-actualState:
-  executable: C:\Windows\system32\cmd.exe
-  arguments:
-  - /C
-  - echo Hello world
-inDesiredState: true
-differingProperties: []
-```
-
-The `inDesiredState` field always returns `true` because of [pretest][02] is supported.
-This means the command is always executed during the **Set** operation.
-
-## Run the command
-
-To execute the command, use the [dsc resource set][03] command.
-
-```powershell
 dsc resource set --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
 ```
 
@@ -84,7 +50,4 @@ changedProperties: []
 > If you want to capture the output, you should redirect it to a file.
 
 <!-- Link reference definitions -->
-[00]: ../../../../../cli/resource/test.md
-[01]: ../../../../../../schemas/resource/manifest/test.md
-[02]: ../../../../../../../reference/cli/resource/set.md
-[03]: ../../../../../cli/resource/set.md
+[00]: ../../../../../cli/resource/set.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
@@ -1,0 +1,89 @@
+---
+description: >
+  Example showing how you can invoke the Microsoft.DSC.Transitional/RunCommandOnSet resource with DSC to run a simple command.
+
+ms.date: 06/30/2025
+ms.topic: reference
+title: Run a simple command
+---
+
+# Run a simple command
+
+This example shows how you can use the `Microsoft.DSC.Transitional/RunCommandOnSet` resource to
+execute a simple command during the set operation.
+
+## Test whether the command would run
+
+The following snippet shows how you can use the resource with the [dsc resource test][01] command to check whether the command would run.
+
+> [!NOTE]
+> The `dsc resource test` command performs a synthetic test on this resource. `Microsoft.DSC.Transitional/RunCommandOnSet` doesn't have
+> the `test` capability defined in the [resource manifest][02]
+
+```powershell
+$instance = @{
+  executable = "echo"
+  arguments  = @("Configuration applied successfully")
+} | ConvertTo-Json
+
+dsc resource test --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
+```
+
+When testing the resource, DSC returns a result indicating the desired state:
+
+```yaml
+desiredState:
+  arguments:
+  - Configuration applied successfully
+  executable: echo
+actualState:
+  executable: echo
+  arguments:
+  - Configuration applied successfully
+inDesiredState: true
+differingProperties: []
+```
+
+The `inDesiredState` field of the result object is set to `true`, indicating that the command would be executed during a set operation.
+
+## Run the command
+
+To execute the command, use the [dsc resource set][03] command.
+
+```powershell
+$instance = @{
+    executable = "C:\Windows\system32\cmd.exe"
+    arguments = @(
+        '/C',
+        'echo Hello world'
+    )
+} | ConvertTo-Json
+dsc resource set --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
+```
+
+When the resource runs the command, DSC returns a result similar to:
+
+```yaml
+beforeState:
+  executable: cmd
+  arguments:
+  - /C
+  - echo
+  - Hello world
+afterState:
+  executable: cmd
+  arguments:
+  - /C
+  - echo
+  - Hello world
+changedProperties: []
+```
+
+> [!NOTE]
+> The output from the command executed by the `runCommandOnSet` resource isn't displayed in the console.
+> If you want to capture the output, you should redirect it to a file.
+
+<!-- Link reference definitions -->
+[01]: ../../../../../cli/resource/test.md
+[02]: ../../../../../../schemas/resource/manifest/test.md
+[03]: ../../../../../cli/resource/set.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
@@ -10,7 +10,7 @@ title: Run a simple command
 # Run a simple command
 
 This example shows how you can use the `Microsoft.DSC.Transitional/RunCommandOnSet` resource to
-execute a simple command during the set operation.
+execute a simple command during the **Set** operation.
 
 ## Test whether the command would run
 
@@ -44,7 +44,7 @@ inDesiredState: true
 differingProperties: []
 ```
 
-The `inDesiredState` field of the result object is set to `true`, indicating that the command would be executed during a set operation.
+The `inDesiredState` field of the result object is set to `true`, indicating that the command would be executed during a **Set** operation.
 
 ## Run the command
 

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
@@ -9,11 +9,12 @@ title: Run a PowerShell command
 
 # Run a PowerShell command
 
-This example shows how you can use the `Microsoft.DSC.Transitional/RunCommandOnSet` resource to execute a PowerShell command during the set operation.
+This example shows how you can use the `Microsoft.DSC.Transitional/RunCommandOnSet` resource to execute a PowerShell command
+during the **Set** operation.
 
 ## Define the PowerShell command to run
 
-The following snippet shows how you can define a PowerShell command to run during the DSC set operation:
+The following snippet shows how you can define a PowerShell command to run during the DSC **Set** operation:
 
 ```powershell
 $command = "Write-Output Hello | Out-File $env:TEMP\hello.txt"

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
@@ -1,0 +1,76 @@
+---
+description: >
+  Example showing how you can invoke the Microsoft.DSC.Transitional/RunCommandOnSet resource with DSC to
+  run a PowerShell command.
+ms.date: 06/30/2025
+ms.topic: reference
+title: Run a PowerShell command
+---
+
+# Run a PowerShell command
+
+This example shows how you can use the `Microsoft.DSC.Transitional/RunCommandOnSet` resource to execute a PowerShell command during the set operation.
+
+## Define the PowerShell command to run
+
+The following snippet shows how you can define a PowerShell command to run during the DSC set operation:
+
+```powershell
+$command = "Write-Output Hello | Out-File $env:TEMP\hello.txt"
+$instance = @{
+  executable = "powershell.exe"
+  arguments  = @(
+    "-Command",
+    $command
+  )
+} | ConvertTo-Json
+
+dsc resource set --resource Microsoft.DSC.Transitional/RunCommandOnSet --input $instance
+```
+
+To verify the results, run the following command:
+
+```powershell
+Get-Content -Path $env:TEMP\hello.txt
+```
+
+This should return:
+
+```text
+Hello
+```
+
+## Run the PowerShell command in a configuration document
+
+You can also include this resource in a DSC configuration document:
+
+```powershell
+$command = "if ((Get-Command -Name winget -CommandType Application -ErrorAction Ignore)) {winget install --id Microsoft.PowerShell.Preview}"
+$document = @"
+`$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: RunPowerShellCommand
+    type: Microsoft.DSC.Transitional/RunCommandOnSet
+    properties:
+      executable: "powershell.exe"
+      arguments:
+        - "-Command"
+        - $command
+      exitCode: 0
+"@
+```
+
+Apply the configuration document with the [dsc config set][00] command:
+
+```powershell
+dsc config set --input $document
+```
+
+To verify the result, you can run the `winget.exe` command:
+
+```powershell
+winget list --id Microsoft.PowerShell
+```
+
+<!-- Link reference definitions -->
+[00]: ../../../../../cli/config/set.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
@@ -54,7 +54,7 @@ The resource allows you to:
 > [!IMPORTANT]
 > The **Get** operation for this resource does not return any output from the executed command.
 > Additionally, when using the **Test** operation, the resource always reports as being
-> in the desired state.
+> in the desired state. DSC _always_ invokes the command during **Set**.
 
 ## Capabilities
 
@@ -121,7 +121,8 @@ IsWriteOnly       : false
 </details>
 
 Defines the arguments to pass to the executable. Each element in the array represents a
-separate argument that will be passed to the executable.
+separate argument that will be passed to the executable. The arguments are passed
+in the same order that you specify them.
 
 ### exitCode
 
@@ -138,7 +139,7 @@ DefaultValue          : 0
 
 </details>
 
-Defines the expected exit code to indicate success if not zero. By default, an exit code of 0 indicates
+Defines the expected exit code to indicate success if not zero. By default, an exit code of `0` indicates
 successful execution. If your executable returns a different exit code to indicate success, specify that value here.
 
 ## Instance validating schema

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
@@ -1,0 +1,171 @@
+---
+description: Microsoft.DSC.Transitional/RunCommandOnSet resource reference documentation
+ms.date:     06/30/2025
+ms.topic:    reference
+title:       Microsoft.DSC.Transitional/RunCommandOnSet
+---
+
+# Microsoft.DSC.Transitional/RunCommandOnSet
+
+## Synopsis
+
+Execute a command during DSC set operations.
+
+## Metadata
+
+```yaml
+Version    : 0.1.0
+Kind       : resource
+Tags       : [transitional, windows, linux, macos]
+Author     : Microsoft
+```
+
+## Instance definition syntax
+
+```yaml
+resources:
+  - name: <instance name>
+    type: Microsoft.DSC.Transitional/RunCommandOnSet
+    properties:
+      # Required properties
+      executable: string
+      # Optional properties
+      arguments: array
+      exitCode: integer
+```
+
+## Description
+
+The `Microsoft.DSC.Transitional/RunCommandOnSet` resource enables you to run a specified executable command during the DSC
+set operation. This is useful for commands that need to run as part of your configuration, but haven't fully transitioned to
+a DSC resource.
+
+The resource allows you to:
+
+- Specify an executable to run
+- Pass arguments to the executable
+- Define a custom exit code to indicate success
+
+## Capabilities
+
+The resource has the following capabilities:
+
+- `get` - You can use the resource to retrieve the actual state of an instance.
+- `set` - You can use the resource to enforce the desired state for an instance.
+
+This resource uses the synthetic test functionality of DSC to determine whether an instance is in
+the desired state. For more information about resource capabilities, see
+[DSC resource capabilities][00].
+
+## Examples
+
+1. [Run a simple command][01] - Shows how to create and delete registry keys with the
+   `dsc resource` commands.
+1. [Run a PowerShell command][02] - Shows how to create, modify, and delete registry values with the
+   `dsc resource` commands.
+
+## Properties
+
+The following list describes the properties for the resource.
+
+- **Required properties:** <a id="required-properties"></a> The following properties are always
+  required when defining an instance of the resource. An instance that doesn't define each of these
+  properties is invalid.
+
+  - [executable](#executable) - The executable to run on set.
+
+- **Instance properties:** <a id="instance-properties"></a> The following properties are optional.
+  They define the desired state for an instance of the resource.
+
+  - [arguments](#arguments) - The argument(s), if any, to pass to the executable that runs on get or set.
+  - [exitCode](#exitcode) - The expected exit code to indicate success, if non-zero. Default is zero for success.
+
+### executable
+
+<details><summary>Expand for <code>executable</code> property metadata</summary>
+
+```yaml
+Type             : string
+IsRequired       : true
+IsKey            : false
+IsReadOnly       : false
+IsWriteOnly      : false
+```
+
+</details>
+
+Defines the executable program or command to run during the DSC Set operation.
+This can be any valid executable file or command accessible from the system PATH.
+
+### arguments
+
+<details><summary>Expand for <code>arguments</code> property metadata</summary>
+
+```yaml
+Type              : array
+ItemsType         : string
+IsRequired        : false
+IsKey             : false
+IsReadOnly        : false
+IsWriteOnly       : false
+```
+
+</details>
+
+Defines the arguments to pass to the executable. Each element in the array represents a
+separate argument that will be passed to the executable.
+
+### exitCode
+
+<details><summary>Expand for <code>exitCode</code> property metadata</summary>
+
+```yaml
+Type                  : integer
+IsRequired            : false
+IsKey                 : false
+IsReadOnly            : false
+IsWriteOnly           : false
+DefaultValue          : 0
+```
+
+</details>
+
+Defines the expected exit code to indicate success if not zero. By default, an exit code of 0 indicates
+successful execution. If your executable returns a different exit code to indicate success, specify that value here.
+
+## Instance validating schema
+
+The following snippet contains the JSON Schema that validates an instance of the resource.
+
+```json
+{
+  "type": "object",
+  "required": [
+    "executable"
+  ],
+  "properties": {
+    "arguments": {
+      "title": "The argument(s), if any, to pass to the executable that runs on set",
+      "type": "array"
+    },
+    "executable": {
+      "title": "The executable to run on set",
+      "type": "string"
+    },
+    "exitCode": {
+      "title": "The expected exit code to indicate success, if non-zero. Default is zero for success.",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": false
+}
+```
+
+## See also
+
+- [Microsoft.DSC.PowerShell](../../PowerShell/index.md)
+- [Microsoft.Windows.WindowsPowerShell](../../../../Microsoft/Windows/WindowsPowerShell/index.md)
+
+[00]: ../../../../concepts/dsc/resource-capabilities.md
+[01]: ./examples/run-a-simple-command.md
+[02]: ./examples/run-powershell-command.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
@@ -9,14 +9,19 @@ title:       Microsoft.DSC.Transitional/RunCommandOnSet
 
 ## Synopsis
 
-Execute a command during DSC set operations.
+Execute a command during DSC **Set** operation.
+
+> [!IMPORTANT]
+> The `runcommandonset` command and `Microsoft.DSC.Transitional/RunCommandOnSet` resource
+> is intended as a temporary transitional resource while migrating DSCv3 resources for
+> your needs.
 
 ## Metadata
 
 ```yaml
 Version    : 0.1.0
 Kind       : resource
-Tags       : [transitional, windows, linux, macos]
+Tags       : [Transitional, Windows, Linux, MacOS]
 Author     : Microsoft
 ```
 
@@ -36,9 +41,9 @@ resources:
 
 ## Description
 
-The `Microsoft.DSC.Transitional/RunCommandOnSet` resource enables you to run a specified executable command during the DSC
-set operation. This is useful for commands that need to run as part of your configuration, but haven't fully transitioned to
-a DSC resource.
+The `Microsoft.DSC.Transitional/RunCommandOnSet` resource enables you to run a specified executable command
+during the DSC **Set** operation. This is useful for commands that need to run as part of your configuration,
+but haven't fully transitioned to a DSC resource.
 
 The resource allows you to:
 
@@ -94,7 +99,7 @@ IsWriteOnly      : false
 
 </details>
 
-Defines the executable program or command to run during the DSC Set operation.
+Defines the executable program or command to run during the DSC **Set** operation.
 This can be any valid executable file or command accessible from the system PATH.
 
 ### arguments

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
@@ -51,6 +51,11 @@ The resource allows you to:
 - Pass arguments to the executable
 - Define a custom exit code to indicate success
 
+> [!IMPORTANT]
+> The **Get** operation for this resource does not return any output from the executed command.
+> Additionally, when using the **Test** operation, the resource always reports as being
+> in the desired state.
+
 ## Capabilities
 
 The resource has the following capabilities:
@@ -64,10 +69,8 @@ the desired state. For more information about resource capabilities, see
 
 ## Examples
 
-1. [Run a simple command][01] - Shows how to create and delete registry keys with the
-   `dsc resource` commands.
-1. [Run a PowerShell command][02] - Shows how to create, modify, and delete registry values with the
-   `dsc resource` commands.
+1. [Run a simple command][01] - Shows how to run a simple command.
+1. [Run a PowerShell command][02] - Shows how you can run a PowerShell command.
 
 ## Properties
 

--- a/runcommandonset/tests/runcommandonset.set.tests.ps1
+++ b/runcommandonset/tests/runcommandonset.set.tests.ps1
@@ -80,7 +80,7 @@ Describe 'tests for runcommandonset set' {
     It 'Input provided via configuration doc' {
         $command = "Write-Output Hello | Out-File " + $TestDrive + "/output.txt" + " -Append"
         $config_yaml = @"
-            `$schema: https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/config/document.json
+            `$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
             resources:
             - name: set
               type: Microsoft.DSC.Transitional/RunCommandOnSet


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As part of https://github.com/PowerShell/DSC/issues/665, this PR adds reference documentation for the Microsoft.DSC.Transitional/RunCommandOnSet resource. Updated the manifest URI in the test.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
