### PR TITLE
Fix trace message for function result

### DIFF
--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -113,7 +113,7 @@ impl Expression {
     /// This function will return an error if the expression fails to execute.
     pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<Value, DscError> {
         let result = self.function.invoke(function_dispatcher, context)?;
-        // TODO: check if `secret()` funciton and don't emit result
+        // TODO: check if `secret()` function and don't emit result
         let result_json = serde_json::to_string(&result)?;
         trace!("{}", t!("parser.expression.functionResult", results = result_json));
         if self.accessors.is_empty() {

--- a/dsc_lib/src/parser/expressions.rs
+++ b/dsc_lib/src/parser/expressions.rs
@@ -113,7 +113,9 @@ impl Expression {
     /// This function will return an error if the expression fails to execute.
     pub fn invoke(&self, function_dispatcher: &FunctionDispatcher, context: &Context) -> Result<Value, DscError> {
         let result = self.function.invoke(function_dispatcher, context)?;
-        trace!("{}", t!("parser.expression.functionResult", result = result : {:?}));
+        // TODO: check if `secret()` funciton and don't emit result
+        let result_json = serde_json::to_string(&result)?;
+        trace!("{}", t!("parser.expression.functionResult", results = result_json));
         if self.accessors.is_empty() {
             Ok(result)
         }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Previously the code was using `result` as the trace parameter name, but it's actually `results`.  However, it also used the debug format which although more human readable, I think JSON is easier as you can pretty print or even convert to YAML easily.