### PR TITLE
Add support for user function namespace to have underscore prefix

### DIFF
--- a/dsc/tests/dsc_user_functions.tests.ps1
+++ b/dsc/tests/dsc_user_functions.tests.ps1
@@ -3,7 +3,7 @@
 
 Describe 'user function tests' {
     It 'user function working with expression: <expression>' -TestCases @(
-        @{ expression = "[MyFunction.ComboFunction('test', 42, true)]"; expected = 'test-42-True' }
+        @{ expression = "[__MyFunction.ComboFunction('test', 42, true)]"; expected = 'test-42-True' }
         @{ expression = "[MyOtherNamespace.ArrayFunction(createArray('a','b','c','d'))]"; expected = @('["b","c","d"]-a') }
     ) {
         param($expression, $expected)
@@ -11,7 +11,7 @@ Describe 'user function tests' {
         $configYaml = @"
 `$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 functions:
-- namespace: MyFunction
+- namespace: __MyFunction
   members:
     ComboFunction:
       parameters:

--- a/grammars/tree-sitter-dscexpression/grammar.js
+++ b/grammars/tree-sitter-dscexpression/grammar.js
@@ -24,7 +24,7 @@ module.exports = grammar({
 
     function: $ => prec(PREC.FUNCTION, seq(field('name', $.functionName), '(', field('args', optional($.arguments)), ')')),
     functionName: $ => choice(
-      /[a-zA-Z][a-zA-Z0-9]*(\.[a-zA-Z0-9]+)?/,
+      /[_a-zA-Z][_a-zA-Z0-9]*(\.[a-zA-Z0-9]+)?/,
       $._booleanLiteral
     ),
     arguments: $ => seq($._argument, repeat(seq(',', $._argument))),

--- a/grammars/tree-sitter-dscexpression/test/corpus/valid_expressions.txt
+++ b/grammars/tree-sitter-dscexpression/test/corpus/valid_expressions.txt
@@ -370,3 +370,16 @@ User Function with nested function
               (function
                 (functionName)))
             (boolean)))))
+
+=====
+User Function with namespace prefixed by underscores
+=====
+[__bicep.myFunction('param1')]
+---
+
+    (statement
+      (expression
+        (function
+          (functionName)
+          (arguments
+            (string)))))


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

User functions namespace can have underscores prefix as generated from bicep.  This fixes the grammar to allow for underscores in the namespace but not the function name.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1271
