### PR TITLE
Allow parameters to use secret() function

### DIFF
--- a/dsc/tests/dsc_extension_secret.tests.ps1
+++ b/dsc/tests/dsc_extension_secret.tests.ps1
@@ -148,6 +148,6 @@ Describe 'Tests for the secret() function and extensions' {
       $out = dsc -l trace config get -i $configYaml 2> $TestDrive/error.log | ConvertFrom-Json
       $LASTEXITCODE | Should -Be 0
       $out.results.Count | Should -Be 1
-      $out.results[0].result.actualState.Output | Should -BeExactly 'World'
+      $out.results[0].result.actualState.Output | Should -BeExactly 'Hello'
     }
 }

--- a/dsc/tests/dsc_extension_secret.tests.ps1
+++ b/dsc/tests/dsc_extension_secret.tests.ps1
@@ -150,4 +150,21 @@ Describe 'Tests for the secret() function and extensions' {
       $out.results.Count | Should -Be 1
       $out.results[0].result.actualState.Output | Should -BeExactly 'Hello'
     }
+
+    It 'Allows to pass in secret() through variables' {
+      $configYaml = @'
+          $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+          variables:
+            myString: "[secret('MySecret')]"
+          resources:
+          - name: Database Connection
+            type: Microsoft.DSC.Debug/Echo
+            properties:
+              output: "[variables('myString')]"
+'@
+      $out = dsc -l trace config get -i $configYaml 2> $TestDrive/error.log | ConvertFrom-Json
+      $LASTEXITCODE | Should -Be 0
+      $out.results.Count | Should -Be 1
+      $out.results[0].result.actualState.Output | Should -BeExactly 'Hello'
+    }
 }

--- a/dsc_lib/src/configure/mod.rs
+++ b/dsc_lib/src/configure/mod.rs
@@ -699,9 +699,10 @@ impl Configurator {
     /// This function will return an error if the parameters are invalid.
     pub fn set_context(&mut self, parameters_input: Option<&Value>) -> Result<(), DscError> {
         let config = serde_json::from_str::<Configuration>(self.json.as_str())?;
+
+        self.context.extensions = self.discovery.extensions.values().cloned().collect();
         self.set_parameters(parameters_input, &config)?;
         self.set_variables(&config)?;
-        self.context.extensions = self.discovery.extensions.values().cloned().collect();
         Ok(())
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Initialization order changes before evaluating parameter defaults to allow parameters to use `secret()` function.

## PR Context

Fix #1078 
