### PR TITLE
Fix ordering of category for `concat` and `contains`

### DIFF
--- a/dsc_lib/src/functions/concat.rs
+++ b/dsc_lib/src/functions/concat.rs
@@ -16,7 +16,7 @@ impl Function for Concat {
         FunctionMetadata {
             name: "concat".to_string(),
             description: t!("functions.concat.description").to_string(),
-            category: vec![FunctionCategory::String, FunctionCategory::Array],
+            category: vec![FunctionCategory::Array, FunctionCategory::String],
             min_args: 2,
             max_args: usize::MAX,
             accepted_arg_ordered_types: vec![

--- a/dsc_lib/src/functions/contains.rs
+++ b/dsc_lib/src/functions/contains.rs
@@ -16,7 +16,7 @@ impl Function for Contains {
         FunctionMetadata {
             name: "contains".to_string(),
             description: t!("functions.contains.description").to_string(),
-            category: vec![FunctionCategory::String, FunctionCategory::Array],
+            category: vec![FunctionCategory::Array, FunctionCategory::String],
             min_args: 2,
             max_args: 2,
             accepted_arg_ordered_types: vec![


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

During the CoPilot PR to make function category a vec, it was missed that `concat` and `contains` functions didn't have the categories in alphabetical order and thus doesn't show up correctly with `dsc function list`
