### PR TITLE
Update GitHub release task to not create a change log

### DIFF
--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -468,16 +468,10 @@ extends:
               if ($packageVersion -like '*-*') {
                 Write-Verbose -Verbose "Pre-release version detected: $packageVersion"
                 Write-Host "##vso[task.setvariable variable=IsPreRelease]true"
-
-                Write-Verbose -verbose "Setting the ChangeLogCompareToRelease to 'lastNonDraftRelease'"
-                Write-Host "##vso[task.setvariable variable=ChangeLogCompareToRelease]lastNonDraftRelease"
               }
               else {
                 Write-Verbose -Verbose "Stable release version detected: $packageVersion"
                 Write-Host "##vso[task.setvariable variable=IsPreRelease]false"
-
-                Write-Verbose -verbose "Setting the ChangeLogCompareToRelease to 'lastFullRelease'"
-                Write-Host "##vso[task.setvariable variable=ChangeLogCompareToRelease]lastFullRelease"
               }
 
               $githubReleaseVersion = "v$packageVersion"
@@ -495,9 +489,7 @@ extends:
               $(GitHubReleaseDirectory)\*.zip
               $(GitHubReleaseDirectory)\*.tar.gz
               $(GitHubReleaseDirectory)\*.msixbundle
-            addChangeLog: true
-            changeLogType: commitBased
-            changeLogCompareToRelease: '$(ChangeLogCompareToRelease)'
+            addChangeLog: false
             tagSource: 'userSpecifiedTag'
             tag: '$(GitHubReleaseVersion)'
             isDraft: true


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request makes adjustments to the release pipeline configuration in `.pipelines/DSC-Official.yml`, specifically around how changelogs are handled during release creation. The main change is that changelogs will no longer be automatically generated and included in GitHub releases.

Release pipeline configuration changes:

* Removed logic that set the `ChangeLogCompareToRelease` variable based on whether the release is a pre-release or stable release. This means the pipeline no longer dynamically determines which previous release to compare for changelog generation.
* Disabled changelog generation in the GitHub release step by setting `addChangeLog` to `false` and removing related changelog configuration options.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
