### PR TITLE
Fix how clippy is used in build

### DIFF
--- a/build.helpers.psm1
+++ b/build.helpers.psm1
@@ -1300,7 +1300,7 @@ function Export-GrammarBinding {
             } finally {
                 Pop-Location
             }
-            
+
         }
     }
 
@@ -1369,9 +1369,13 @@ function Build-RustProject {
             cargo clean
         }
 
-        if ($Clippy) {
+        if ($Clippy -and !$Project.ClippyUnclean) {
             $clippyFlags = @()
-            cargo clippy @clippyFlags --% -- -Dwarnings --no-deps
+            if (!$Project.ClippyPedanticUnclean) {
+                cargo clippy @clippyFlags --% -- -Dclippy::pedantic --no-deps -Dwarnings
+            } else {
+                cargo clippy @clippyFlags --% -- -Dwarnings --no-deps
+            }
 
             if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
                 throw "Last exit code is $LASTEXITCODE, clippy failed for at least one project"

--- a/grammars/tree-sitter-dscexpression/.project.data.json
+++ b/grammars/tree-sitter-dscexpression/.project.data.json
@@ -3,6 +3,7 @@
     "Kind": "Grammar",
     "IsRust": true,
     "ClippyUnclean": true,
+    "ClippyPedanticUnclean": true,
     "SkipTest": {
         "Windows": true
     }

--- a/grammars/tree-sitter-dscexpression/grammar.js
+++ b/grammars/tree-sitter-dscexpression/grammar.js
@@ -6,7 +6,7 @@ const PREC = {
   STRINGLITERAL: -11,
 }
 
-module.exports = grammar({
+export default grammar({
   name: 'dscexpression',
 
   extras: $ => ['\n', ' '],

--- a/grammars/tree-sitter-dscexpression/package.json
+++ b/grammars/tree-sitter-dscexpression/package.json
@@ -2,6 +2,7 @@
   "name": "tree-sitter-dscexpression",
   "version": "1.0.0",
   "description": "Dscexpression grammar for tree-sitter",
+  "type": "module",
   "repository": "github:tree-sitter/tree-sitter-dscexpression",
   "license": "MIT",
   "main": "bindings/node",

--- a/grammars/tree-sitter-ssh-server-config/.project.data.json
+++ b/grammars/tree-sitter-ssh-server-config/.project.data.json
@@ -2,5 +2,6 @@
     "Name": "tree-sitter-ssh-server-config",
     "Kind": "Grammar",
     "IsRust": true,
-    "ClippyUnclean": true
+    "ClippyUnclean": true,
+    "ClippyPedanticUnclean": true
 }

--- a/grammars/tree-sitter-ssh-server-config/grammar.js
+++ b/grammars/tree-sitter-ssh-server-config/grammar.js
@@ -8,7 +8,7 @@ const PREC = {
   OPERATOR: 1
 }
 
-module.exports = grammar({
+export default grammar({
   name: 'ssh_server_config',
 
   extras: $ => [' ', '\t', '\r'],

--- a/grammars/tree-sitter-ssh-server-config/package.json
+++ b/grammars/tree-sitter-ssh-server-config/package.json
@@ -2,6 +2,7 @@
   "name": "tree-sitter-ssh-server-config",
   "version": "1.0.0",
   "description": "sshd_config grammar for tree-sitter",
+  "type": "module",
   "repository": "https://github.com/powershell/dsc",
   "license": "MIT",
   "main": "bindings/node",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Looks like the build helper wasn't using pedantic mode, so added that
- Declare the generated code for grammars in the project data files to be pedantic unclean
- Tree-sitter auto-changed the grammar.js
- Removed unused use declaration in dsc lib
