### PR TITLE
Fix so that extension discovery failure doesn't fail entire discovery

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -243,10 +243,10 @@ if ($null -ne $packageType) {
         } else {
             if ($architecture -ne 'current') {
                 write-verbose -verbose "Installing clippy for $architecture"
-                & $rustup component add clippy --target $architecture
+                rustup component add clippy --target $architecture
             } else {
                 write-verbose -verbose "Installing clippy for current architecture"
-                & $rustup component add clippy
+                rustup component add clippy
             }
         }
         if ($LASTEXITCODE -ne 0) {

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -128,4 +128,18 @@ Describe 'Discover extension tests' {
         }
         $foundWideLine | Should -BeTrue
     }
+
+    It 'Failed extension discovery should not fail overall discovery' -Skip:(!$IsWindows) {
+        try {
+            # exclude finding powershell.exe
+            $oldPath = $env:PATH
+            $env:PATH = $env:PATH="$env:PROGRAMFILES\PowerShell\7"
+            $out = dsc resource list 2> $TestDrive/error.log | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $out.Count | Should -BeGreaterThan 0
+            (Get-Content -Path "$TestDrive/error.log" -Raw) | Should -BeLike "WARN Extension 'Microsoft.Windows.Appx/Discover' failed to discover resources: Command: Operation program not found for executable 'powershell'" -Because (Get-Content -Path "$TestDrive/error.log" -Raw | Out-String)
+        } finally {
+            $env:PATH = $oldPath
+        }
+    }
 }

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -133,8 +133,9 @@ Describe 'Discover extension tests' {
         try {
             # exclude finding powershell.exe
             $oldPath = $env:PATH
-            $env:PATH = "$env:PROGRAMFILES\PowerShell\7"
-            $out = dsc resource list 2> $TestDrive/error.log | ConvertFrom-Json
+            $dscFolder = Split-Path (Get-Command dsc).Source -Parent
+            $env:PATH = "$env:PROGRAMFILES\PowerShell\7;$dscFolder"
+            $out = dsc -l warn resource list 2> $TestDrive/error.log | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
             $out.Count | Should -BeGreaterThan 0
             (Get-Content -Path "$TestDrive/error.log" -Raw) | Should -BeLike "*WARN Extension 'Microsoft.Windows.Appx/Discover' failed to discover resources: Command: Operation program not found for executable 'powershell'*" -Because (Get-Content -Path "$TestDrive/error.log" -Raw | Out-String)

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -133,11 +133,11 @@ Describe 'Discover extension tests' {
         try {
             # exclude finding powershell.exe
             $oldPath = $env:PATH
-            $env:PATH = $env:PATH="$env:PROGRAMFILES\PowerShell\7"
+            $env:PATH = "$env:PROGRAMFILES\PowerShell\7"
             $out = dsc resource list 2> $TestDrive/error.log | ConvertFrom-Json
             $LASTEXITCODE | Should -Be 0
             $out.Count | Should -BeGreaterThan 0
-            (Get-Content -Path "$TestDrive/error.log" -Raw) | Should -BeLike "WARN Extension 'Microsoft.Windows.Appx/Discover' failed to discover resources: Command: Operation program not found for executable 'powershell'" -Because (Get-Content -Path "$TestDrive/error.log" -Raw | Out-String)
+            (Get-Content -Path "$TestDrive/error.log" -Raw) | Should -BeLike "*WARN Extension 'Microsoft.Windows.Appx/Discover' failed to discover resources: Command: Operation program not found for executable 'powershell'*" -Because (Get-Content -Path "$TestDrive/error.log" -Raw | Out-String)
         } finally {
             $env:PATH = $oldPath
         }

--- a/dsc_lib/locales/en-us.toml
+++ b/dsc_lib/locales/en-us.toml
@@ -110,6 +110,7 @@ searchingForResources = "Searching for resources: %{resources}"
 foundResourceWithVersion = "Found matching resource '%{resource}' version %{version}"
 foundNonAdapterResources = "Found %{count} non-adapter resources"
 resourceMissingRequireAdapter = "Resource '%{resource}' is missing 'require_adapter' field."
+extensionDiscoverFailed = "Extension '%{extension}' failed to discover resources: %{error}"
 
 [dscresources.commandResource]
 invokeGet = "Invoking get for '%{resource}'"

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -310,7 +310,13 @@ impl ResourceDiscovery for CommandDiscovery {
                 for extension in self.extensions.values() {
                     if extension.capabilities.contains(&ExtensionCapability::Discover) {
                         debug!("{}", t!("discovery.commandDiscovery.callingExtension", extension = extension.type_name));
-                        let discovered_resources = extension.discover()?;
+                        let discovered_resources = match extension.discover() {
+                            Ok(res) => res,
+                            Err(e) => {
+                                warn!("{}", t!("discovery.commandDiscovery.extensionDiscoverFailed", extension = extension.type_name, error = e).to_string());
+                                continue;
+                            }
+                        };
                         debug!("{}", t!("discovery.commandDiscovery.extensionFoundResources", extension = extension.type_name, count = discovered_resources.len()));
                         for resource in discovered_resources {
                             if regex.is_match(&resource.type_name) {

--- a/dsc_lib/src/discovery/command_discovery.rs
+++ b/dsc_lib/src/discovery/command_discovery.rs
@@ -313,7 +313,7 @@ impl ResourceDiscovery for CommandDiscovery {
                         let discovered_resources = match extension.discover() {
                             Ok(res) => res,
                             Err(e) => {
-                                warn!("{}", t!("discovery.commandDiscovery.extensionDiscoverFailed", extension = extension.type_name, error = e).to_string());
+                                warn!("{}", t!("discovery.commandDiscovery.extensionDiscoverFailed", extension = extension.type_name, error = e));
                                 continue;
                             }
                         };


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Add error handling when an extension fails discovery to emit a warning message instead of bubbling up the error which causes discovery to entirely fail

Unrelated, but prevented local clippy run, needed to change build.ps1 to use `rustup` explicitly to install clippy since `msrustup` doesn't support installing it.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1150