### PR TITLE
Change missing binary to `info` instead of `warn`

### DIFF
--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -209,12 +209,12 @@ Describe 'tests for resource discovery' {
         try {
             $env:DSC_RESOURCE_PATH = $testdrive
             Set-Content -Path "$testdrive/test.dsc.resource.json" -Value $manifest
-            $out = dsc resource list 'Test/ExecutableNotFound' 2> "$testdrive/error.txt" | ConvertFrom-Json
+            $out = dsc -l info resource list 'Test/ExecutableNotFound' 2> "$testdrive/error.txt" | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
             $out.Count | Should -Be 1
             $out.Type | Should -BeExactly 'Test/ExecutableNotFound'
             $out.Kind | Should -BeExactly 'resource'
-            Get-Content -Path "$testdrive/error.txt" | Should -Match "WARN.*?Executable 'doesNotExist' not found"
+            (Get-Content -Path "$testdrive/error.txt" -Raw) | Should -Match "INFO.*?Executable 'doesNotExist' not found"
         }
         finally {
             $env:DSC_RESOURCE_PATH = $oldPath

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -756,7 +756,7 @@ fn load_extension_manifest(path: &Path, manifest: &ExtensionManifest) -> Result<
 
 fn verify_executable(resource: &str, operation: &str, executable: &str) {
     if which(executable).is_err() {
-        warn!("{}", t!("discovery.commandDiscovery.executableNotFound", resource = resource, operation = operation, executable = executable));
+        info!("{}", t!("discovery.commandDiscovery.executableNotFound", resource = resource, operation = operation, executable = executable));
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

With the addition of the `bicep` extension, if you don't have `bicep` installed, you always get a visible warning message since `warn` is the default trace level.  Moving this message to `info`.