### PR TITLE
Fix typo Select-Obect -> Select-Object from commit 91a6293…

### DIFF
--- a/adapters/powershell/psDscAdapter/powershell.resource.ps1
+++ b/adapters/powershell/psDscAdapter/powershell.resource.ps1
@@ -50,7 +50,7 @@ if ($Operation -eq 'ClearCache') {
 
 if ($PSVersionTable.PSVersion.Major -le 5) {
     # For Windows PowerShell, we want to remove any PowerShell 7 paths from PSModulePath
-    if ($pwshPath = Get-Command 'pwsh' -ErrorAction Ignore | Select-Obect -ExpandProperty Source) {
+    if ($pwshPath = Get-Command 'pwsh' -ErrorAction Ignore | Select-Object -ExpandProperty Source) {
         $pwshDefaultModulePaths = @(
             "$HOME\Documents\PowerShell\Modules"                # CurrentUser
             "$Env:ProgramFiles\PowerShell\Modules"              # AllUsers


### PR DESCRIPTION
I had the error:

_"The term 'Select-Obect' is not recognized as a name of a cmdlet, function, script file, or executable program."_

So this is just a fix for what appears to be a standard typo.