### PR TITLE
(MAINT) Minimally Parallelize pester tests

### DIFF
--- a/.github/workflows/rust.new.yml
+++ b/.github/workflows/rust.new.yml
@@ -14,45 +14,133 @@ on:
 env:
   CARGO_TERM_COLOR: always
 
+defaults:
+  run:
+    shell: pwsh
+
 jobs:
-  build-linux-new:
+  linux-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - name: Install prerequisites
-      shell: pwsh
-      run: ./build.new.ps1 -SkipBuild -Clippy  -Verbose
-    - name: Build
-      shell: pwsh
-      run: ./build.new.ps1 -Clippy -Verbose
-    - name: Run tests
-      shell: pwsh
-      run: ./build.new.ps1 -Test -Verbose
-
-  build-windows-new:
-    runs-on: windows-latest
+      - uses: actions/checkout@v5
+      - name: Install prerequisites
+        run: ./build.new.ps1 -SkipBuild -Clippy  -Verbose
+      - name: Build
+        run: ./build.new.ps1 -Clippy -Verbose
+      - name: Run rust tests
+        run: ./build.new.ps1 -SkipBuild -Test -ExcludePesterTests -Verbose
+      - name:  Prepare build artifact
+        run:   tar -cvf bin.tar bin/
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: linux-bin
+          path: bin.tar
+  linux-pester:
+    needs: linux-build
+    strategy:
+      matrix:
+        group: [dsc, adapters, extensions, resources]
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
-    - name: Install prerequisites
-      shell: pwsh
-      run: ./build.new.ps1 -SkipBuild -Clippy -Verbose
-    - name: Build
-      shell: pwsh
-      run: ./build.new.ps1 -Clippy -Verbose
-    - name: Run tests
-      shell: pwsh
-      run: ./build.new.ps1 -Test -Verbose
+      - uses: actions/checkout@v5
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: linux-bin
+      - name:  Expand build artifact
+        run:   tar -xvf bin.tar
+      - name: Test ${{matrix.group}}
+        run: |-
+          $params = @{
+            SkipBuild        = $true
+            Test             = $true
+            ExcludeRustTests = $true
+            Verbose          = $true
+          }
+          ./build.new.ps1 @params -PesterTestGroup ${{matrix.group}}
 
-  build-macos-new:
+  macos-build:
     runs-on: macos-latest
     steps:
-    - uses: actions/checkout@v5
-    - name: Install prerequisites
-      shell: pwsh
-      run: ./build.new.ps1 -SkipBuild -Clippy -Verbose
-    - name: Build
-      shell: pwsh
-      run: ./build.new.ps1 -Clippy -Verbose
-    - name: Run tests
-      shell: pwsh
-      run: ./build.new.ps1 -Test -Verbose
+      - uses: actions/checkout@v5
+      - name: Install prerequisites
+        run: ./build.new.ps1 -SkipBuild -Clippy  -Verbose
+      - name: Build
+        run: ./build.new.ps1 -Clippy -Verbose
+      - name: Run rust tests
+        run: ./build.new.ps1 -SkipBuild -Test -ExcludePesterTests -Verbose
+      - name:  Prepare build artifact
+        run:   tar -cvf bin.tar bin/
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-bin
+          path: bin.tar
+  macos-pester:
+    needs: macos-build
+    strategy:
+      matrix:
+        group: [dsc, adapters, extensions, resources]
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-bin
+      - name:  Expand build artifact
+        run:   tar -xvf bin.tar
+      - name: Test ${{matrix.group}}
+        run: |-
+          $params = @{
+            SkipBuild        = $true
+            Test             = $true
+            ExcludeRustTests = $true
+            Verbose          = $true
+          }
+          ./build.new.ps1 @params -PesterTestGroup ${{matrix.group}}
+
+  # Windows
+  windows-build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install prerequisites
+        run: ./build.new.ps1 -SkipBuild -Clippy  -Verbose
+      - name: Build
+        run: ./build.new.ps1 -Clippy -Verbose
+      - name: Run rust tests
+        run: ./build.new.ps1 -SkipBuild -Test -ExcludePesterTests -Verbose
+      - name: List bin folder files
+        run:  Get-ChildItem bin
+      - name:  Prepare build artifact
+        run:   tar -cvf bin.tar bin
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-bin
+          path: bin.tar
+  windows-pester:
+    needs: windows-build
+    strategy:
+      matrix:
+        group: [dsc, adapters, extensions, resources]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Download build artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: windows-bin
+      - name:  Expand build artifact
+        run:   tar -xvf bin.tar
+      - name: Test ${{matrix.group}}
+        run: |-
+          $params = @{
+            SkipBuild        = $true
+            Test             = $true
+            ExcludeRustTests = $true
+            Verbose          = $true
+          }
+          ./build.new.ps1 @params -PesterTestGroup ${{matrix.group}}


### PR DESCRIPTION
# PR Summary

Prior to this change, the pester tests made up the majority of the build time in CI. This change attempts to speed up the pester tests by parallelizing them roughly by folder:

- The tests in the `dsc` folder run in their own cell.
- The tests in the `adapters` folder run in their own cell.
- The tests in the `extensions` folder run in their own cell.
- The tests in the `resources` folder run in their own cell.

This should substantially reduce the time spent on tests, particularly on Windows, where the CLI tests take much longer.

This change makes minor changes to the new build script and helpers to support targeted test execution.

## PR Context

Depends on #1161 
