### PR TITLE
Update OSInfo resource to return `_name`

### DIFF
--- a/osinfo/osinfo.dsc.resource.json
+++ b/osinfo/osinfo.dsc.resource.json
@@ -13,7 +13,10 @@
         "executable": "osinfo"
     },
     "export": {
-        "executable": "osinfo"
+        "executable": "osinfo",
+        "args": [
+            "export"
+        ]
     },
     "schema": {
         "embedded": {

--- a/osinfo/src/config.rs
+++ b/osinfo/src/config.rs
@@ -72,7 +72,12 @@ impl OsInfo {
             family,
             version,
             architecture.as_deref().unwrap_or("")
-        ));
+        let name = Some(
+            match &architecture {
+                Some(arch) => format!("{:?} {} {}", family, version, arch),
+                None => format!("{:?} {}", family, version),
+            }
+        );
         Self {
             id: ID.to_string(),
             family,

--- a/osinfo/src/config.rs
+++ b/osinfo/src/config.rs
@@ -62,7 +62,7 @@ impl Display for Family {
 const ID: &str = "https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json";
 
 impl OsInfo {
-    pub fn new() -> Self {
+    pub fn new(include_name: bool) -> Self {
         let os_info = os_info::get();
         let edition = os_info.edition().map(ToString::to_string);
         let codename = os_info.codename().map(ToString::to_string);
@@ -78,12 +78,16 @@ impl OsInfo {
             _ => Bitness::Unknown,
         };
         let version = os_info.version().to_string();
-        let name = Some(
-            match &architecture {
-                Some(arch) => format!("{family} {version} {arch}"),
-                None => format!("{family:?} {version}"),
-            }
-        );
+        let name = if include_name {
+            Some(
+                match &architecture {
+                    Some(arch) => format!("{family} {version} {arch}"),
+                    None => format!("{family:?} {version}"),
+                }
+            )
+        } else {
+            None
+        };
         Self {
             id: ID.to_string(),
             family,

--- a/osinfo/src/config.rs
+++ b/osinfo/src/config.rs
@@ -24,6 +24,8 @@ pub struct OsInfo {
     /// Defines the processor architecture as reported by `uname -m` on the operating system.
     #[serde(skip_serializing_if = "Option::is_none")]
     architecture: Option<String>,
+    #[serde(rename = "_name", skip_serializing_if = "Option::is_none")]
+    name: Option<String>,
 }
 
 /// Defines whether the operating system is a 32-bit or 64-bit operating system.
@@ -64,14 +66,22 @@ impl OsInfo {
             os_info::Bitness::X64 => Bitness::Bit64,
             _ => Bitness::Unknown,
         };
+        let version = os_info.version().to_string();
+        let name = Some(format!(
+            "{:?} {} {}",
+            family,
+            version,
+            architecture.as_deref().unwrap_or("")
+        ));
         Self {
             id: ID.to_string(),
             family,
-            version: os_info.version().to_string(),
+            version,
             edition,
             codename,
             bitness: bits,
             architecture,
+            name,
         }
     }
 }

--- a/osinfo/src/config.rs
+++ b/osinfo/src/config.rs
@@ -67,15 +67,10 @@ impl OsInfo {
             _ => Bitness::Unknown,
         };
         let version = os_info.version().to_string();
-        let name = Some(format!(
-            "{:?} {} {}",
-            family,
-            version,
-            architecture.as_deref().unwrap_or("")
         let name = Some(
             match &architecture {
-                Some(arch) => format!("{:?} {} {}", family, version, arch),
-                None => format!("{:?} {}", family, version),
+                Some(arch) => format!("{family:?} {version} {arch}"),
+                None => format!("{family:?} {version}"),
             }
         );
         Self {

--- a/osinfo/src/config.rs
+++ b/osinfo/src/config.rs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 use serde::Serialize;
+use std::fmt::Display;
 use std::string::ToString;
 
 /// Returns information about the operating system.
@@ -48,6 +49,16 @@ pub enum Family {
     Windows,
 }
 
+impl Display for Family {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Family::Linux => write!(f, "Linux"),
+            Family::MacOS => write!(f, "macOS"),
+            Family::Windows => write!(f, "Windows"),
+        }
+    }
+}
+
 const ID: &str = "https://developer.microsoft.com/json-schemas/dsc/os_info/20230303/Microsoft.Dsc.OS_Info.schema.json";
 
 impl OsInfo {
@@ -69,7 +80,7 @@ impl OsInfo {
         let version = os_info.version().to_string();
         let name = Some(
             match &architecture {
-                Some(arch) => format!("{family:?} {version} {arch}"),
+                Some(arch) => format!("{family} {version} {arch}"),
                 None => format!("{family:?} {version}"),
             }
         );

--- a/osinfo/src/main.rs
+++ b/osinfo/src/main.rs
@@ -4,6 +4,12 @@
 mod config;
 
 fn main() {
-    let json = serde_json::to_string(&config::OsInfo::new()).unwrap();
+    let args: Vec<String> = std::env::args().collect();
+    let include_name = if args.len() > 1 && args[1] == "export" {
+        true
+    } else {
+        false
+    };
+    let json = serde_json::to_string(&config::OsInfo::new(include_name)).unwrap();
     println!("{json}");
 }

--- a/osinfo/src/main.rs
+++ b/osinfo/src/main.rs
@@ -5,11 +5,7 @@ mod config;
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
-    let include_name = if args.len() > 1 && args[1] == "export" {
-        true
-    } else {
-        false
-    };
+    let include_name = args.len() > 1 && args[1] == "export";
     let json = serde_json::to_string(&config::OsInfo::new(include_name)).unwrap();
     println!("{json}");
 }

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -52,5 +52,6 @@ Describe 'osinfo resource tests' {
         elseif ($IsMacOS) {
             $out.resources[0].properties.family | Should -BeExactly 'macOS'
         }
+        $out.resources[0].name | Should -BeExactly "$($out.resources[0].properties.family) $($out.resources[0].properties.version) $($out.resources[0].properties.architecture)"
     }
 }

--- a/osinfo/tests/osinfo.tests.ps1
+++ b/osinfo/tests/osinfo.tests.ps1
@@ -22,6 +22,8 @@ Describe 'osinfo resource tests' {
         else {
             $out.actualState.bitness | Should -BeExactly '32'
         }
+
+        $out._name | Should -BeNullOrEmpty
     }
 
     It 'should perform synthetic test' {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Since we added the ability for resources to return `_name`, update OSInfo resource to use this as "<family> <version> <architecture>"