### PR TITLE
Fix to allow default value to be set as null

### DIFF
--- a/dsc/tests/dsc_parameters.tests.ps1
+++ b/dsc/tests/dsc_parameters.tests.ps1
@@ -236,6 +236,25 @@ Describe 'Parameters tests' {
         $out.results[3].result.actualState.output | Should -BeExactly @('hello', 'world')
     }
 
+    It 'Null default value is handled correctly' {
+        $config_yaml = @"
+          `$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+          parameters:
+            customValue:
+              type: string
+              defaultValue: null
+          resources:
+          - name: Configuration with fallbacks
+            type: Microsoft.DSC.Debug/Echo
+            properties:
+              output:
+                configValue: "[parameters('customValue')]"
+"@
+        $out = $config_yaml | dsc config get -f - | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        $out.results.result.actualState.output.configValue | Should -BeNullOrEmpty
+    }
+
     It 'property value uses parameter value' {
       $os = 'Windows'
       if ($IsLinux) {

--- a/dsc_lib/src/configure/config_doc.rs
+++ b/dsc_lib/src/configure/config_doc.rs
@@ -126,7 +126,7 @@ pub struct Configuration {
 pub struct Parameter {
     #[serde(rename = "type")]
     pub parameter_type: DataType,
-    #[serde(rename = "defaultValue", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "defaultValue", default, deserialize_with = "null_handler::deserialize")]
     pub default_value: Option<Value>,
     #[serde(rename = "allowedValues", skip_serializing_if = "Option::is_none")]
     pub allowed_values: Option<Vec<Value>>,
@@ -332,6 +332,19 @@ impl Resource {
 impl Default for Resource {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+// Custom deserializer to handle null values
+mod null_handler {
+    use serde::{Deserialize, Deserializer};
+    use serde_json::Value;
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Value>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Ok(Some(Value::deserialize(deserializer)?))
     }
 }
 

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -814,6 +814,11 @@ impl Configurator {
     }
 
     fn validate_parameter_type(name: &str, value: &Value, parameter_type: &DataType) -> Result<(), DscError> {
+        // Null values are valid for any parameter type
+        if value.is_null() {
+            return Ok(());
+        }
+
         match parameter_type {
             DataType::String | DataType::SecureString => {
                 if !value.is_string() {

--- a/dsc_lib/src/functions/parameters.rs
+++ b/dsc_lib/src/functions/parameters.rs
@@ -41,6 +41,11 @@ impl Function for Parameters {
             if context.parameters.contains_key(key) {
                 let (value, data_type) = &context.parameters[key];
 
+                // Handle null values explicitly
+                if value.is_null() {
+                    return Ok(Value::Null);
+                }
+
                 // if secureString or secureObject types, we keep it as JSON object
                 match data_type {
                     DataType::SecureString => {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Allows default values to be null in parameters. This allows the coalesce function to work correctly.

## PR Context

Fix #1000.

> [!NOTE]
> Used the following as reference: https://github.com/serde-rs/serde/issues/1098
