### PR TITLE
Fix tests to not emit unused stderr output

### DIFF
--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -166,21 +166,18 @@ Describe 'tests for resource discovery' {
         $env:PSModulePath = $oldPSModulePath
     }
 
-    It 'Verify non-zero exit code when resource not found' {
+    It 'Verify non-zero exit code when resource not found: <cmdline>' -TestCases @(
+        @{ cmdline = "dsc resource get -r abc/def" }
+        @{ cmdline = "dsc resource get --all -r abc/def" }
+        @{ cmdline = "dsc resource set -r abc/def -f -" }
+        @{ cmdline = "dsc resource test -r abc/def -f -" }
+        @{ cmdline = "dsc resource delete -r abc/def -f -" }
+        @{ cmdline = "dsc resource export -r abc/def" }
+        @{ cmdline = "dsc resource schema -r abc/def" }
+    ) {
+        param($cmdline)
 
-        $out = dsc resource get -r abc/def
-        $LASTEXITCODE | Should -Be 7
-        $out = dsc resource get --all -r abc/def
-        $LASTEXITCODE | Should -Be 7
-        $out = 'abc' | dsc resource set -r abc/def -f -
-        $LASTEXITCODE | Should -Be 7
-        $out = 'abc' | dsc resource test -r abc/def -f -
-        $LASTEXITCODE | Should -Be 7
-        $out = 'abc' | dsc resource delete -r abc/def -f -
-        $LASTEXITCODE | Should -Be 7
-        $out = dsc resource export -r abc/def
-        $LASTEXITCODE | Should -Be 7
-        $out = dsc resource schema -r abc/def
+        Invoke-Expression $cmdline 2>$null
         $LASTEXITCODE | Should -Be 7
     }
 

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -108,7 +108,6 @@ Describe 'Discover extension tests' {
             $out.Count | Should -Be 1 -Because ($out | Out-String)
             $out.type | Should -Be 'Test/DiscoverRelative'
             $out = dsc resource list 2> $TestDrive/error.log
-            write-verbose -verbose (Get-Content -Path "$TestDrive/error.log" -Raw)
             $LASTEXITCODE | Should -Be 0
             $out | Should -BeNullOrEmpty
             $errorMessage = Get-Content -Path "$TestDrive/error.log" -Raw

--- a/dsc/tests/dsc_include.tests.ps1
+++ b/dsc/tests/dsc_include.tests.ps1
@@ -35,7 +35,7 @@ Describe 'Include tests' {
 "@
         $configPath = Join-Path $TestDrive 'config.dsc.yaml'
         $config | Set-Content -Path $configPath
-        dsc config get -f $configPath
+        dsc config get -f $configPath 2>$null
         $LASTEXITCODE | Should -Be 2
     }
 

--- a/dsc/tests/dsc_securitycontext.tests.ps1
+++ b/dsc/tests/dsc_securitycontext.tests.ps1
@@ -13,7 +13,7 @@ Describe 'Tests for configuration security context metadata' {
     }
 
     It 'Require admin' {
-        $out = dsc config get -f $PSScriptRoot/../examples/require_admin.yaml
+        $out = dsc config get -f $PSScriptRoot/../examples/require_admin.yaml 2>$null
         if ($isAdmin) {
             $LASTEXITCODE | Should -Be 0
             $out | Should -Not -BeNullOrEmpty

--- a/dsc/tests/dsc_set.tests.ps1
+++ b/dsc/tests/dsc_set.tests.ps1
@@ -61,7 +61,7 @@ Describe 'resource set tests' {
                 "_exist": false
             }
 '@
-            $null = registry config set --input $json
+            $null = registry config set --input $json 2>$null
         }
     }
 

--- a/dsc/tests/dsc_test.tests.ps1
+++ b/dsc/tests/dsc_test.tests.ps1
@@ -9,7 +9,7 @@ Describe 'resource test tests' {
             "valueName": "ProductName"
         }
 '@
-        $current = registry config get --input $json
+        $current = registry config get --input $json 2>$null
         $out = $current | dsc resource test -r Microsoft.Windows/Registry -f -
         $LASTEXITCODE | Should -Be 0
         $out = $out | ConvertFrom-Json

--- a/dsc/tests/dsc_variables.tests.ps1
+++ b/dsc/tests/dsc_variables.tests.ps1
@@ -22,7 +22,6 @@ resources:
     output: "[variables('myVariable')]"
 '@
     $out = dsc config get -i $configYaml | ConvertFrom-Json
-    Write-Verbose -Verbose $out
     $LASTEXITCODE | Should -Be 0
     $out.results[0].result.actualState.output | Should -Be 'bar'
   }
@@ -39,7 +38,6 @@ resources:
     output: "[variables('myVariable')]"
 '@
     $out = dsc config get -i $configYaml 2>&1 | Out-String
-    Write-Verbose -Verbose $out
     $LASTEXITCODE | Should -Be 2
     $out | Should -BeLike "*Variable 'myVariable' does not exist or has not been initialized yet*"
   }

--- a/powershell-adapter/psDscAdapter/powershell.resource.ps1
+++ b/powershell-adapter/psDscAdapter/powershell.resource.ps1
@@ -26,11 +26,6 @@ trap {
     Write-DscTrace -Operation Debug -Message ($_ | Format-List -Force | Out-String)
 }
 
-# Adding some debug info to STDERR
-'PSVersion=' + $PSVersionTable.PSVersion.ToString() | Write-DscTrace
-'PSPath=' + $PSHome | Write-DscTrace
-'PSModulePath=' + $env:PSModulePath | Write-DscTrace
-
 if ($Operation -eq 'ClearCache') {
     $cacheFilePath = if ($IsWindows) {
         # PS 6+ on Windows
@@ -44,10 +39,14 @@ if ($Operation -eq 'ClearCache') {
         }
     }
 
-    'Deleting cache file ' + $cacheFilePath | Write-DscTrace
     Remove-Item -Force -ea SilentlyContinue -Path $cacheFilePath
     exit 0
 }
+
+# Adding some debug info to STDERR
+'PSVersion=' + $PSVersionTable.PSVersion.ToString() | Write-DscTrace
+'PSPath=' + $PSHome | Write-DscTrace
+'PSModulePath=' + $env:PSModulePath | Write-DscTrace
 
 if ($PSVersionTable.PSVersion.Major -le 5) {
     # For Windows PowerShell, we want to remove any PowerShell 7 paths from PSModulePath
@@ -87,7 +86,7 @@ switch ($Operation) {
 
         # cache was refreshed on script load
         foreach ($dscResource in $dscResourceCache) {
-        
+
             # https://learn.microsoft.com/dotnet/api/system.management.automation.dscresourceinfo
             $DscResourceInfo = $dscResource.DscResourceInfo
 
@@ -99,7 +98,7 @@ switch ($Operation) {
                 if ($DscResourceInfo.Capabilities) {
                     $capabilities = $DscResourceInfo.Capabilities
                 } elseif ($module.PrivateData.PSData.DscCapabilities) {
-                    
+
                     $capabilities = $module.PrivateData.PSData.DscCapabilities
                 } else {
                     $capabilities = @('get', 'set', 'test')
@@ -183,7 +182,7 @@ switch ($Operation) {
             }
             $result += $actualState
         }
-    
+
         # OUTPUT json to stderr for debug, and to stdout
         if ($Operation -eq 'Test') {
             $result = @{ result = $result; _inDesiredState = $inDesiredState } | ConvertTo-Json -Depth 10 -Compress
@@ -196,7 +195,7 @@ switch ($Operation) {
     }
     'Validate' {
         # VALIDATE not implemented
-        
+
         # OUTPUT
         @{ valid = $true } | ConvertTo-Json
     }

--- a/registry/tests/registry.config.get.tests.ps1
+++ b/registry/tests/registry.config.get.tests.ps1
@@ -8,7 +8,7 @@ Describe 'Registry config get tests' {
             "keyPath": "HKLM\\Software\\Microsoft\\Windows\\CurrentVersion"
         }
 '@
-        $out = registry config get --input $json 
+        $out = registry config get --input $json 2>$null
         $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
         $result.keyPath | Should -Be 'HKLM\Software\Microsoft\Windows\CurrentVersion'
@@ -22,7 +22,7 @@ Describe 'Registry config get tests' {
             "valueName": "ProgramFilesPath"
         }
 '@
-        $out = registry config get --input $json
+        $out = registry config get --input $json 2>$null
         $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
         $result.keyPath | Should -Be 'HKLM\Software\Microsoft\Windows\CurrentVersion'

--- a/registry/tests/registry.config.set.tests.ps1
+++ b/registry/tests/registry.config.set.tests.ps1
@@ -18,16 +18,16 @@ Describe 'registry config set tests' {
             }
         }
 '@
-        $out = registry config set --input $json
+        $out = registry config set --input $json 2>$null
         $LASTEXITCODE | Should -Be 0
         $out | Should -BeNullOrEmpty
-        $result = registry config get --input $json | ConvertFrom-Json
+        $result = registry config get --input $json 2>$null | ConvertFrom-Json
         $result.keyPath | Should -Be 'HKCU\1\2\3'
         $result.valueName | Should -Be 'Hello'
         $result.valueData.String | Should -Be 'World'
         ($result.psobject.properties | Measure-Object).Count | Should -Be 3
 
-        $out = registry config get --input $json
+        $out = registry config get --input $json 2>$null
         $LASTEXITCODE | Should -Be 0
         $result = $out | ConvertFrom-Json
         $result.keyPath | Should -Be 'HKCU\1\2\3'
@@ -82,7 +82,7 @@ Describe 'registry config set tests' {
               properties:
                 keyPath: 'HKCU\1'
                 valueName: Test
-                _exist: true            
+                _exist: true
 '@
 
         $out = dsc config set -i $configYaml | ConvertFrom-Json

--- a/registry/tests/registry.config.whatif.tests.ps1
+++ b/registry/tests/registry.config.whatif.tests.ps1
@@ -16,15 +16,15 @@ Describe 'registry config whatif tests' {
             "keyPath": "HKCU\\1\\2\\3"
         }
 '@
-        registry config set -w --input $json | Write-Host
-        $get_before = registry config get --input $json
-        $result = registry config set -w --input $json | ConvertFrom-Json
+        registry config set -w --input $json 2>$null | Write-Host
+        $get_before = registry config get --input $json 2>$null
+        $result = registry config set -w --input $json 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $result.keyPath | Should -Be 'HKCU\1\2\3'
         $result._metadata.whatIf[0] | Should -Match '.*1.*'
         $result._metadata.whatIf[1] | Should -Match '.*2.*'
         $result._metadata.whatIf[2] | Should -Match '.*3.*'
-        $get_after = registry config get --input $json
+        $get_after = registry config get --input $json 2>$null
         $get_before | Should -EQ $get_after
     }
 
@@ -38,7 +38,7 @@ Describe 'registry config whatif tests' {
             }
         }
 '@
-        $result = registry config set -w --input $json | ConvertFrom-Json
+        $result = registry config set -w --input $json 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $result.keyPath | Should -Be 'HKCU\1\2\3'
         $result.valueName | Should -Be 'Hello'
@@ -54,7 +54,7 @@ Describe 'registry config whatif tests' {
             "keyPath": "HKCU\\1\\2"
         }
 '@
-        registry config set --input $set_json
+        registry config set --input $set_json 2>$null
         $whatif_json = @'
             {
                 "keyPath": "HKCU\\1\\2",
@@ -64,7 +64,7 @@ Describe 'registry config whatif tests' {
                 }
             }
 '@
-        $result = registry config set -w --input $whatif_json | ConvertFrom-Json
+        $result = registry config set -w --input $whatif_json 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $result.keyPath | Should -Be 'HKCU\1\2'
         $result.valueName | Should -Be 'Hello'
@@ -82,7 +82,7 @@ Describe 'registry config whatif tests' {
             }
         }
 '@
-        registry config set --input $set_json
+        registry config set --input $set_json 2>$null
         $whatif_json = @'
         {
             "keyPath": "HKCU\\1\\2\\3",
@@ -92,7 +92,7 @@ Describe 'registry config whatif tests' {
             }
         }
 '@
-        $result = registry config set -w --input $whatif_json | ConvertFrom-Json
+        $result = registry config set -w --input $whatif_json 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $result.keyPath | Should -Be 'HKCU\1\2\3'
         $result.valueName | Should -Be 'Hello'
@@ -110,7 +110,7 @@ Describe 'registry config whatif tests' {
             }
         }
 '@
-        registry config set --input $set_json
+        registry config set --input $set_json 2>$null
         $set_json = @'
         {
             "keyPath": "HKCU\\1\\2\\3",
@@ -120,13 +120,13 @@ Describe 'registry config whatif tests' {
             }
         }
 '@
-        registry config set --input $set_json
+        registry config set --input $set_json 2>$null
         $whatif_json = @'
         {
             "keyPath": "HKCU\\1\\2"
         }
 '@
-        $result = registry config set -w --input $whatif_json | ConvertFrom-Json
+        $result = registry config set -w --input $whatif_json 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $result.keyPath | Should -Be 'HKCU\1\2'
         ($result.psobject.properties | Measure-Object).Count | Should -Be 1

--- a/runcommandonset/tests/runcommandonset.get.tests.ps1
+++ b/runcommandonset/tests/runcommandonset.get.tests.ps1
@@ -11,7 +11,7 @@ Describe 'tests for runcommandonset get' {
         }
 "@
 
-        $result = $json | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet -f - | ConvertFrom-Json
+        $result = $json | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $result.actualState.arguments | Should -BeExactly @('bar', 'baz')
         $result.actualState.executable | Should -BeExactly 'foo'
@@ -19,12 +19,12 @@ Describe 'tests for runcommandonset get' {
     }
 
     It 'Executable is a required input via CLI arguments' {
-        $null = runcommandonset get -a foo
+        $null = runcommandonset get -a foo 2>$null
         $LASTEXITCODE | Should -Be 4
     }
 
     It 'Executable is a required input via STDIN' {
-        '{ "arguments": "foo" }' | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet -f -
+        '{ "arguments": "foo" }' | dsc resource get -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2>$null
         $LASTEXITCODE | Should -Be 2
     }
 
@@ -39,7 +39,7 @@ Describe 'tests for runcommandonset get' {
                 arguments:
                 - "bar"
 "@
-        $out = $config_yaml | dsc config get -f - | ConvertFrom-Json
+        $out = $config_yaml | dsc config get -f - 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.hadErrors | Should -BeFalse
         $out.results.Count | Should -Be 1

--- a/runcommandonset/tests/runcommandonset.set.tests.ps1
+++ b/runcommandonset/tests/runcommandonset.set.tests.ps1
@@ -15,7 +15,7 @@ Describe 'tests for runcommandonset set' {
             "arguments": ["-Command", "echo hello world"]
         }
 "@
-        $input_json | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f -
+        $input_json | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2>$null
         # TODO: test output once DSC PR to capture it is merged
         $LASTEXITCODE | Should -Be 0
     }
@@ -45,23 +45,23 @@ Describe 'tests for runcommandonset set' {
     }
 
     It 'Executable is a required input via CLI arguments' {
-        $null = runcommandonset set -a foo
+        $null = runcommandonset set -a foo 2>$null
         $LASTEXITCODE | Should -Be 4
     }
 
     It 'Executable is a required input via STDIN' {
-        $null = '{ "arguments": "foo" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f -
+        $null = '{ "arguments": "foo" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2>$null
         $LASTEXITCODE | Should -Be 2
     }
 
     It 'Executable can be provided without arguments' {
-        $result = '{ "executable": "pwsh" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - | ConvertFrom-Json
+        $result = '{ "executable": "pwsh" }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2>$null | ConvertFrom-Json
         $result.changedProperties | Should -Be @()
         $LASTEXITCODE | Should -Be 0
     }
 
     It 'Exit code does not need to be provided to detect difference' {
-        $result = '{ "executable": "pwsh", "arguments": ["invalid input"] }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - | ConvertFrom-Json
+        $result = '{ "executable": "pwsh", "arguments": ["invalid input"] }' | dsc resource set -r Microsoft.DSC.Transitional/RunCommandOnSet -f - 2>$null | ConvertFrom-Json
         $result.changedProperties | Should -Be @( 'exitCode' )
         $LASTEXITCODE | Should -Be 0
     }
@@ -90,7 +90,7 @@ Describe 'tests for runcommandonset set' {
                 - -Command
                 - $command
 "@
-        $out = $config_yaml | dsc config set -f - | ConvertFrom-Json
+        $out = $config_yaml | dsc config set -f - 2>$null | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
         $out.hadErrors | Should -BeFalse
         $out.results.Count | Should -Be 1
@@ -98,7 +98,7 @@ Describe 'tests for runcommandonset set' {
         $out.results[0].result.afterState.executable | Should -BeExactly 'pwsh'
         $out.results[0].result.afterState.arguments[0] | Should -BeExactly '-Command'
         Get-Content $TestDrive/output.txt  | Should -BeExactly 'Hello'
-        $out = $config_yaml | dsc config set -f - | ConvertFrom-Json
+        $out = $config_yaml | dsc config set -f - 2>$null | ConvertFrom-Json
         Get-Content $TestDrive/output.txt  | Should -BeExactly @('Hello', 'Hello')
     }
 }

--- a/sshdconfig/tests/defaultshell.tests.ps1
+++ b/sshdconfig/tests/defaultshell.tests.ps1
@@ -70,7 +70,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
             $testShell = "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
             New-ItemProperty -Path $RegistryPath -Name "DefaultShell" -Value $testShell
 
-            $output = sshdconfig get -s windows-global
+            $output = sshdconfig get -s windows-global 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $result = $output | ConvertFrom-Json
@@ -86,7 +86,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
             New-ItemProperty -Path $RegistryPath -Name "DefaultShellCommandOption" -Value "/c"
             New-ItemProperty -Path $RegistryPath -Name "DefaultShellEscapeArguments" -Value 0 -Type DWord
 
-            $output = sshdconfig get -s windows-global
+            $output = sshdconfig get -s windows-global 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $result = $output | ConvertFrom-Json
@@ -96,7 +96,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
         }
 
         It 'Should handle empty default shell registry values' -Skip:(!$IsWindows) {
-            $output = sshdconfig get -s windows-global
+            $output = sshdconfig get -s windows-global 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $result = $output | ConvertFrom-Json
@@ -116,7 +116,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
                 escapeArguments = $false
             } | ConvertTo-Json
 
-            sshdconfig set --input $inputConfig
+            sshdconfig set --input $inputConfig 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $defaultShell = Get-ItemProperty -Path $RegistryPath -Name "DefaultShell" -ErrorAction SilentlyContinue
@@ -134,7 +134,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
                 shell = "C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe"
             } | ConvertTo-Json
 
-            sshdconfig set --input $inputConfig
+            sshdconfig set --input $inputConfig 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $defaultShell = Get-ItemProperty -Path $RegistryPath -Name "DefaultShell" -ErrorAction SilentlyContinue
@@ -144,7 +144,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
         It 'Should handle invalid JSON input gracefully' {
             $invalidJson = "{ invalid json }"
 
-            sshdconfig set --input $invalidJson
+            sshdconfig set --input $invalidJson 2>$null
             $LASTEXITCODE | Should -Not -Be 0
         }
 
@@ -153,7 +153,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
 
             $inputConfig = @{ shell = $null } | ConvertTo-Json
 
-            sshdconfig set --input $inputConfig
+            sshdconfig set --input $inputConfig 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $result = Get-ItemProperty -Path $RegistryPath -Name "DefaultShell" -ErrorAction SilentlyContinue
@@ -170,10 +170,10 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
             }
             $inputJson = $originalConfig | ConvertTo-Json
 
-            sshdconfig set --input $inputJson
+            sshdconfig set --input $inputJson 2>$null
             $LASTEXITCODE | Should -Be 0
 
-            $getOutput = sshdconfig get -s windows-global
+            $getOutput = sshdconfig get -s windows-global 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $retrievedConfig = $getOutput | ConvertFrom-Json
@@ -191,7 +191,7 @@ Describe 'Default Shell Configuration Tests' -Skip:(!$IsWindows -or !$isElevated
 
             $inputConfig = @{ shell = $null } | ConvertTo-Json
 
-            sshdconfig set --input $inputConfig
+            sshdconfig set --input $inputConfig 2>$null
             $LASTEXITCODE | Should -Be 0
 
             $result = Get-ItemProperty -Path $RegistryPath -Name "DefaultShell" -ErrorAction SilentlyContinue


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Tests were emitting messages to STDERR which makes the CI result output noisy to find actual failures.  Redirect unused stderr to `$null`