### PR TITLE
Add wmiAdapter module to Windows package

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -65,6 +65,8 @@ $filesForWindowsPackage = @(
     'windowspowershell.dsc.resource.json',
     'wmi.dsc.resource.json',
     'wmi.resource.ps1',
+    'wmiAdapter.psd1',
+    'wmiAdapter.psm1',
     'windows_baseline.dsc.yaml',
     'windows_inventory.dsc.yaml'
 )


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

A PR to convert wmiAdapter to use the module pattern failed to add the module to the package list for Windows.  Fix is to add the psd1 and psm1.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/967