### PR TITLE
Fix expression grammar to work with boolean functions

### DIFF
--- a/dsc/tests/dsc_functions.tests.ps1
+++ b/dsc/tests/dsc_functions.tests.ps1
@@ -120,7 +120,7 @@ Describe 'tests for function expressions' {
     @{ expression = "[intersection(parameters('firstObject'), parameters('firstArray'))]"; isError = $true }
     @{ expression = "[intersection(parameters('firstArray'), parameters('secondArray'), parameters('fifthArray'))]"; expected = @('cd') }
     @{ expression = "[intersection(parameters('firstObject'), parameters('secondObject'), parameters('sixthObject'))]"; expected = [pscustomobject]@{ two = 'b' } }
-    @{ expression = "[intersection(parameters('nestedObject1'), parameters('nestedObject2'))]"; expected = [pscustomobject]@{ 
+    @{ expression = "[intersection(parameters('nestedObject1'), parameters('nestedObject2'))]"; expected = [pscustomobject]@{
       shared = [pscustomobject]@{ value = 42; flag = $true }
       level = 1
     } }
@@ -665,5 +665,26 @@ Describe 'tests for function expressions' {
     $LASTEXITCODE | Should -Not -Be 0
     $errorContent = Get-Content $TestDrive/error.log -Raw
     $errorContent | Should -Match ([regex]::Escape($expectedError))
+  }
+
+  It 'mixed booleans with functions works' -TestCases @(
+    @{ expression = "[and(true(), false, not(false))]"; expected = $false }
+    @{ expression = "[or(false, false(), not(false()))]"; expected = $true }
+    @{ expression = "[and(true(), true, not(false))]"; expected = $true }
+    @{ expression = "[or(false, false(), not(true()))]"; expected = $false }
+  ) {
+    param($expression, $expected)
+
+    $config_yaml = @"
+            `$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+            resources:
+            - name: Echo
+              type: Microsoft.DSC.Debug/Echo
+              properties:
+                output: "$expression"
+"@
+    $out = dsc -l trace config get -i $config_yaml 2>$TestDrive/error.log | ConvertFrom-Json
+    $LASTEXITCODE | Should -Be 0 -Because (Get-Content $TestDrive/error.log -Raw)
+    $out.results[0].result.actualState.output | Should -BeExactly $expected
   }
 }

--- a/tree-sitter-dscexpression/test/corpus/invalid_expressions.txt
+++ b/tree-sitter-dscexpression/test/corpus/invalid_expressions.txt
@@ -18,7 +18,6 @@ String parameter not in quotes
         (function
           (functionName)
           (ERROR
-            (functionName)
             (functionName)))))
 
 =====
@@ -79,8 +78,6 @@ String starting with bracket
 ---
 
     (ERROR
-      (ERROR
-        (functionName))
       (functionName))
 
 =====
@@ -179,8 +176,7 @@ Expression with member accessor outside
           (functionName)
           (arguments
             (number))))
-      (ERROR
-        (functionName)))
+      (ERROR))
 
 =====
 Expression with index accessor outside
@@ -209,6 +205,4 @@ String with un-escaped single-quote
           (functionName)
           (arguments
             (string))
-          (ERROR
-            (functionName)
-            (functionName)))))
+          (ERROR))))

--- a/tree-sitter-dscexpression/test/corpus/valid_expressions.txt
+++ b/tree-sitter-dscexpression/test/corpus/valid_expressions.txt
@@ -34,7 +34,7 @@ Simple expression
 =====
 Multiple arguments
 =====
-[myFunction('argString', 1, -1, true)]
+[myFunction('argString', 1, -1, true, false)]
 ---
 
 (statement
@@ -45,6 +45,7 @@ Multiple arguments
         (string)
         (number)
         (number)
+        (boolean)
         (boolean)))))
 
 =====
@@ -335,3 +336,19 @@ User Function
       (arguments
         (number)
         (number)))))
+
+=====
+User Function with nested function
+=====
+[Environment.getEnvironmentConfig(true(), false)]
+---
+
+(statement
+      (expression
+        (function
+          (functionName)
+          (arguments
+            (expression
+              (function
+                (functionName)))
+            (boolean)))))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The grammar didn't allow for functions `true()` and `false()` and only expected boolean arguments `true` and `false` so this resulted in a parsing error.  Fix is to update the grammar with precedence for functions and booleans (in that order) so that `true()` and `false()` will be accepted as function names and not treated as booleans and thus invalidating the rest of the expression.

Some of the invalid tests needed to be updated, but all still result in an error as expected.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1136