### PR TITLE
Add FilteredExport resource and update export method handling

### DIFF
--- a/adapters/powershell/Tests/TestClassResource/0.0.1/TestClassResource.psd1
+++ b/adapters/powershell/Tests/TestClassResource/0.0.1/TestClassResource.psd1
@@ -34,7 +34,7 @@ VariablesToExport = @()
 AliasesToExport = @()
 
 # DSC resources to export from this module
-DscResourcesToExport = @('TestClassResource', 'NoExport')
+DscResourcesToExport = @('TestClassResource', 'NoExport', 'FilteredExport')
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{

--- a/adapters/powershell/Tests/TestClassResource/0.0.1/TestClassResource.psm1
+++ b/adapters/powershell/Tests/TestClassResource/0.0.1/TestClassResource.psm1
@@ -155,6 +155,52 @@ class NoExport: BaseTestClass
     }
 }
 
+[DscResource()]
+class FilteredExport : BaseTestClass
+{
+    [DscProperty(Key)]
+    [string] $Name
+
+    [DscProperty()]
+    [string] $Prop1
+
+    [void] Set()
+    {
+    }
+
+    [bool] Test()
+    {
+        return $true
+    }
+
+    [FilteredExport] Get()
+    {
+        return $this
+    }
+
+    static [FilteredExport[]] Export()
+    {
+        $resultList = [List[FilteredExport]]::new()
+        $obj = New-Object FilteredExport
+        $obj.Name = "DefaultObject"
+        $obj.Prop1 = "Default Property"
+        $resultList.Add($obj)
+
+        return $resultList.ToArray()
+    }
+
+    static [FilteredExport[]] Export([FilteredExport]$Name)
+    {
+        $resultList = [List[FilteredExport]]::new()
+        $obj = New-Object FilteredExport
+        $obj.Name = $Name
+        $obj.Prop1 = "Filtered Property for $Name"
+        $resultList.Add($obj)
+
+        return $resultList.ToArray()
+    }
+}
+
 function Test-World()
 {
     "Hello world from PSTestModule!"

--- a/adapters/powershell/psDscAdapter/powershell.resource.ps1
+++ b/adapters/powershell/psDscAdapter/powershell.resource.ps1
@@ -181,7 +181,7 @@ switch ($Operation) {
             # process the INPUT (desiredState) for each resource as dscresourceInfo and return the OUTPUT as actualState
             $actualState = $psDscAdapter.invoke( { param($op, $ds, $dscResourceCache) Invoke-DscOperation -Operation $op -DesiredState $ds -dscResourceCache $dscResourceCache }, $Operation, $ds, $dscResourceCache)
             if ($null -eq $actualState) {
-                Write-DscTrace -Operation Error -Message 'Incomplete GET for resource ' + $ds.Name
+                "Failed to invoke operation '{0}' for resource name '{1}'." -f $Operation, $ds.Name | Write-DscTrace -Operation Error
                 exit 1
             }
             if ($null -ne $actualState.Properties -and $actualState.Properties.InDesiredState -eq $false) {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds the ability to apply a filter on `Export` through the PowerShell adapter. A new helper function determines the user's input and returns the appropriate method. An additional class was introduced in the `TestClassResource.psm1` file to avoid interfering with other tests, since it requires the returned type.

## PR Context

Fix #1277.
