### PR TITLE
Fix GitHub release and add stage dependency for Universal package release

### DIFF
--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -402,12 +402,6 @@ extends:
               Copy-Item -Path $_.FullName -Destination $outputDir -Force -Verbose
             }
 
-            if (-not (Test-Path $(Build.SourcesDirectory)\CHANGELOG.md)) {
-              throw "CHANGELOG.md file not found in source directory."
-            }
-
-            Copy-Item -Path "$(Build.SourcesDirectory)\CHANGELOG.md" -Destination $outputDir -Force -Verbose
-
             Write-Verbose -Verbose "Copy completed"
           displayName: Copy artifacts to release area
 
@@ -454,15 +448,11 @@ extends:
             script: |
               Write-Verbose -Verbose "Release version: $(PackageVersion)"
 
-              $artifacts = Get-ChildItem "$(Pipeline.Workspace)" -Recurse -Include '*.zip', '*.tar.gz', '*.msixbundle', '*.MD'
+              $artifacts = Get-ChildItem "$(Pipeline.Workspace)" -Recurse -Include '*.zip', '*.tar.gz', '*.msixbundle'
 
               $artifacts | ForEach-Object {
                 Write-Verbose -Verbose "Found artifact: $($_.FullName)"
               }
-
-              $ChangeLogDirectory = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/ChangeLog" -Force -ErrorAction Ignore
-              Write-Host "##vso[task.setvariable variable=ChangeLogDirectory]$ChangeLogDirectory"
-              Copy-Item -Path "$(Pipeline.Workspace)/releasePrep/CHANGELOG.md" -Destination $ChangeLogDirectory -Force -Verbose
 
               $GitHubReleaseDirectory = New-Item -ItemType Directory -Path "$(Pipeline.Workspace)/GitHubRelease" -Force -ErrorAction Ignore
               Write-Host "##vso[task.setvariable variable=GitHubReleaseDirectory]$GitHubReleaseDirectory"
@@ -478,15 +468,20 @@ extends:
               if ($packageVersion -like '*-*') {
                 Write-Verbose -Verbose "Pre-release version detected: $packageVersion"
                 Write-Host "##vso[task.setvariable variable=IsPreRelease]true"
+
+                Write-Verbose -verbose "Setting the ChangeLogCompareToRelease to 'lastNonDraftRelease'"
+                Write-Host "##vso[task.setvariable variable=ChangeLogCompareToRelease]lastNonDraftRelease"
               }
               else {
                 Write-Verbose -Verbose "Stable release version detected: $packageVersion"
                 Write-Host "##vso[task.setvariable variable=IsPreRelease]false"
+
+                Write-Verbose -verbose "Setting the ChangeLogCompareToRelease to 'lastFullRelease'"
+                Write-Host "##vso[task.setvariable variable=ChangeLogCompareToRelease]lastFullRelease"
               }
 
               $githubReleaseVersion = "v$packageVersion"
               Write-Verbose -Verbose "GitHub Release version: $githubReleaseVersion"
-
               Write-Host "##vso[task.setvariable variable=GitHubReleaseVersion]$githubReleaseVersion"
 
         - task: GitHubRelease@1
@@ -496,20 +491,20 @@ extends:
             repositoryName: PowerShell/DSC
             target: main
             action: create
-            title: $(GitHubReleaseVersion)
             assets: |
               $(GitHubReleaseDirectory)\*.zip
               $(GitHubReleaseDirectory)\*.tar.gz
+              $(GitHubReleaseDirectory)\*.msixbundle
             addChangeLog: true
             changeLogType: commitBased
-            releaseNotesFilePath: '$(ChangeLogDirectory)\CHANGELOG.md'
+            changeLogCompareToRelease: '$(ChangeLogCompareToRelease)'
             tagSource: 'userSpecifiedTag'
             tag: '$(GitHubReleaseVersion)'
             isDraft: true
             isPreRelease: '$(IsPreRelease)'
 
     - stage: ReleaseUniversalPackage
-      dependsOn: ['Release']
+      dependsOn: ['BuildAndSign','Release']
       condition: and(succeeded(), ne(variables['Build.Reason'], 'Schedule'), eq(variables.officialBuild, true))
       variables:
         - name: PackageVersion


### PR DESCRIPTION
# PR Summary

This pull request makes several updates to the `.pipelines/DSC-Official.yml` pipeline configuration, primarily focused on improving artifact handling and changelog management during the release process. The changes simplify the copying of artifacts, adjust how changelogs are managed, and enhance the release logic to better distinguish between pre-release and stable release workflows.

**Artifact and changelog handling improvements:**

* Removed the explicit copying and existence check for the `CHANGELOG.md` file during artifact preparation, simplifying the release artifact process.
* Updated artifact discovery to exclude `.MD` files, ensuring only relevant package files are included in the release.
* Removed the creation of a dedicated `ChangeLogDirectory` and the copying of `CHANGELOG.md` to this directory, streamlining changelog management.

**Release workflow enhancements:**

* Added logic to set the `ChangeLogCompareToRelease` variable based on whether the release is a pre-release or stable release, allowing for more accurate changelog generation.
* Updated the GitHub release task to use the new `changeLogCompareToRelease` variable instead of a static changelog file path, and ensured `.msixbundle` files are included in release assets. Also adjusted stage dependencies to ensure proper sequencing.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
