### PR TITLE
Allow resource and extension manifests to have `metadata` property

### DIFF
--- a/lib/dsc-lib/src/dscresources/resource_manifest.rs
+++ b/lib/dsc-lib/src/dscresources/resource_manifest.rs
@@ -5,7 +5,7 @@ use rust_i18n::t;
 use schemars::{Schema, JsonSchema, json_schema};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 
 use crate::{dscerror::DscError, schemas::DscRepoSchema};
@@ -71,6 +71,8 @@ pub struct ResourceManifest {
     /// Details how to get the schema of the resource.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub schema: Option<SchemaKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Map<String, Value>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]

--- a/lib/dsc-lib/src/extensions/extension_manifest.rs
+++ b/lib/dsc-lib/src/extensions/extension_manifest.rs
@@ -5,7 +5,7 @@ use rust_i18n::t;
 use schemars::{Schema, JsonSchema, json_schema};
 use semver::Version;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 
 use crate::{dscerror::DscError, schemas::DscRepoSchema};
@@ -36,6 +36,8 @@ pub struct ExtensionManifest {
     /// Mapping of exit codes to descriptions.  Zero is always success and non-zero is always failure.
     #[serde(rename = "exitCodes", skip_serializing_if = "Option::is_none")]
     pub exit_codes: Option<HashMap<i32, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<Map<String, Value>>,
 }
 
 impl DscRepoSchema for ExtensionManifest {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Allow resource and extension manifests to have `metadata` property.  Developers can put whatever they want in there, but `Microsoft.DSC` namespace is still reserved, otherwise, any metadata is ignored by DSC.

@Bpoe FYI
