### PR TITLE
Enable resources to return metadata

### DIFF
--- a/dsc/tests/dsc_metadata.tests.ps1
+++ b/dsc/tests/dsc_metadata.tests.ps1
@@ -1,0 +1,74 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'metadata tests' {
+    It 'resource can provide metadata for <operation>' -TestCases @(
+        @{ operation = 'get' }
+        @{ operation = 'set' }
+        @{ operation = 'test' }
+    ) {
+        param($operation)
+
+        $configYaml = @'
+        $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+        resources:
+          - name: test
+            type: Test/Metadata
+            properties:
+              _metadata:
+                hello: world
+                myNumber: 42
+'@
+
+        $out = dsc config $operation -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results.count | Should -Be 1
+        $out.results[0].metadata.hello | Should -BeExactly 'world'
+        $out.results[0].metadata.myNumber | Should -Be 42
+    }
+
+    It 'resource can provide metadata for export' {
+        $configYaml = @'
+        $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+        resources:
+          - name: test
+            type: Test/Metadata
+            properties:
+              _metadata:
+                hello: There
+                myNumber: 16
+'@
+        $out = dsc config export -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.resources.count | Should -Be 3
+        $out.resources[0].metadata.hello | Should -BeExactly 'There'
+        $out.resources[0].metadata.myNumber | Should -Be 16
+        $out.resources[0].name | Should -BeExactly 'Metadata example 1'
+        $out.resources[1].metadata.hello | Should -BeExactly 'There'
+        $out.resources[1].metadata.myNumber | Should -Be 16
+        $out.resources[1].name | Should -BeExactly 'Metadata example 2'
+        $out.resources[2].metadata.hello | Should -BeExactly 'There'
+        $out.resources[2].metadata.myNumber | Should -Be 16
+        $out.resources[2].name | Should -BeExactly 'Metadata example 3'
+    }
+
+    It 'resource returning Microsoft.DSC metadata is ignored' {
+        $configYaml = @'
+        $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+        resources:
+          - name: test
+            type: Test/Metadata
+            properties:
+              _metadata:
+                Microsoft.DSC:
+                  hello: world
+                validOne: true
+'@
+        $out = dsc config get -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results.count | Should -Be 1
+        $out.results[0].metadata.validOne | Should -BeTrue
+        $out.results[0].metadata.Microsoft.DSC | Should -BeNullOrEmpty
+        (Get-Content $TestDrive/error.log) | Should -BeLike "*Resource returned metadata property 'Microsoft.DSC' which is ignored*"
+    }
+}

--- a/dsc/tests/dsc_metadata.tests.ps1
+++ b/dsc/tests/dsc_metadata.tests.ps1
@@ -69,6 +69,6 @@ Describe 'metadata tests' {
         $out.results.count | Should -Be 1
         $out.results[0].metadata.validOne | Should -BeTrue
         $out.results[0].metadata.Microsoft.DSC | Should -BeNullOrEmpty
-        (Get-Content $TestDrive/error.log) | Should -BeLike "*Resource returned metadata property 'Microsoft.DSC' which is ignored*"
+        (Get-Content $TestDrive/error.log) | Should -BeLike "*WARN*Resource returned metadata property 'Microsoft.DSC' which is ignored*"
     }
 }

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -67,6 +67,8 @@ parameterNotObject = "Parameter '%{name}' is not an object"
 invokePropertyExpressions = "Invoke property expressions"
 invokeExpression = "Invoke property expression for %{name}: %{value}"
 propertyNotString = "Property '%{name}' with value '%{value}' is not a string"
+metadataMicrosoftDscIgnored = "Resource returned metadata property 'Microsoft.DSC' which is ignored"
+metadataNotObject = "Resource returned 'metadata' property which is not an object"
 
 [discovery.commandDiscovery]
 couldNotReadSetting = "Could not read 'resourcePath' setting"

--- a/tools/dsctest/metadata.dsc.resource.json
+++ b/tools/dsctest/metadata.dsc.resource.json
@@ -1,0 +1,57 @@
+{
+    "$schema": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/2024/04/bundled/resource/manifest.json",
+    "type": "Test/Metadata",
+    "version": "0.1.0",
+    "get": {
+        "executable": "dsctest",
+        "args": [
+            "metadata",
+            {
+                "jsonInputArg": "--input",
+                "mandatory": true
+            }
+        ]
+    },
+    "set": {
+        "executable": "dsctest",
+        "args": [
+            "metadata",
+            {
+                "jsonInputArg": "--input",
+                "mandatory": true
+            }
+        ],
+        "return": "state"
+    },
+    "test": {
+        "executable": "dsctest",
+        "args": [
+            "metadata",
+            {
+                "jsonInputArg": "--input",
+                "mandatory": true
+            }
+        ]
+    },
+    "export": {
+        "executable": "dsctest",
+        "args": [
+            "metadata",
+            {
+                "jsonInputArg": "--input",
+                "mandatory": true
+            },
+            "--export"
+        ]
+    },
+    "schema": {
+        "command": {
+            "executable": "dsctest",
+            "args": [
+                "schema",
+                "-s",
+                "metadata"
+            ]
+        }
+    }
+}

--- a/tools/dsctest/src/args.rs
+++ b/tools/dsctest/src/args.rs
@@ -8,9 +8,10 @@ pub enum Schemas {
     Delete,
     Exist,
     ExitCode,
-    InDesiredState,
     Export,
     Exporter,
+    InDesiredState,
+    Metadata,
     Sleep,
     Trace,
     WhatIf,
@@ -44,11 +45,6 @@ pub enum SubCommand {
         input: String,
     },
 
-    #[clap(name = "in-desired-state", about = "Specify if the resource is in the desired state")]
-    InDesiredState {
-        #[clap(name = "input", short, long, help = "The input to the in desired state command as JSON")]
-        input: String,
-    },
     #[clap(name = "export", about = "Export instances")]
     Export {
         #[clap(name = "input", short, long, help = "The input to the export command as JSON")]
@@ -59,6 +55,20 @@ pub enum SubCommand {
     Exporter {
         #[clap(name = "input", short, long, help = "The input to the exporter command as JSON")]
         input: String,
+    },
+
+    #[clap(name = "in-desired-state", about = "Specify if the resource is in the desired state")]
+    InDesiredState {
+        #[clap(name = "input", short, long, help = "The input to the in desired state command as JSON")]
+        input: String,
+    },
+
+    #[clap(name = "metadata", about = "Return the metadata")]
+    Metadata {
+        #[clap(name = "input", short, long, help = "The input to the metadata command as JSON")]
+        input: String,
+        #[clap(name = "export", short, long, help = "Use export operation")]
+        export: bool,
     },
 
     #[clap(name = "schema", about = "Get the JSON schema for a subcommand")]

--- a/tools/dsctest/src/metadata.rs
+++ b/tools/dsctest/src/metadata.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+#[allow(clippy::struct_field_names)]
+pub struct Metadata {
+    #[serde(rename="_metadata", skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Map<String, Value>>,
+    #[serde(rename="_name", skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<u32>,
+}


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enable resources to return `_metadata` object that gets populated into the resource `metadata` field.  Reserved `Microsoft.DSC` property is ignored, but a warning message is emitted.  Works for all operations.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/467