### PR TITLE
Fix build script to use CratesIO

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,8 +19,3 @@ rustflags = ["-Ccontrol-flow-guard", "-Ctarget-feature=+crt-static", "-Clink-arg
 [source.crates-io]
 replace-with = "POWERSHELL"
 
-#[target.aarch64-unknown-linux-gnu]
-#linker = "aarch64-linux-gnu-gcc"
-
-#[target.aarch64-unknown-linux-musl]
-#linker = "aarch64-linux-musl-gcc"

--- a/build.ps1
+++ b/build.ps1
@@ -164,8 +164,6 @@ if ($null -ne (Get-Command msrustup -CommandType Application -ErrorAction Ignore
     }
 } elseif ($null -ne (Get-Command rustup -CommandType Application -ErrorAction Ignore)) {
         $rustup = 'rustup'
-} else {
-    $rustup = 'echo'
 }
 
 if ($null -ne $packageType) {
@@ -229,7 +227,11 @@ if ($null -ne $packageType) {
     ## Test if tree-sitter is installed
     if ($null -eq (Get-Command tree-sitter -ErrorAction Ignore)) {
         Write-Verbose -Verbose "tree-sitter not found, installing..."
-        cargo install tree-sitter-cli --config .cargo/config.toml
+        if ($UseCratesIO) {
+            cargo install tree-sitter-cli
+        } else {
+            cargo install tree-sitter-cli --config .cargo/config.toml
+        }
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to install tree-sitter-cli"
         }
@@ -380,7 +382,11 @@ if (!$SkipBuild) {
                 else {
                     if ($Audit) {
                         if ($null -eq (Get-Command cargo-audit -ErrorAction Ignore)) {
-                            cargo install cargo-audit --features=fix --config .cargo/config.toml
+                            if ($UseCratesIO) {
+                                cargo install cargo-audit --features=fix
+                            } else {
+                                cargo install cargo-audit --features=fix --config .cargo/config.toml
+                            }
                         }
 
                         cargo audit fix
@@ -413,7 +419,11 @@ if (!$SkipBuild) {
                     else {
                         if ($Audit) {
                             if ($null -eq (Get-Command cargo-audit -ErrorAction Ignore)) {
-                                cargo install cargo-audit --features=fix --config .cargo/config.toml
+                                if ($UseCratesIO) {
+                                    cargo install cargo-audit --features=fix
+                                } else {
+                                    cargo install cargo-audit --features=fix --config .cargo/config.toml
+                                }
                             }
 
                             cargo audit fix


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request updates the usage of the `UseCratesIO` switch parameter vs `config.toml`. Also adds the changes from #1063 

## PR Context

Partially addresses #1036 
