### PR TITLE
Enable passing Bicep files directly to dsc

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -40,6 +40,7 @@ if ($GetPackageVersion) {
 $filesForWindowsPackage = @(
     'appx.dsc.extension.json',
     'appx-discover.ps1',
+    'bicep.dsc.extension.json',
     'dsc.exe',
     'dsc_default.settings.json',
     'dsc.settings.json',
@@ -75,6 +76,7 @@ $filesForWindowsPackage = @(
 )
 
 $filesForLinuxPackage = @(
+    'bicep.dsc.extension.json',
     'dsc',
     'dsc_default.settings.json',
     'dsc.settings.json'
@@ -99,6 +101,7 @@ $filesForLinuxPackage = @(
 )
 
 $filesForMacPackage = @(
+    'bicep.dsc.extension.json',
     'dsc',
     'dsc_default.settings.json',
     'dsc.settings.json'
@@ -305,6 +308,7 @@ if (!$SkipBuild) {
         "dsc_lib",
         "dsc",
         "dscecho",
+        "extensions/bicep",
         "osinfo",
         "powershell-adapter",
         'resources/PSScript',
@@ -313,8 +317,7 @@ if (!$SkipBuild) {
         "sshdconfig",
         "tools/dsctest",
         "tools/test_group_resource",
-        "y2j",
-        "."
+        "y2j"
     )
     $pedantic_unclean_projects = @()
     $clippy_unclean_projects = @("tree-sitter-dscexpression", "tree-sitter-ssh-server-config")

--- a/dsc/Cargo.lock
+++ b/dsc/Cargo.lock
@@ -582,6 +582,7 @@ dependencies = [
  "jsonschema",
  "linked-hash-map",
  "num-traits",
+ "path-absolutize",
  "regex",
  "rt-format",
  "rust-i18n",

--- a/dsc/examples/bicepconfig.json
+++ b/dsc/examples/bicepconfig.json
@@ -1,0 +1,5 @@
+{
+  "experimentalFeaturesEnabled": {
+    "desiredStateConfiguration": true
+  }
+}

--- a/dsc/examples/hello_world.dsc.bicep
+++ b/dsc/examples/hello_world.dsc.bicep
@@ -1,0 +1,11 @@
+// This is a very simple example Bicep file for testing
+
+targetScope = 'desiredStateConfiguration'
+
+// use workaround where Bicep currently requires version in date format
+resource echo 'Microsoft.DSC.Debug/Echo@2025-01-01' = {
+  name: 'exampleEcho'
+  properties: {
+    output: 'Hello, world!'
+  }
+}

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -480,7 +480,7 @@ pub fn validate_config(config: &Configuration, progress_format: ProgressFormat) 
     let schema = serde_json::to_value(get_schema(SchemaType::Configuration))?;
     let config_value = serde_json::to_value(config)?;
     validate_json("Configuration", &schema, &config_value)?;
-    let mut dsc = DscManager::new()?;
+    let mut dsc = DscManager::new();
 
     // then validate each resource
     let Some(resources) = config_value["resources"].as_array() else {
@@ -551,13 +551,7 @@ pub fn validate_config(config: &Configuration, progress_format: ProgressFormat) 
 }
 
 pub fn extension(subcommand: &ExtensionSubCommand, progress_format: ProgressFormat) {
-    let mut dsc = match DscManager::new() {
-        Ok(dsc) => dsc,
-        Err(err) => {
-            error!("Error: {err}");
-            exit(EXIT_DSC_ERROR);
-        }
-    };
+    let mut dsc = DscManager::new();
 
     match subcommand {
         ExtensionSubCommand::List{extension_name, output_format} => {
@@ -577,13 +571,7 @@ pub fn function(subcommand: &FunctionSubCommand) {
 
 #[allow(clippy::too_many_lines)]
 pub fn resource(subcommand: &ResourceSubCommand, progress_format: ProgressFormat) {
-    let mut dsc = match DscManager::new() {
-        Ok(dsc) => dsc,
-        Err(err) => {
-            error!("Error: {err}");
-            exit(EXIT_DSC_ERROR);
-        }
-    };
+    let mut dsc = DscManager::new();
 
     match subcommand {
         ResourceSubCommand::List { resource_name, adapter_name, description, tags, output_format } => {

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -3,9 +3,6 @@
 
 use crate::args::{SchemaType, OutputFormat, TraceFormat};
 use crate::resolve::Include;
-use dsc_lib::configure::config_result::ResourceTestResult;
-use dsc_lib::extensions::discover::DiscoverResult;
-use dsc_lib::extensions::extension_manifest::ExtensionManifest;
 use dsc_lib::{
     configure::{
         config_doc::{
@@ -16,22 +13,33 @@ use dsc_lib::{
         config_result::{
             ConfigurationGetResult,
             ConfigurationSetResult,
-            ConfigurationTestResult
-        }
+            ConfigurationTestResult,
+            ResourceTestResult,
+        },
     },
+    discovery::Discovery,
     dscerror::DscError,
     dscresources::{
         command_resource::TraceLevel,
-        dscresource::DscResource, invoke_result::{
+        dscresource::DscResource,
+        invoke_result::{
             GetResult,
             SetResult,
             TestResult,
             ResolveResult,
-        }, resource_manifest::ResourceManifest
+        },
+        resource_manifest::ResourceManifest
+    },
+    extensions::{
+        discover::DiscoverResult,
+        dscextension::Capability,
+        extension_manifest::ExtensionManifest,
     },
     functions::FunctionDefinition,
-    util::parse_input_to_json,
-    util::get_setting,
+    util::{
+        get_setting,
+        parse_input_to_json,
+    },
 };
 use jsonschema::Validator;
 use path_absolutize::Absolutize;
@@ -487,6 +495,14 @@ pub fn get_input(input: Option<&String>, file: Option<&String>, parameters_from_
                 }
             }
         } else {
+            // see if an extension should handle this file
+            let mut discovery = Discovery::new();
+            for extension in discovery.get_extensions(&Capability::Import) {
+                let Ok(content) = extension.import(path) else {
+                    continue;
+                };
+                return content;
+            }
             match std::fs::read_to_string(path) {
                 Ok(input) => {
                     // check if it contains UTF-8 BOM and remove it

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -498,10 +498,9 @@ pub fn get_input(input: Option<&String>, file: Option<&String>, parameters_from_
             // see if an extension should handle this file
             let mut discovery = Discovery::new();
             for extension in discovery.get_extensions(&Capability::Import) {
-                let Ok(content) = extension.import(path) else {
-                    continue;
-                };
-                return content;
+                if let Ok(content) = extension.import(path) {
+                    return content;
+                }
             }
             match std::fs::read_to_string(path) {
                 Ok(input) => {

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -15,11 +15,15 @@ Describe 'Discover extension tests' {
     It 'Discover extensions' {
         $out = dsc extension list | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out.Count | Should -Be 1
-        $out.type | Should -BeExactly 'Test/Discover'
-        $out.version | Should -BeExactly '0.1.0'
-        $out.capabilities | Should -BeExactly @('discover')
-        $out.manifest | Should -Not -BeNullOrEmpty
+        $out.Count | Should -Be 2 -Because ($out | Out-String)
+        $out[0].type | Should -Be 'Microsoft.DSC.Extension/Bicep'
+        $out[0].version | Should -Be '0.1.0'
+        $out[0].capabilities | Should -BeExactly @('import')
+        $out[0].manifest | Should -Not -BeNullOrEmpty
+        $out[1].type | Should -BeExactly 'Test/Discover'
+        $out[1].version | Should -BeExactly '0.1.0'
+        $out[1].capabilities | Should -BeExactly @('discover')
+        $out[1].manifest | Should -Not -BeNullOrEmpty
     }
 
     It 'Filtering works for extension discovered resources' {

--- a/dsc_lib/Cargo.lock
+++ b/dsc_lib/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "jsonschema",
  "linked-hash-map",
  "num-traits",
+ "path-absolutize",
  "regex",
  "rt-format",
  "rust-i18n",
@@ -1086,6 +1087,24 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/dsc_lib/Cargo.toml
+++ b/dsc_lib/Cargo.toml
@@ -21,6 +21,7 @@ indicatif = "0.18"
 jsonschema = { version = "0.30", default-features = false }
 linked-hash-map = "0.5"
 num-traits = "0.2"
+path-absolutize = { version = "3.1" }
 regex = "1.11"
 rt-format = "0.3"
 rust-i18n = { version = "3.1" }

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -97,7 +97,6 @@ callingExtension = "Calling extension '%{extension}' to discover resources"
 extensionFoundResources = "Extension '%{extension}' found %{count} resources"
 invalidManifestVersion = "Manifest '%{path}' has invalid version: %{err}"
 importExtensionsEmpty = "Import extension '%{extension}' has no import extensions defined"
-importNotSupported = "Import is not supported by extension '%{extension}' for file '%{file}'"
 
 [dscresources.commandResource]
 invokeGet = "Invoking get for '%{resource}'"

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -96,6 +96,8 @@ extensionResourceFound = "Extension found resource '%{resource}'"
 callingExtension = "Calling extension '%{extension}' to discover resources"
 extensionFoundResources = "Extension '%{extension}' found %{count} resources"
 invalidManifestVersion = "Manifest '%{path}' has invalid version: %{err}"
+importExtensionsEmpty = "Import extension '%{extension}' has no import extensions defined"
+importNotSupported = "Import is not supported by extension '%{extension}' for file '%{file}'"
 
 [dscresources.commandResource]
 invokeGet = "Invoking get for '%{resource}'"
@@ -183,6 +185,7 @@ secretExtensionReturnedInvalidJson = "Extension '%{extension}' returned invalid 
 extensionReturnedSecret = "Extension '%{extension}' returned secret"
 extensionReturnedNoSecret = "Extension '%{extension}' did not return a secret"
 secretNoResults = "Extension '%{extension}' returned no output"
+importingFile = "Importing file '%{file}' with extension '%{extension}'"
 
 [extensions.extension_manifest]
 extensionManifestSchemaTitle = "Extension manifest schema URI"

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -186,6 +186,8 @@ extensionReturnedSecret = "Extension '%{extension}' returned secret"
 extensionReturnedNoSecret = "Extension '%{extension}' did not return a secret"
 secretNoResults = "Extension '%{extension}' returned no output"
 importingFile = "Importing file '%{file}' with extension '%{extension}'"
+importNotSupported = "Import is not supported by extension '%{extension}' for file '%{file}'"
+importNoResults = "Extension '%{extension}' returned no results for import"
 
 [extensions.extension_manifest]
 extensionManifestSchemaTitle = "Extension manifest schema URI"
@@ -456,3 +458,4 @@ foundSetting = "Found setting '%{name}' in %{path}"
 notFoundSetting = "Setting '%{name}' not found in %{path}"
 failedToGetExePath = "Can't get 'dsc' executable path"
 settingNotFound = "Setting '%{name}' not found"
+failedToAbsolutizePath = "Failed to absolutize path '%{path}'"

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -266,7 +266,7 @@ impl Configurator {
     ///
     /// This function will return an error if the configuration is invalid or the underlying discovery fails.
     pub fn new(json: &str, progress_format: ProgressFormat) -> Result<Configurator, DscError> {
-        let discovery = Discovery::new()?;
+        let discovery = Discovery::new();
         let mut config = Configurator {
             json: json.to_owned(),
             config: Configuration::new(),

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -726,12 +726,25 @@ fn load_extension_manifest(path: &Path, manifest: &ExtensionManifest) -> Result<
         verify_executable(&manifest.r#type, "secret", &secret.executable);
         capabilities.push(dscextension::Capability::Secret);
     }
+    let import_extensions = if let Some(import) = &manifest.import {
+        verify_executable(&manifest.r#type, "import", &import.executable);
+        capabilities.push(dscextension::Capability::Import);
+        if import.extensions.is_empty() {
+            warn!("{}", t!("discovery.commandDiscovery.importExtensionsEmpty", extension = manifest.r#type));
+            None
+        } else {
+            Some(import.extensions.clone())
+        }
+    } else {
+        None
+    };
 
     let extension = DscExtension {
         type_name: manifest.r#type.clone(),
         description: manifest.description.clone(),
         version: manifest.version.clone(),
         capabilities,
+        import_extensions,
         path: path.to_str().unwrap().to_string(),
         directory: path.parent().unwrap().to_str().unwrap().to_string(),
         manifest: serde_json::to_value(manifest)?,

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -744,7 +744,7 @@ fn load_extension_manifest(path: &Path, manifest: &ExtensionManifest) -> Result<
         description: manifest.description.clone(),
         version: manifest.version.clone(),
         capabilities,
-        import_extensions,
+        import_file_extensions: import_extensions,
         path: path.to_str().unwrap().to_string(),
         directory: path.parent().unwrap().to_str().unwrap().to_string(),
         manifest: serde_json::to_value(manifest)?,

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -729,11 +729,11 @@ fn load_extension_manifest(path: &Path, manifest: &ExtensionManifest) -> Result<
     let import_extensions = if let Some(import) = &manifest.import {
         verify_executable(&manifest.r#type, "import", &import.executable);
         capabilities.push(dscextension::Capability::Import);
-        if import.extensions.is_empty() {
+        if import.file_extensions.is_empty() {
             warn!("{}", t!("discovery.commandDiscovery.importExtensionsEmpty", extension = manifest.r#type));
             None
         } else {
-            Some(import.extensions.clone())
+            Some(import.file_extensions.clone())
         }
     } else {
         None

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -25,6 +25,7 @@ impl Discovery {
     ///
     /// This function will return an error if the underlying instance creation fails.
     ///
+    #[must_use]
     pub fn new() -> Self {
         Self {
             resources: BTreeMap::new(),

--- a/dsc_lib/src/discovery/mod.rs
+++ b/dsc_lib/src/discovery/mod.rs
@@ -5,8 +5,9 @@ pub mod command_discovery;
 pub mod discovery_trait;
 
 use crate::discovery::discovery_trait::{DiscoveryKind, ResourceDiscovery};
-use crate::extensions::dscextension::DscExtension;
-use crate::{dscresources::dscresource::DscResource, dscerror::DscError, progress::ProgressFormat};
+use crate::extensions::dscextension::{Capability, DscExtension};
+use crate::{dscresources::dscresource::DscResource, progress::ProgressFormat};
+use core::result::Result::Ok;
 use std::collections::BTreeMap;
 use command_discovery::{CommandDiscovery, ImportedManifest};
 use tracing::error;
@@ -24,11 +25,11 @@ impl Discovery {
     ///
     /// This function will return an error if the underlying instance creation fails.
     ///
-    pub fn new() -> Result<Self, DscError> {
-        Ok(Self {
+    pub fn new() -> Self {
+        Self {
             resources: BTreeMap::new(),
             extensions: BTreeMap::new(),
-        })
+        }
     }
 
     /// List operation for getting available resources based on the filters.
@@ -64,9 +65,23 @@ impl Discovery {
                     resources.push(resource.clone());
                 }
             };
+
+            if let Ok(extensions) = discovery_type.get_extensions() {
+                self.extensions.extend(extensions);
+            }
         }
 
         resources
+    }
+
+    pub fn get_extensions(&mut self, capability: &Capability) -> Vec<DscExtension> {
+        if self.extensions.is_empty() {
+            self.list_available(&DiscoveryKind::Extension, "*", "", ProgressFormat::None);
+        }
+        self.extensions.values()
+            .filter(|ext| ext.capabilities.contains(capability))
+            .cloned()
+            .collect()
     }
 
     #[must_use]
@@ -108,7 +123,7 @@ impl Discovery {
 
 impl Default for Discovery {
     fn default() -> Self {
-        Self::new().unwrap()
+        Self::new()
     }
 }
 

--- a/dsc_lib/src/extensions/dscextension.rs
+++ b/dsc_lib/src/extensions/dscextension.rs
@@ -41,6 +41,8 @@ pub enum Capability {
     Discover,
     /// The extension aids in retrieving secrets.
     Secret,
+    /// The extension imports configuration from a different format.
+    Import,
 }
 
 impl Display for Capability {
@@ -48,6 +50,7 @@ impl Display for Capability {
         match self {
             Capability::Discover => write!(f, "Discover"),
             Capability::Secret => write!(f, "Secret"),
+            Capability::Import => write!(f, "Import"),
         }
     }
 }

--- a/dsc_lib/src/extensions/dscextension.rs
+++ b/dsc_lib/src/extensions/dscextension.rs
@@ -152,7 +152,8 @@ impl DscExtension {
     pub fn import(&self, file: &str) -> Result<String, DscError> {
         if self.capabilities.contains(&Capability::Import) {
             let file_path = Path::new(file);
-            if self.import_extensions.as_ref().is_some_and(|exts| exts.contains(&file_path.extension().and_then(|s| s.to_str()).unwrap_or_default().to_string())) {
+            let file_extension = file_path.extension().and_then(|s| s.to_str()).unwrap_or_default().to_string();
+            if self.import_extensions.as_ref().is_some_and(|exts| exts.contains(&file_extension)) {
                 debug!("{}", t!("extensions.dscextension.importingFile", file = file, extension = self.type_name));
             } else {
                 debug!("{}", t!("extensions.dscextension.importNotSupported", file = file, extension = self.type_name));
@@ -267,7 +268,7 @@ fn process_import_args(args: Option<&Vec<ImportArgKind>>, file: &str) -> Result<
     // make path absolute
     let path = Path::new(file);
     let Ok(full_path) = path.absolutize() else {
-        return Err(DscError::Extension(t!("util.failedToAbsolutizePath").to_string()));
+        return Err(DscError::Extension(t!("util.failedToAbsolutizePath", path = path : {:?}).to_string()));
     };
 
     let mut processed_args = Vec::<String>::new();

--- a/dsc_lib/src/extensions/dscextension.rs
+++ b/dsc_lib/src/extensions/dscextension.rs
@@ -145,10 +145,14 @@ impl DscExtension {
     /// # Returns
     ///
     /// A result containing the imported file content or an error.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the import fails or if the extension does not support the import capability.
     pub fn import(&self, file: &str) -> Result<String, DscError> {
         if self.capabilities.contains(&Capability::Import) {
             let file_path = Path::new(file);
-            if self.import_extensions.as_ref().map_or(false, |exts| exts.contains(&file_path.extension().and_then(|s| s.to_str()).unwrap_or_default().to_string())) {
+            if self.import_extensions.as_ref().is_some_and(|exts| exts.contains(&file_path.extension().and_then(|s| s.to_str()).unwrap_or_default().to_string())) {
                 debug!("{}", t!("extensions.dscextension.importingFile", file = file, extension = self.type_name));
             } else {
                 debug!("{}", t!("extensions.dscextension.importNotSupported", file = file, extension = self.type_name));

--- a/dsc_lib/src/extensions/dscextension.rs
+++ b/dsc_lib/src/extensions/dscextension.rs
@@ -24,7 +24,8 @@ pub struct DscExtension {
     /// The capabilities of the resource.
     pub capabilities: Vec<Capability>,
     /// The extensions supported for importing.
-    pub import_extensions: Option<Vec<String>>,
+    #[serde(rename = "importFileExtensions")]
+    pub import_file_extensions: Option<Vec<String>>,
     /// The file path to the resource.
     pub path: String,
     /// The description of the resource.
@@ -65,7 +66,7 @@ impl DscExtension {
             type_name: String::new(),
             version: String::new(),
             capabilities: Vec::new(),
-            import_extensions: None,
+            import_file_extensions: None,
             description: None,
             path: String::new(),
             directory: String::new(),
@@ -153,7 +154,7 @@ impl DscExtension {
         if self.capabilities.contains(&Capability::Import) {
             let file_path = Path::new(file);
             let file_extension = file_path.extension().and_then(|s| s.to_str()).unwrap_or_default().to_string();
-            if self.import_extensions.as_ref().is_some_and(|exts| exts.contains(&file_extension)) {
+            if self.import_file_extensions.as_ref().is_some_and(|exts| exts.contains(&file_extension)) {
                 debug!("{}", t!("extensions.dscextension.importingFile", file = file, extension = self.type_name));
             } else {
                 debug!("{}", t!("extensions.dscextension.importNotSupported", file = file, extension = self.type_name));

--- a/dsc_lib/src/extensions/extension_manifest.rs
+++ b/dsc_lib/src/extensions/extension_manifest.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use std::collections::HashMap;
 
 use crate::{dscerror::DscError, schemas::DscRepoSchema};
-use crate::extensions::{discover::DiscoverMethod, secret::SecretMethod};
+use crate::extensions::{discover::DiscoverMethod, import::ImportMethod, secret::SecretMethod};
 
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 #[serde(deny_unknown_fields)]
@@ -29,6 +29,8 @@ pub struct ExtensionManifest {
     pub tags: Option<Vec<String>>,
     /// Details how to call the Discover method of the extension.
     pub discover: Option<DiscoverMethod>,
+    /// Details how to call the Import method of the extension.
+    pub import: Option<ImportMethod>,
     /// Details how to call the Secret method of the extension.
     pub secret: Option<SecretMethod>,
     /// Mapping of exit codes to descriptions.  Zero is always success and non-zero is always failure.

--- a/dsc_lib/src/extensions/import.rs
+++ b/dsc_lib/src/extensions/import.rs
@@ -1,0 +1,3 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+

--- a/dsc_lib/src/extensions/import.rs
+++ b/dsc_lib/src/extensions/import.rs
@@ -1,3 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub struct ImportMethod {
+    /// The extensions to import.
+    pub extensions: Vec<String>,
+    /// The command to run to get the state of the resource.
+    pub executable: String,
+    /// The arguments to pass to the command to perform a Get.
+    pub args: Option<Vec<ImportArgKind>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ImportArgKind {
+    /// The argument is a string.
+    String(String),
+    /// The argument accepts the file path.
+    File {
+        /// The argument that accepts the file path.
+        #[serde(rename = "fileArg")]
+        file_arg: String,
+    },
+}

--- a/dsc_lib/src/extensions/import.rs
+++ b/dsc_lib/src/extensions/import.rs
@@ -10,7 +10,7 @@ pub struct ImportMethod {
     pub extensions: Vec<String>,
     /// The command to run to get the state of the resource.
     pub executable: String,
-    /// The arguments to pass to the command to perform a Get.
+    /// The arguments to pass to the command to perform an Import.
     pub args: Option<Vec<ImportArgKind>>,
 }
 

--- a/dsc_lib/src/extensions/import.rs
+++ b/dsc_lib/src/extensions/import.rs
@@ -7,7 +7,8 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Default, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct ImportMethod {
     /// The extensions to import.
-    pub extensions: Vec<String>,
+    #[serde(rename = "fileExtensions")]
+    pub file_extensions: Vec<String>,
     /// The command to run to get the state of the resource.
     pub executable: String,
     /// The arguments to pass to the command to perform an Import.

--- a/dsc_lib/src/extensions/mod.rs
+++ b/dsc_lib/src/extensions/mod.rs
@@ -5,3 +5,4 @@ pub mod discover;
 pub mod dscextension;
 pub mod extension_manifest;
 pub mod secret;
+pub mod import;

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -34,10 +34,10 @@ impl DscManager {
     ///
     /// This function will return an error if the underlying discovery fails.
     ///
-    pub fn new() -> Result<Self, DscError> {
-        Ok(Self {
-            discovery: discovery::Discovery::new()?,
-        })
+    pub fn new() -> Self {
+        Self {
+            discovery: discovery::Discovery::new(),
+        }
     }
 
     /// Find a resource by name.
@@ -107,6 +107,6 @@ impl DscManager {
 
 impl Default for DscManager {
     fn default() -> Self {
-        Self::new().unwrap()
+        Self::new()
     }
 }

--- a/dsc_lib/src/lib.rs
+++ b/dsc_lib/src/lib.rs
@@ -34,6 +34,7 @@ impl DscManager {
     ///
     /// This function will return an error if the underlying discovery fails.
     ///
+    #[must_use]
     pub fn new() -> Self {
         Self {
             discovery: discovery::Discovery::new(),

--- a/extensions/bicep/bicep.dsc.extension.json
+++ b/extensions/bicep/bicep.dsc.extension.json
@@ -4,7 +4,7 @@
     "version": "0.1.0",
     "description": "Enable passing Bicep file directly to DSC, but requires bicep executable to be available.",
     "import": {
-        "extensions": ["bicep"],
+        "fileExtensions": ["bicep"],
         "executable": "bicep",
         "args": [
             "build",

--- a/extensions/bicep/bicep.dsc.extension.json
+++ b/extensions/bicep/bicep.dsc.extension.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+    "type": "Microsoft.DSC.Extension/Bicep",
+    "version": "0.1.0",
+    "description": "Enable passing Bicep file directly to DSC, but requires bicep executable to be available.",
+    "import": {
+        "extensions": ["bicep"],
+        "executable": "bicep",
+        "args": [
+            "build",
+            {
+                "fileArg": ""
+            },
+            "--stdout"
+        ]
+    }
+}

--- a/extensions/bicep/bicep.tests.ps1
+++ b/extensions/bicep/bicep.tests.ps1
@@ -12,6 +12,7 @@ BeforeDiscovery {
 Describe 'Bicep extension tests' -Skip:(!$foundBicep) {
     It 'Example bicep file should work' {
         $bicepFile = Resolve-Path -Path "$PSScriptRoot\..\..\dsc\examples\hello_world.dsc.bicep"
+        Write-Verbose -Verbose (bicep -v)
         $out = dsc -l trace config get -f $bicepFile 2>$TestDrive/error.log | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Path $TestDrive/error.log -Raw | Out-String)
         $out.results[0].result.actualState.output | Should -BeExactly 'Hello, world!'

--- a/extensions/bicep/bicep.tests.ps1
+++ b/extensions/bicep/bicep.tests.ps1
@@ -2,8 +2,7 @@
 # Licensed under the MIT License.
 
 BeforeDiscovery {
-    $foundBicep = if ($null -ne (Get-Command bicep -ErrorAction Ignore)) {
-
+    $foundBicep = if (Get-Command bicep -ErrorAction Ignore) {
         $true
     } else {
         $false

--- a/extensions/bicep/bicep.tests.ps1
+++ b/extensions/bicep/bicep.tests.ps1
@@ -12,7 +12,7 @@ BeforeDiscovery {
 Describe 'Bicep extension tests' -Skip:(!$foundBicep) {
     It 'Example bicep file should work' {
         $bicepFile = Resolve-Path -Path "$PSScriptRoot\..\..\dsc\examples\hello_world.dsc.bicep"
-        $out = dsc -l debug config get -f $bicepFile 2>$TestDrive/error.log | ConvertFrom-Json
+        $out = dsc -l trace config get -f $bicepFile 2>$TestDrive/error.log | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Path $TestDrive/error.log -Raw | Out-String)
         $out.results[0].result.actualState.output | Should -BeExactly 'Hello, world!'
         (Get-Content -Path $TestDrive/error.log -Raw) | Should -Match "Importing file '$bicepFile' with extension 'Microsoft.DSC.Extension/Bicep'"

--- a/extensions/bicep/bicep.tests.ps1
+++ b/extensions/bicep/bicep.tests.ps1
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+BeforeDiscovery {
+    $foundBicep = if ($null -ne (Get-Command bicep -ErrorAction Ignore)) {
+        $true
+    } else {
+        $false
+    }
+}
+
+Describe 'Bicep extension tests' -Skip:(!$foundBicep) {
+    It 'Example bicep file should work' {
+        $bicepFile = Resolve-Path -Path "$PSScriptRoot\..\..\dsc\examples\hello_world.dsc.bicep"
+        $out = dsc -l debug config get -f $bicepFile 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Path $TestDrive/error.log -Raw | Out-String)
+        $out.results[0].result.actualState.output | Should -BeExactly 'Hello, world!'
+        (Get-Content -Path $TestDrive/error.log -Raw) | Should -Match "Importing file '$bicepFile' with extension 'Microsoft.DSC.Extension/Bicep'"
+    }
+}

--- a/extensions/bicep/bicep.tests.ps1
+++ b/extensions/bicep/bicep.tests.ps1
@@ -17,4 +17,19 @@ Describe 'Bicep extension tests' -Skip:(!$foundBicep) {
         $out.results[0].result.actualState.output | Should -BeExactly 'Hello, world!'
         (Get-Content -Path $TestDrive/error.log -Raw) | Should -Match "Importing file '$bicepFile' with extension 'Microsoft.DSC.Extension/Bicep'"
     }
+
+    It 'Invalid bicep file returns error' {
+        $bicepFile = "$TestDrive/invalid.bicep"
+        Set-Content -Path $bicepFile -Value @"
+        myresource invalid 'Microsoft.DSC.Extension/Bicep:1.0' = {
+            name: 'invalid'
+            properties: {
+                output: 'This is invalid'
+"@
+        $out = dsc -l trace config get -f $bicepFile 2>$TestDrive/error.log | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 4 -Because (Get-Content -Path $TestDrive/error.log -Raw | Out-String)
+        $content = (Get-Content -Path $TestDrive/error.log -Raw)
+        $content | Should -Match "Importing file '$bicepFile' with extension 'Microsoft.DSC.Extension/Bicep'"
+        $content | Should -Match "BCP279: Expected a type at this location"
+    }
 }

--- a/extensions/bicep/copy_files.txt
+++ b/extensions/bicep/copy_files.txt
@@ -1,0 +1,1 @@
+bicep.dsc.extension.json

--- a/resources/PSScript/psscript.tests.ps1
+++ b/resources/PSScript/psscript.tests.ps1
@@ -187,7 +187,8 @@ Describe 'Tests for PSScript resource' {
         $result = dsc resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content $TestDrive/error.txt -Raw | Out-String)
         $result.actualState.output.Count | Should -Be 0 -Because ($result | ConvertTo-Json | Out-String)
-        (Get-Content $TestDrive/error.txt -Raw) | Should -BeLike '*WARN*:*This is a warning*WARN*:*This is second warning*'
+        (Get-Content $TestDrive/error.txt -Raw) | Should -BeLike '*WARN*:*This is a warning*'
+        (Get-Content $TestDrive/error.txt -Raw) | Should -BeLike '*WARN*:*This is second warning*'
     }
 
     It 'Write-Error shows up as error traces for <resourceType>' -TestCases $testCases {

--- a/tools/test_group_resource/Cargo.lock
+++ b/tools/test_group_resource/Cargo.lock
@@ -429,6 +429,7 @@ dependencies = [
  "jsonschema",
  "linked-hash-map",
  "num-traits",
+ "path-absolutize",
  "regex",
  "rt-format",
  "rust-i18n",
@@ -1086,6 +1087,24 @@ dependencies = [
  "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "path-absolutize"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4af381fe79fa195b4909485d99f73a80792331df0625188e707854f0b3383f5"
+dependencies = [
+ "path-dedot",
+]
+
+[[package]]
+name = "path-dedot"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07ba0ad7e047712414213ff67533e6dd477af0a4e1d14fb52343e53d30ea9397"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

New `import` extension where the output to stdout needs to be a JSON string representing a valid DSC config file.
Bicep extension that implements this requiring the `bicep` exe to be in PATH to transpile the bicep file to JSON.
Still need to resolve with Bicep to not strictly validate the version to be in date format to allow semver or the word `latest`.

Some other changes:
- reformatted/ordered some of the `use` statements to make it more organized
- Discovery and DscManager `new()` no longer needs to return a DscError since no code is run for creation, so removed the `?` operator in many places
- Add new `get_extensions()` function to discovery which is used by `dsc` host since that is where file reading happens rather than in `dsc_lib`
- since `bicep` takes a positional arg for the file path, the args specified in the manifest can be an empty string and no arg name is passed, just the arg value (file path)

Note that until DSC support in Bicep is out of Experimental status, you must have a `bicepconfig.json` that enables that feature:

```json
{
  "experimentalFeaturesEnabled": {
    "desiredStateConfiguration": true
  }
}
```

Also made change to PSScript multi-warning test since traces are async, order is not guaranteed.

## PR Context

Part of https://github.com/PowerShell/DSC/issues/976