### PR TITLE
Fix crash when pipe is closed by shell

### DIFF
--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -47,7 +47,7 @@ use schemars::{Schema, schema_for};
 use serde::Deserialize;
 use std::collections::HashMap;
 use std::env;
-use std::io::{IsTerminal, Read};
+use std::io::{IsTerminal, Read, stdout, Write};
 use std::path::Path;
 use std::process::exit;
 use syntect::{
@@ -293,7 +293,11 @@ pub fn write_object(json: &str, format: Option<&OutputFormat>, include_separator
         }
     }
     else {
-        println!("{output}");
+        let mut lock = stdout().lock();
+        if writeln!(lock, "{output}").is_err() {
+            // likely caused by a broken pipe (e.g. 'head' command closed early)
+            exit(EXIT_SUCCESS);
+        }
     }
 }
 

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -293,8 +293,8 @@ pub fn write_object(json: &str, format: Option<&OutputFormat>, include_separator
         }
     }
     else {
-        let mut lock = stdout().lock();
-        if writeln!(lock, "{output}").is_err() {
+        let mut stdout_lock = stdout().lock();
+        if writeln!(stdout_lock, "{output}").is_err() {
             // likely caused by a broken pipe (e.g. 'head' command closed early)
             exit(EXIT_SUCCESS);
         }

--- a/dsc/tests/dsc.exit_code.tests.ps1
+++ b/dsc/tests/dsc.exit_code.tests.ps1
@@ -15,4 +15,9 @@ Describe 'exit code tests' {
         $result.actualState.exitCode | Should -Be 0
         $LASTEXITCODE | Should -Be 0
     }
+    It 'Exiting early due to broken pipe is a success' {
+        $out = dsc resource list | Select-Object -First 1 | ConvertFrom-Json
+        $out.Count | Should -Be 1
+        $LASTEXITCODE | Should -Be 0
+    }
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Found this while working on MCP tool.  On Windows, if you do:

```powershell
dsc resource list | select-object -first 1
```

`dsc` will emit JSON lines and after the first line, the cmdlet causes the pipeline to close therefore closing STDOUT for the `dsc` process.  Without this change, it attempts to write to a broken pipe and crashes.  On Unix systems, a signal is sent to the process to exit so it doesn't attempt to write to a broken pipe.
