### PR TITLE
Enable resources to return _restartRequired metadata

### DIFF
--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -289,4 +289,5 @@ pub enum SchemaType {
     ExtensionManifest,
     ExtensionDiscoverResult,
     FunctionDefinition,
+    RestartRequired
 }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -8,7 +8,10 @@ use dsc_lib::extensions::discover::DiscoverResult;
 use dsc_lib::extensions::extension_manifest::ExtensionManifest;
 use dsc_lib::{
     configure::{
-        config_doc::Configuration,
+        config_doc::{
+            Configuration,
+            RestartRequired,
+        },
         config_result::{
             ConfigurationGetResult,
             ConfigurationSetResult,
@@ -187,6 +190,9 @@ pub fn get_schema(schema: SchemaType) -> RootSchema {
         },
         SchemaType::FunctionDefinition => {
             schema_for!(FunctionDefinition)
+        },
+        SchemaType::RestartRequired => {
+            schema_for!(RestartRequired)
         }
     }
 }

--- a/dsc/tests/dsc_metadata.tests.ps1
+++ b/dsc/tests/dsc_metadata.tests.ps1
@@ -123,4 +123,21 @@ Describe 'metadata tests' {
         $out.metadata.'Microsoft.DSC'.restartRequired[4].process.name | Should -BeExactly 'anotherProcess'
         $out.metadata.'Microsoft.DSC'.restartRequired[4].process.id | Should -Be 5678
     }
+
+    It 'invalid item in _restartRequired metadata is a warning' {
+        $configYaml = @'
+        $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+        resources:
+          - name: test
+            type: Test/Metadata
+            properties:
+              _metadata:
+                _restartRequired:
+                  - invalid: item
+'@
+        $out = dsc config get -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        (Get-Content $TestDrive/error.log) | Should -BeLike "*WARN*Resource returned '_metadata' property '_restartRequired' which contains invalid value: ``[{`"invalid`":`"item`"}]*"
+        $out.results[0].metadata._restartRequired | Should -BeNullOrEmpty
+    }
 }

--- a/dsc/tests/dsc_metadata.tests.ps1
+++ b/dsc/tests/dsc_metadata.tests.ps1
@@ -71,4 +71,56 @@ Describe 'metadata tests' {
         $out.results[0].metadata.Microsoft.DSC | Should -BeNullOrEmpty
         (Get-Content $TestDrive/error.log) | Should -BeLike "*WARN*Resource returned '_metadata' property 'Microsoft.DSC' which is ignored*"
     }
+
+    It 'resource returning _restartRequired metadata is handled' {
+        $configYaml = @'
+        $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+        resources:
+          - name: one
+            type: Test/Metadata
+            properties:
+              _metadata:
+                _restartRequired:
+                  - system: mySystem
+                  - service: myService
+          - name: two
+            type: Test/Metadata
+            properties:
+              _metadata:
+                _restartRequired:
+                  - service: sshd
+          - name: three
+            type: Test/Metadata
+            properties:
+              _metadata:
+                _restartRequired:
+                  - process:
+                      name: myProcess
+                      id: 1234
+                  - process:
+                      name: anotherProcess
+                      id: 5678
+'@
+        $out = dsc config get -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results.count | Should -Be 3
+        $out.results[0].metadata._restartRequired.count | Should -Be 2
+        $out.results[0].metadata._restartRequired[0].system | Should -BeExactly 'mySystem'
+        $out.results[0].metadata._restartRequired[1].service | Should -BeExactly 'myService'
+        $out.results[1].metadata._restartRequired.count | Should -Be 1
+        $out.results[1].metadata._restartRequired[0].service | Should -BeExactly 'sshd'
+        $out.results[2].metadata._restartRequired.count | Should -Be 2
+        $out.results[2].metadata._restartRequired[0].process.name | Should -BeExactly 'myProcess'
+        $out.results[2].metadata._restartRequired[0].process.id | Should -Be 1234
+        $out.results[2].metadata._restartRequired[1].process.name | Should -BeExactly 'anotherProcess'
+        $out.results[2].metadata._restartRequired[1].process.id | Should -Be 5678
+        $out.metadata.'Microsoft.DSC'.restartRequired.count | Should -Be 5
+        $out.metadata.'Microsoft.DSC'.restartRequired[0].system | Should -BeExactly 'mySystem'
+        $out.metadata.'Microsoft.DSC'.restartRequired[1].service | Should -BeExactly 'myService'
+        $out.metadata.'Microsoft.DSC'.restartRequired[2].service | Should -BeExactly 'sshd'
+        $out.metadata.'Microsoft.DSC'.restartRequired[3].process.name | Should -BeExactly 'myProcess'
+        $out.metadata.'Microsoft.DSC'.restartRequired[3].process.id | Should -Be 1234
+        $out.metadata.'Microsoft.DSC'.restartRequired[4].process.name | Should -BeExactly 'anotherProcess'
+        $out.metadata.'Microsoft.DSC'.restartRequired[4].process.id | Should -Be 5678
+    }
 }

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -69,6 +69,7 @@ invokeExpression = "Invoke property expression for %{name}: %{value}"
 propertyNotString = "Property '%{name}' with value '%{value}' is not a string"
 metadataMicrosoftDscIgnored = "Resource returned '_metadata' property 'Microsoft.DSC' which is ignored"
 metadataNotObject = "Resource returned '_metadata' property which is not an object"
+metadataRestartRequiredInvalid = "Resource returned '_metadata' property '_restartRequired' which contains invalid value: %{value}"
 
 [discovery.commandDiscovery]
 couldNotReadSetting = "Could not read 'resourcePath' setting"

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -34,6 +34,21 @@ pub enum ExecutionKind {
     WhatIf,
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Process {
+    pub name: String,
+    pub id: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum RestartRequired {
+    System(String),
+    Service(String),
+    Process(Process),
+}
+
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct MicrosoftDscMetadata {
     /// Version of DSC
@@ -57,6 +72,9 @@ pub struct MicrosoftDscMetadata {
     /// The security context of the configuration operation, can be specified to be required
     #[serde(rename = "securityContext", skip_serializing_if = "Option::is_none")]
     pub security_context: Option<SecurityContextKind>,
+    /// Indicates what needs to be restarted after the configuration operation
+    #[serde(rename = "restartRequired", skip_serializing_if = "Option::is_none")]
+    pub restart_required: Option<Vec<RestartRequired>>,
 }
 
 impl MicrosoftDscMetadata {

--- a/dsc_lib/src/configure/context.rs
+++ b/dsc_lib/src/configure/context.rs
@@ -7,7 +7,7 @@ use security_context_lib::{get_security_context, SecurityContext};
 use serde_json::{Map, Value};
 use std::{collections::HashMap, path::PathBuf};
 
-use super::config_doc::{DataType, SecurityContextKind};
+use super::config_doc::{DataType, RestartRequired, SecurityContextKind};
 
 pub struct Context {
     pub execution_type: ExecutionKind,
@@ -17,6 +17,7 @@ pub struct Context {
     pub security_context: SecurityContextKind,
     pub variables: Map<String, Value>,
     pub start_datetime: DateTime<Local>,
+    pub restart_required: Option<Vec<RestartRequired>>,
 }
 
 impl Context {
@@ -33,6 +34,7 @@ impl Context {
             },
             variables: Map::new(),
             start_datetime: chrono::Local::now(),
+            restart_required: None,
         }
     }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -235,7 +235,7 @@ fn get_metadata_from_result(mut context: Option<&mut Context>, result: &mut Valu
                 }
                 if let Some(ref mut context) = context {
                     if key == "_restartRequired" {
-                        if let Some(restart_required) = serde_json::from_value::<Vec<RestartRequired>>(value.clone()).ok() {
+                        if let Ok(restart_required) = serde_json::from_value::<Vec<RestartRequired>>(value.clone()) {
                             context.restart_required.get_or_insert_with(Vec::new).extend(restart_required);
                         } else {
                             warn!("{}", t!("configure.mod.metadataRestartRequiredInvalid", value = value));
@@ -775,11 +775,7 @@ impl Configurator {
                     end_datetime: Some(end_datetime.to_rfc3339()),
                     duration: Some(end_datetime.signed_duration_since(self.context.start_datetime).to_string()),
                     security_context: Some(self.context.security_context.clone()),
-                    restart_required: if let Some(restart_required) = self.context.restart_required.clone() {
-                        Some(restart_required)
-                    } else {
-                        None
-                    },
+                    restart_required: self.context.restart_required.clone(),
                 }
             ),
             other: Map::new(),


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Allow resources to return `_restartRequired` as part of `_metadata`.  This is an array that can contain any of:

```json
{ "system": "computerName" }
```

```json
{ "service": "serviceName" }
```

```json
{ "process":
  {
    "name": "processName",
    "id": "pid"
  }
}
```

The metadata is pulled into each resources metadata as part of result object, but also collected into the top level `Microsoft.DSC` metadata:

<img width="1147" height="1047" alt="image" src="https://github.com/user-attachments/assets/16e4ec63-6241-4391-b078-a8d800d941f7" />

Any items in the array that don't conform to the above results in a warning.  `dsc schema -t restart-required` returns the JSONSchema.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/50