### PR TITLE
(DOCS) Sync back minor fixes from docs publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@ changes since the last release, see the [diff on GitHub][unreleased].
     for the `v3.0.0.0-alpha.5` release. Leave the release links under the release section.
 -->
 
+## [v3.1.0][release-v3.1.0] - 2025-06-18
+
+This section includes a summary of changes for the `3.1.0` release. For the full list of changes
+in this release, see the [diff on GitHub][compare-v3.1.0].
+
+<!-- Release links -->
+[release-v3.1.0]: https://github.com/PowerShell/DSC/releases/tag/v3.1.0 "Link to the DSC v3.1.0 release on GitHub"
+[compare-v3.1.0]: https://github.com/PowerShell/DSC/compare/v3.0.2...v3.1.0
+
 ### Added
 
 - Added support for defining adapted resource instances in configuration documents without

--- a/docs/reference/cli/resource/test.md
+++ b/docs/reference/cli/resource/test.md
@@ -16,19 +16,19 @@ Validates the actual state of a resource instance against a desired state.
 ### Instance properties from input option
 
 ```sh
-dsc resource set --input <INPUT> --resource <RESOURCE>
+dsc resource test --input <INPUT> --resource <RESOURCE>
 ```
 
 ### Instance properties from file
 
 ```sh
-dsc resource set --file <FILE> --resource <RESOURCE>
+dsc resource test --file <FILE> --resource <RESOURCE>
 ```
 
 ### Instance properties from stdin
 
 ```sh
-cat <FILE> | dsc resource set [Options] --resource <RESOURCE> --file -
+cat <FILE> | dsc resource test [Options] --resource <RESOURCE> --file -
 ```
 
 ## Description

--- a/docs/reference/schemas/config/parameter.md
+++ b/docs/reference/schemas/config/parameter.md
@@ -29,7 +29,7 @@ Parameters are defined as key-value pairs in the `parameters` property of a conf
 The key is the parameter's name, which is used to reference the parameter in the [resources][01]
 property of the configuration document. The value is an object that defines the parameter.
 
-Every parameter defines its data type. Parameters may also define a default value, validation
+Every parameter defines its data type. Parameters can also define a default value, validation
 checks, a description of their purpose, and arbitrary metadata.
 
 To reference parameters in resource instances, use the [parameters() configuration function][02].
@@ -42,7 +42,7 @@ To reference parameters in resource instances, use the [parameters() configurati
 
 ### description
 
-Parameters may define a short explanation of their purpose and usage with the `description`
+Parameters can define a short explanation of their purpose and usage with the `description`
 property. To define a longer explanation in YAML, use the folded block syntax or literal block
 syntax.
 
@@ -68,8 +68,8 @@ data type for every passed parameter before executing a configuration operation.
 
 The `secure*` data types indicate that DSC and integrating tools shouldn't log or record the
 values. If a secure data type parameter is used for a resource instance property that doesn't
-expect a secure value, the resource may still log or record the value. If the resource has
-independent logging or recording that isn't handled by DSC, the value may be stored insecurely.
+expect a secure value, the resource might still log or record the value. If the resource has
+independent logging or recording that isn't handled by DSC, the value might be stored insecurely.
 
 Use secure strings for passwords and secrets.
 
@@ -84,7 +84,7 @@ ValidValues: [string, securestring, int, bool, object, secureobject, array]
 
 ### defaultValue
 
-Parameters may define a default value with the `defaultValue` property. If the parameter isn't
+Parameters can define a default value with the `defaultValue` property. If the parameter isn't
 passed at runtime, DSC uses the default value for the parameter. If the parameter isn't passed at
 runtime and no default value is defined, DSC raises an error. The value must be valid for the
 parameter's `type`.
@@ -96,7 +96,7 @@ ValidJSONTypes: [string, integer, object, array, boolean]
 
 ### allowedValues
 
-Parameters may limit the set of valid values for the parameter by defining the `allowedValues`
+Parameters can limit the set of valid values for the parameter by defining the `allowedValues`
 property. DSC validates parameters passed at runtime and defined as `defaultValue` against this
 list of values. If any of the values is invalid, DSC raises an error.
 

--- a/docs/reference/schemas/config/resource.md
+++ b/docs/reference/schemas/config/resource.md
@@ -69,7 +69,7 @@ Pattern:  ^\w+(\.\w+){0,2}\/\w+$
 ### properties
 
 The `properties` of a resource instance define its desired state. The value of this property must
-be an object. For assertion  resources, the value may be an empty object (`{}`). DSC uses the
+be an object. For assertion  resources, the value can be an empty object (`{}`). DSC uses the
 DSC Resource's instance schema to validate the defined properties.
 
 <!-- For more information about instance schemas in DSC, see [DSC Resource instance schemas][aa]. -->

--- a/docs/reference/schemas/resource/properties/purge.md
+++ b/docs/reference/schemas/resource/properties/purge.md
@@ -1,5 +1,5 @@
 ---
-description: JSON schema reference for the '_purge' well-known DSC Resource property.
+description: JSON schema reference for the '_purge' canonical DSC Resource property.
 ms.date:     07/03/2025
 ms.topic:    reference
 title:       DSC Resource _purge property schema


### PR DESCRIPTION
# PR Summary

This change syncs minor fixes to reference documentation and the project changelog made when publishing the v3.1.0 reference updates to the docs platform.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
