### PR TITLE
(DOCS) Scaffold resource authoring docs

### DIFF
--- a/docs/concepts/resources/authoring/adapter/resource-manifest.md
+++ b/docs/concepts/resources/authoring/adapter/resource-manifest.md
@@ -1,0 +1,78 @@
+---
+description: >-
+  Considerations and guidance for authoring the document that defines an adapter resource.
+ms.date: 08/15/2025
+title: Authoring a DSC adapter resource manifest
+---
+
+# Authoring a DSC adapter resource manifest
+
+<!-- Introduction -->
+
+## Defining the initial manifest
+
+<!--
+    Provide an overview of the resource manifest structure with a copy-pastable example to start
+    from and guidance for defining the resource metadata.
+-->
+
+## Defining operations
+
+<!--
+    Explain how DSC invokes resource operations from manifest definitions and provide guidance on
+    which operations a resource can or should support and how to define those manifest fields.
+-->
+
+### Defining validate
+
+<!--
+    Provide guidance for defining the validate operation.
+-->
+
+### Defining get
+
+<!--
+    Provide guidance for defining the get operation.
+-->
+
+### Defining set
+
+<!--
+    Provide guidance for defining the set operation.
+-->
+
+### Defining whatIf
+
+<!--
+    Provide guidance for defining the whatIf operation.
+-->
+
+### Defining test
+
+<!--
+    Provide guidance for defining the test operation.
+-->
+
+### Defining export
+
+<!--
+    Provide guidance for defining the export operation.
+-->
+
+### Defining delete
+
+<!--
+    Provide guidance for defining the delete operation.
+-->
+
+## Defining exit codes
+
+<!--
+    Provide guidance on defining exit codes for a manifest to improve UX.
+-->
+
+## Best practices
+
+<!--
+    Provide a list of best practices to follow with reasoning for each.
+-->

--- a/docs/concepts/resources/authoring/emitting-messages.md
+++ b/docs/concepts/resources/authoring/emitting-messages.md
@@ -1,0 +1,30 @@
+---
+description: >-
+  Considerations and guidance for emitting messages from a DSC resource.
+ms.date: 08/15/2025
+title: Emitting messages from a DSC resource
+---
+
+# Emitting messages from a DSC resource
+
+<!-- Introduction -->
+
+## Emitting trace messages
+
+<!-- Guidance on when to emit trace messages with example message data -->
+
+## Emitting debug messages
+
+<!-- Guidance on when to emit debug messages with example message data -->
+
+## Emitting info messages
+
+<!-- Guidance on when to emit info messages with example message data -->
+
+## Emitting warning messages
+
+<!-- Guidance on when to emit warning messages with example message data -->
+
+## Emitting error messages
+
+<!-- Guidance on when to emit error messages with example message data -->

--- a/docs/concepts/resources/authoring/exit-codes.md
+++ b/docs/concepts/resources/authoring/exit-codes.md
@@ -1,0 +1,18 @@
+---
+description: >-
+  Considerations and guidance for defining exit codes for a resource.
+ms.date: 08/15/2025
+title: Defining exit codes for a DSC resource
+---
+
+# Defining exit codes for a DSC resource
+
+<!-- Introduction -->
+
+## Minimal exit codes
+
+<!-- Overview of default exit codes 0 and 1 -->
+
+## Defining useful exit codes
+
+<!-- Overview of whether and how to define discrete exit codes for a resource -->

--- a/docs/concepts/resources/authoring/exporter/resource-manifest.md
+++ b/docs/concepts/resources/authoring/exporter/resource-manifest.md
@@ -1,0 +1,42 @@
+---
+description: >-
+  Considerations and guidance for authoring the document that defines an exporter resource.
+ms.date: 08/15/2025
+title: Authoring a DSC exporter resource manifest
+---
+
+# Authoring a DSC exporter resource manifest
+
+<!-- Introduction -->
+
+## Defining the initial manifest
+
+<!--
+    Provide an overview of the resource manifest structure with a copy-pastable example to start
+    from and guidance for defining the resource metadata.
+-->
+
+## Defining operations
+
+<!--
+    Explain how DSC invokes resource operations from manifest definitions and provide guidance on
+    which operations a resource can or should support and how to define those manifest fields.
+-->
+
+### Defining export
+
+<!--
+    Provide guidance for defining the validate operation.
+-->
+
+## Defining exit codes
+
+<!--
+    Provide guidance on defining exit codes for a manifest to improve UX.
+-->
+
+## Best practices
+
+<!--
+    Provide a list of best practices to follow with reasoning for each.
+-->

--- a/docs/concepts/resources/authoring/index.md
+++ b/docs/concepts/resources/authoring/index.md
@@ -1,0 +1,36 @@
+---
+description: >-
+  Overview of the process and considerations for authoring a DSC resource.
+ms.date: 03/25/2025
+title: Authoring a DSC resource
+---
+
+# Authoring a DSC resource
+
+<!-- Introduction -->
+
+## Choosing a resource kind
+
+<!--
+    Provide guidance on how to choose a resource kind
+-->
+
+## Defining resource metadata
+
+<!--
+    Provide guidance on defining the resource metadata fields.
+-->
+
+## Defining exit codes
+
+<!--
+    Provide guidance on defining specific exit codes for a resource and link to
+    specific document.
+-->
+
+## Resource messaging
+
+<!--
+    Provide overview of emitting messages from a resource and link to specific
+    document.
+-->

--- a/docs/concepts/resources/authoring/toc.yml
+++ b/docs/concepts/resources/authoring/toc.yml
@@ -1,0 +1,22 @@
+items:
+  - name: Overview
+    href: index.md
+  - name: Typical resources
+    items:
+      - name: Resource manifest
+        href: typical/resource-manifest.md
+      - name: Resource instance schema
+        href: typical/resource-instance-schema.md
+  - name: Adapter resources
+    items:
+      - name: Resource manifest
+        href: adapter/resource-manifest.md
+  - name: Exporter resources
+    items:
+      - name: Resource manifest
+        href: exporter/resource-manifest.md
+  - name: Emitting messages
+    href: emitting-messages.md
+  - name: Defining exit codes
+    href: exit-codes.md
+  - 

--- a/docs/concepts/resources/authoring/typical/resource-instance-schema.md
+++ b/docs/concepts/resources/authoring/typical/resource-instance-schema.md
@@ -1,0 +1,50 @@
+---
+description: >-
+  Considerations and guidance for defining the JSON Schema that represents an instance of a typical
+  DSC resource.
+ms.date: 08/15/2025
+title: Authoring a typical DSC resource instance JSON Schema
+---
+
+# Authoring a DSC resource instance JSON Schema
+
+<!-- Introduction -->
+
+## Defining the initial schema
+
+<!-- Provide copy-pastable snippet to use as scaffold with explanation -->
+
+## Handling whether an instance exists
+
+<!-- Provide overview of `_exist` and how to add it to the instance schema if needed -->
+
+## Defining configurable properties
+
+<!-- Provide overview of data types and how to define them for the instance schema -->
+
+## Defining read-only properties
+
+<!--
+    Provide overview of how DSC handles read-only properties, when to use them, and how to define
+    them in the schema.
+-->
+
+## Defining write-only properties
+
+<!--
+    Provide overview of how DSC handles write-only properties, when to use them, and how to define
+    them in the schema.
+-->
+
+## Handling complex schemas
+
+<!--
+    Provide overview of how to add handling for complex cases to a schema, including schema
+    composition and conditionals, and guidance for when to use them or decompose a resource.
+-->
+
+## Best practices
+
+<!--
+    Provide a list of best practices with reasoning.
+-->

--- a/docs/concepts/resources/authoring/typical/resource-manifest.md
+++ b/docs/concepts/resources/authoring/typical/resource-manifest.md
@@ -1,0 +1,72 @@
+---
+description: >-
+  Considerations and guidance for defining the document that defines a typical DSC resource.
+ms.date: 08/15/2025
+title: Authoring a typical DSC resource manifest
+---
+
+# Authoring a typical DSC resource manifest
+
+<!-- Introduction -->
+
+## Defining the initial manifest
+
+<!--
+    Provide an overview of the resource manifest structure with a copy-pastable example to start
+    from and guidance for defining the resource metadata.
+-->
+
+## Defining operations
+
+<!--
+    Explain how DSC invokes resource operations from manifest definitions and provide guidance on
+    which operations a resource can or should support and how to define those manifest fields.
+-->
+
+### Defining get
+
+<!--
+    Provide guidance for defining the get operation.
+-->
+
+### Defining set
+
+<!--
+    Provide guidance for defining the set operation.
+-->
+
+### Defining whatIf
+
+<!--
+    Provide guidance for defining the whatIf operation.
+-->
+
+### Defining test
+
+<!--
+    Provide guidance for defining the test operation.
+-->
+
+### Defining export
+
+<!--
+    Provide guidance for defining the export operation.
+-->
+
+### Defining delete
+
+<!--
+    Provide guidance for defining the delete operation.
+-->
+
+## Defining exit codes
+
+<!--
+    Provide guidance on defining exit codes for a manifest to improve UX.
+-->
+
+## Best practices
+
+<!--
+    Provide a list of best practices to follow with reasoning for each.
+-->


### PR DESCRIPTION
# PR Summary

This change adds empty documents to suggest the structure and content of a resource authoring guide.

It is intended to convey high-level design guidance and implementation-agnostic guidance for authoring resource manifests and instance schemas.

It doesn't cover any specifics for defining commands or the resource in a particular language. Those concerns are better covered in the resource development kits or the sample resource tutorials, not the conceptual guide.

## PR Context

A recurring ask from partners and community members is how to begin authoring a DSC resource. This high-level guide will provide a starting point for such development.
