### PR TITLE
Add check if Pester itself fails

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -24,6 +24,8 @@ param(
 )
 
 $env:RUSTC_LOG=$null
+$env:RUSTFLAGS='-Dwarnings'
+
 if ($Verbose) {
     $env:RUSTC_LOG='rustc_codegen_ssa::back::link=info'
 }
@@ -567,7 +569,11 @@ if ($Test) {
         (Get-Module -Name Pester -ListAvailable).Path
     }
 
-    Invoke-Pester -ErrorAction Stop
+    try {
+        Invoke-Pester -ErrorAction Stop
+    } catch {
+        throw "Pester had unexpected error: $($_.Exception.Message)"
+    }
 }
 
 function Find-MakeAppx() {

--- a/dsc_lib/src/functions/less.rs
+++ b/dsc_lib/src/functions/less.rs
@@ -34,7 +34,7 @@ impl Function for Less {
 
     fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
         debug!("{}", t!("functions.less.invoked"));
-        
+
         let first = &args[0];
         let second = &args[1];
 
@@ -83,6 +83,7 @@ mod tests {
         assert_eq!(result, true);
     }
 
+    #[test]
     fn type_mismatch_string_number() {
         let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[lessOrEquals('5', 3)]", &Context::new());

--- a/dsc_lib/src/functions/less_or_equals.rs
+++ b/dsc_lib/src/functions/less_or_equals.rs
@@ -34,7 +34,7 @@ impl Function for LessOrEquals {
 
     fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
         debug!("{}", t!("functions.lessOrEquals.invoked"));
-        
+
         let first = &args[0];
         let second = &args[1];
 
@@ -83,6 +83,7 @@ mod tests {
         assert_eq!(result, true);
     }
 
+    #[test]
     fn type_mismatch_string_number() {
         let mut parser = Statement::new().unwrap();
         let result = parser.parse_and_execute("[lessOrEquals('5', 3)]", &Context::new());


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- One of the unit tests wasn't correctly attributed as a test so it produced a warning, but should have failed the build.  Fix is to use `RUSTFLAGS` env var to turn warnings into errors even when building unit tests
- Pester itself can fail and the build script just treats this as success since Pester didn't report an error, wrap in `try...catch` and throw if Pester has an issue