### PR TITLE
Fix empty path handling for Windows PowerShell adapter

### DIFF
--- a/powershell-adapter/Tests/win_powershellgroup.tests.ps1
+++ b/powershell-adapter/Tests/win_powershellgroup.tests.ps1
@@ -118,7 +118,7 @@ class PSClassResource {
       New-Item -Path $modulePath -ItemType File -Value $module -Force | Out-Null
     }
 
-    $env:PSModulePath = $windowsPowerShellPath + [System.IO.Path]::PathSeparator + $env:PSModulePath
+    $env:PSModulePath = $windowsPowerShellPath + [System.IO.Path]::PathSeparator + $env:PSModulePath + [System.IO.Path]::PathSeparator
   }
 
   AfterAll {

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -711,7 +711,8 @@ function Set-ValidPSModulePath {
     end {
         if (($env:PSModulePath -split [System.IO.Path]::PathSeparator) -contains '') {
             "Removing empty entry from PSModulePath: '$env:PSModulePath'" | Write-DscTrace -Operation Debug
-            $env:PSModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator | Where-Object { $_ -ne '' }) -join [System.IO.Path]::PathSeparator
+            $env:PSModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator | 
+                Where-Object { $_ -ne '' }) -join [System.IO.Path]::PathSeparator
         }
     }
 }

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -711,7 +711,7 @@ function Repair-ValidPSModulePath {
     end {
         if (($env:PSModulePath -split [System.IO.Path]::PathSeparator) -contains '') {
             "Removing empty entry from PSModulePath: '$env:PSModulePath'" | Write-DscTrace -Operation Debug
-            $env:PSModulePath = [String]::Join([System.IO.Path]::PathSeparator, ($env:PSModulePath.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries)))
+            $env:PSModulePath = [String]::Join([System.IO.Path]::PathSeparator, ($env:PSModulePath.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries))).TrimEnd([System.IO.Path]::PathSeparator)
         }
     }
 }

--- a/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
+++ b/powershell-adapter/psDscAdapter/win_psDscAdapter.psm1
@@ -60,8 +60,8 @@ function Invoke-DscCacheRefresh {
     $namedModules = [System.Collections.Generic.List[Object]]::new()
     $cacheFilePath = Join-Path $env:LocalAppData "dsc\WindowsPSAdapterCache.json"
 
-    # Reset PSModulePath to not contain empty entries
-    Set-ValidPSModulePath
+    # Repair PSModulePath to not contain empty entries
+    Repair-ValidPSModulePath
 
     if (Test-Path $cacheFilePath) {
         "Reading from Get-DscResource cache file $cacheFilePath" | Write-DscTrace
@@ -247,10 +247,10 @@ function Invoke-DscCacheRefresh {
             }
 
             $dscResourceCacheEntries.Add([dscResourceCacheEntry]@{
-                    Type            = "$moduleName/$($dscResource.Name)"
-                    DscResourceInfo = $DscResourceInfo
-                    LastWriteTimes  = $lastWriteTimes
-                })
+                Type            = "$moduleName/$($dscResource.Name)"
+                DscResourceInfo = $DscResourceInfo
+                LastWriteTimes  = $lastWriteTimes
+            })
         }
 
         if ($namedModules.Count -gt 0) {
@@ -704,15 +704,14 @@ function GetClassBasedCapabilities {
     }
 }
 
-function Set-ValidPSModulePath {
+function Repair-ValidPSModulePath {
     [CmdletBinding()]
     param()
 
     end {
         if (($env:PSModulePath -split [System.IO.Path]::PathSeparator) -contains '') {
             "Removing empty entry from PSModulePath: '$env:PSModulePath'" | Write-DscTrace -Operation Debug
-            $env:PSModulePath = ($env:PSModulePath -split [System.IO.Path]::PathSeparator | 
-                Where-Object { $_ -ne '' }) -join [System.IO.Path]::PathSeparator
+            $env:PSModulePath = [String]::Join([System.IO.Path]::PathSeparator, ($env:PSModulePath.Split([System.IO.Path]::PathSeparator, [System.StringSplitOptions]::RemoveEmptyEntries)))
         }
     }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request addresses an issue when `$env:PSModulePath` contains empty entries, the PSDesiredStateConfiguration v1.1 module errors out and returns empty results.

Rather than the suggestion in the fixed issue, a reset should always happen because of the line 158 and 170

## PR Context

Fix #1095 
