### PR TITLE
Add support for invoking property expressions in resource configuration

### DIFF
--- a/lib/dsc-lib/src/configure/mod.rs
+++ b/lib/dsc-lib/src/configure/mod.rs
@@ -1037,6 +1037,10 @@ impl Configurator {
                     };
                     new_resource.name = new_name.to_string();
 
+                    if let Some(properties) = &resource.properties {
+                        new_resource.properties = self.invoke_property_expressions(Some(properties))?;
+                    }
+
                     new_resource.copy = None;
                     copy_resources.push(new_resource);
                 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request implements support for evaluating expressions in resource properties during copy operations. Previously, while `copy` count could use expressions, properties within copied resources were not evaluated per iteration, preventing users from using functions like `copyIndex()` within property values.

## PR Context

Fix #1179.

Users can now use:

```yaml
resources:
- name: "[format('Server-{0}', copyIndex())]"
  copy:
    name: testLoop
    count: 3
  type: Microsoft.DSC.Debug/Echo
  properties:
    output: "[format('Port-{0}', copyIndex())]"
```
