### PR TITLE
Add `condition` support to resources within config

### DIFF
--- a/dsc/tests/dsc_resource_condition.tests.ps1
+++ b/dsc/tests/dsc_resource_condition.tests.ps1
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+BeforeDiscovery {
+    $configYaml = @'
+    $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+    resources:
+        - name: test
+        type: Microsoft.DSC.Debug/Echo
+        condition: "[equals('skip', 'yes')]"
+        properties:
+            output: "This should not be executed"
+        - name: test2
+        type: Microsoft.DSC.Debug/Echo
+        condition: "[equals('no', 'no')]"
+        properties:
+            output: "This should be executed"
+'@
+
+}
+
+Describe 'Resource condition tests' {
+    It 'resource should be skipped for <operation>' -TestCases @(
+        @{ operation = 'get'; property = 'actualState' },
+        @{ operation = 'set'; property = 'afterState' },
+        @{ operation = 'test'; property = 'actualState' }
+    ) {
+        param($operation, $property)
+        $out = dsc config $operation -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results.count | Should -Be 1
+        $out.results[0].result.$property.Output | Should -BeExactly "This should be executed"
+    }
+
+    It 'resource should be skipped for export' {
+        $out = dsc config export -i $configYaml 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.resources.count | Should -Be 1
+        $out.resources[0].type | Should -BeExactly 'Microsoft.DSC.Debug/Echo'
+        $out.resources[0].properties.output | Should -BeExactly "This should be executed"
+    }
+}

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -3,6 +3,7 @@ _version = 1
 [configure.config_doc]
 configurationDocumentSchemaTitle = "Configuration document schema URI"
 configurationDocumentSchemaDescription = "Defines the JSON Schema the configuration document adheres to."
+skippingResource = "Skipping resource '%{name}' due to condition '%{condition}' with result '%{result}'"
 
 [configure.constraints]
 minLengthIsNull = "Parameter '%{name}' has minimum length constraint but is null"

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -160,6 +160,8 @@ pub struct Resource {
     pub properties: Option<Map<String, Value>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<Metadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub condition: Option<String>,
 }
 
 impl Default for Configuration {
@@ -217,6 +219,7 @@ impl Resource {
             kind: None,
             properties: None,
             metadata: None,
+            condition: None,
         }
     }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -311,6 +311,14 @@ impl Configurator {
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Get '{}'", resource.name).as_str());
+            if let Some(condition) = &resource.condition {
+                let condition_result = self.statement_parser.parse_and_execute(condition, &self.context)?;
+                if condition_result != Value::Bool(true) {
+                    info!("{}", t!("configure.config_doc.skippingResource", name = resource.name, condition = condition, result = condition_result));
+                    progress.write_increment(1);
+                    continue;
+                }
+            }
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
@@ -387,6 +395,14 @@ impl Configurator {
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Set '{}'", resource.name).as_str());
+            if let Some(condition) = &resource.condition {
+                let condition_result = self.statement_parser.parse_and_execute(condition, &self.context)?;
+                if condition_result != Value::Bool(true) {
+                    info!("{}", t!("configure.config_doc.skippingResource", name = resource.name, condition = condition, result = condition_result));
+                    progress.write_increment(1);
+                    continue;
+                }
+            }
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
@@ -535,6 +551,14 @@ impl Configurator {
         for resource in resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Test '{}'", resource.name).as_str());
+            if let Some(condition) = &resource.condition {
+                let condition_result = self.statement_parser.parse_and_execute(condition, &self.context)?;
+                if condition_result != Value::Bool(true) {
+                    info!("{}", t!("configure.config_doc.skippingResource", name = resource.name, condition = condition, result = condition_result));
+                    progress.write_increment(1);
+                    continue;
+                }
+            }
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type));
             };
@@ -608,6 +632,14 @@ impl Configurator {
         for resource in &resources {
             progress.set_resource(&resource.name, &resource.resource_type);
             progress.write_activity(format!("Export '{}'", resource.name).as_str());
+            if let Some(condition) = &resource.condition {
+                let condition_result = self.statement_parser.parse_and_execute(condition, &self.context)?;
+                if condition_result != Value::Bool(true) {
+                    info!("{}", t!("configure.config_doc.skippingResource", name = resource.name, condition = condition, result = condition_result));
+                    progress.write_increment(1);
+                    continue;
+                }
+            }
             let Some(dsc_resource) = discovery.find_resource(&resource.resource_type) else {
                 return Err(DscError::ResourceNotFound(resource.resource_type.clone()));
             };

--- a/dscecho/echo.dsc.resource.json
+++ b/dscecho/echo.dsc.resource.json
@@ -30,6 +30,15 @@
             }
         ]
     },
+    "export": {
+        "executable": "dscecho",
+        "args": [
+            {
+                "jsonInputArg": "--input",
+                "mandatory": true
+            }
+        ]
+    },
     "schema": {
         "command": {
             "executable": "dscecho"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Support use of ARM's `condition` property for a resource where if the expression evaluates to `true` then the resource is used, but if `false` the resource is skipped.

```yaml
    $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
    resources:
        - name: test
        type: Microsoft.DSC.Debug/Echo
        condition: "[equals('skip', 'yes')]"
        properties:
            output: "This should not be executed"
        - name: test2
        type: Microsoft.DSC.Debug/Echo
        condition: "[equals('no', 'no')]"
        properties:
            output: "This should be executed"
```

## PR Context

Fix https://github.com/PowerShell/DSC/issues/972