### PR TITLE
Change `utcNow()` tests to use regex for validation

### DIFF
--- a/dsc/tests/dsc_functions.tests.ps1
+++ b/dsc/tests/dsc_functions.tests.ps1
@@ -279,7 +279,7 @@ Describe 'tests for function expressions' {
         # ConvertFrom-Json will convert the date to a DateTime object, so we use regex to capture the string
         $out -match '"output":"(?<date>.*?)"' | Should -BeTrue -Because "Output should contain a date"
         $actual = $matches['date']
-        # comapre against the regex
+        # compare against the regex
         $actual | Should -Match $regex -Because "Output date '$actual' should match regex '$regex'"
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

`utcNow()` tests have proven to be fragile due to a race condition of when the function is called and when the PowerShell equivalent used for comparison is called.  In particularly if the second, minute, or hour just clicked over, then it fails.

Since we are primarily focused on the format, use a regex to verify instead of trying to verify the value.
