### PR TITLE
(MAINT) Add 'bicepparams.dsc.extension.json' to packaging and copy files

### DIFF
--- a/extensions/bicep/copy_files.txt
+++ b/extensions/bicep/copy_files.txt
@@ -1,1 +1,2 @@
 bicep.dsc.extension.json
+bicepparams.dsc.extension.json

--- a/packaging.ps1
+++ b/packaging.ps1
@@ -51,6 +51,7 @@ $filesForWindowsPackage = @(
     'appx.dsc.extension.json',
     'appx-discover.ps1',
     'bicep.dsc.extension.json',
+    'bicepparams.dsc.extension.json',
     'dsc.exe',
     'dsc_default.settings.json',
     'dsc.settings.json',
@@ -87,6 +88,7 @@ $filesForWindowsPackage = @(
 
 $filesForLinuxPackage = @(
     'bicep.dsc.extension.json',
+    'bicepparams.dsc.extension.json',
     'dsc',
     'dsc_default.settings.json',
     'dsc.settings.json',
@@ -112,6 +114,7 @@ $filesForLinuxPackage = @(
 
 $filesForMacPackage = @(
     'bicep.dsc.extension.json',
+    'bicepparams.dsc.extension.json',
     'dsc',
     'dsc_default.settings.json',
     'dsc.settings.json',


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds the 'bicepparams.dsc.extension.json' for packaging. Even though `copy_files.txt` is deprecated, I kept it aligned.

## PR Context

Fix #1301.
