### PR TITLE
Fix inconsistencies in reference doc examples

### DIFF
--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
@@ -70,7 +70,7 @@ dsc config set --input $document
 To verify the result, you can run the `winget.exe` command:
 
 ```powershell
-winget list --id Microsoft.PowerShell
+winget list --id Microsoft.PowerShell.Preview
 ```
 
 <!-- Link reference definitions -->

--- a/docs/reference/resources/Microsoft/Windows/WindowsPowerShell/examples/manage-a-windows-service.md
+++ b/docs/reference/resources/Microsoft/Windows/WindowsPowerShell/examples/manage-a-windows-service.md
@@ -40,7 +40,7 @@ differingProperties:
 - StartupType
 ```
 
-The `inDesiredState` field of the result object is set to `false`, indicating that the instance isn't in the desired state. The `differingProperties` field indicates that the `property` property is mismatched between the desired state and actual state.
+The `inDesiredState` field of the result object is set to `false`, indicating that the instance isn't in the desired state. The `differingProperties` field indicates that the `StartupType` property is mismatched between the desired state and actual state.
 
 ## Ensure a service is running with automatic startup
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The examples had inconsistencies where the previous part uses `Microsoft.PowerShell.Preview` and later uses `Microsoft.PowerShell` to verify.  Another example is incorrectly saying the name of the property as `property`, but is actually `StartupType`