### PR TITLE
(MAINT) Update schema for project data files

### DIFF
--- a/.vscode/schemas/definitions.json
+++ b/.vscode/schemas/definitions.json
@@ -19,15 +19,16 @@
                         "required": ["Name", "Kind"],
                         "unevaluatedProperties": false,
                         "properties": {
-                            "Name":                { "$ref": "#/$defs/ProjectName" },
-                            "Kind":                { "$ref": "#/$defs/ProjectKind" },
-                            "SupportedPlatformOS": { "$ref": "#/$defs/ProjectSupportedPlatformOS" },
-                            "IsRust":              { "$ref": "#/$defs/ProjectIsRust" },
-                            "TestOnly":            { "$ref": "#/$defs/ProjectTestOnly" },
-                            "SkipTest":            { "$ref": "#/$defs/ProjectSkipTest" },
-                            "ClippyUnclean":       { "$ref": "#/$defs/ProjectClippyUnclean" },
-                            "Binaries":            { "$ref": "#/$defs/ProjectBinaries" },
-                            "CopyFiles":           { "$ref": "#/$defs/ProjectCopyFiles" }
+                            "Name":                  { "$ref": "#/$defs/ProjectName" },
+                            "Kind":                  { "$ref": "#/$defs/ProjectKind" },
+                            "SupportedPlatformOS":   { "$ref": "#/$defs/ProjectSupportedPlatformOS" },
+                            "IsRust":                { "$ref": "#/$defs/ProjectIsRust" },
+                            "TestOnly":              { "$ref": "#/$defs/ProjectTestOnly" },
+                            "SkipTest":              { "$ref": "#/$defs/ProjectSkipTest" },
+                            "ClippyUnclean":         { "$ref": "#/$defs/ProjectClippyUnclean" },
+                            "ClippyPedanticUnclean": { "$ref": "#/$defs/ProjectClippyPedanticUnclean" },
+                            "Binaries":              { "$ref": "#/$defs/ProjectBinaries" },
+                            "CopyFiles":             { "$ref": "#/$defs/ProjectCopyFiles" }
                         },
                         "allOf": [
                             {
@@ -65,15 +66,16 @@
             "required": ["Name", "Kind"],
             "unevaluatedProperties": false,
             "properties": {
-                "Name":                { "$ref": "#/$defs/ProjectName" },
-                "Kind":                { "$ref": "#/$defs/ProjectKind" },
-                "SupportedPlatformOS": { "$ref": "#/$defs/ProjectSupportedPlatformOS" },
-                "IsRust":              { "$ref": "#/$defs/ProjectIsRust" },
-                "TestOnly":            { "$ref": "#/$defs/ProjectTestOnly" },
-                "SkipTest":            { "$ref": "#/$defs/ProjectSkipTest" },
-                "ClippyUnclean":       { "$ref": "#/$defs/ProjectClippyUnclean" },
-                "Binaries":            { "$ref": "#/$defs/ProjectBinaries" },
-                "CopyFiles":           { "$ref": "#/$defs/ProjectCopyFiles" }
+                "Name":                  { "$ref": "#/$defs/ProjectName" },
+                "Kind":                  { "$ref": "#/$defs/ProjectKind" },
+                "SupportedPlatformOS":   { "$ref": "#/$defs/ProjectSupportedPlatformOS" },
+                "IsRust":                { "$ref": "#/$defs/ProjectIsRust" },
+                "TestOnly":              { "$ref": "#/$defs/ProjectTestOnly" },
+                "SkipTest":              { "$ref": "#/$defs/ProjectSkipTest" },
+                "ClippyUnclean":         { "$ref": "#/$defs/ProjectClippyUnclean" },
+                "ClippyPedanticUnclean": { "$ref": "#/$defs/ProjectClippyPedanticUnclean" },
+                "Binaries":              { "$ref": "#/$defs/ProjectBinaries" },
+                "CopyFiles":             { "$ref": "#/$defs/ProjectCopyFiles" }
             }
         },
         "BuildPackageFiles": {
@@ -225,6 +227,12 @@
             "default": false,
             "title": "Clippy Unclean",
             "markdownDescription": "Indicates whether to skip linting the Rust crate with Clippy."
+        },
+        "ProjectClippyPedanticUnclean": {
+            "type": "boolean",
+            "default": false,
+            "title": "Clippy Pedantic Unclean",
+            "markdownDescription": "Indicates whether to skip linting the pedantic rules for the Rust crate with Clippy."
         },
         "ProjectBinaries": {
             "type": "array",

--- a/build.data.json
+++ b/build.data.json
@@ -181,7 +181,8 @@
       "RelativePath": "extensions/bicep",
       "CopyFiles": {
         "All": [
-          "bicep.dsc.extension.json"
+          "bicep.dsc.extension.json",
+          "bicepparams.dsc.extension.json"
         ]
       }
     },
@@ -190,6 +191,7 @@
       "Kind": "Grammar",
       "RelativePath": "grammars/tree-sitter-dscexpression",
       "IsRust": true,
+      "ClippyPedanticUnclean": true,
       "ClippyUnclean": true,
       "SkipTest": {
         "Windows": true
@@ -200,6 +202,7 @@
       "Kind": "Grammar",
       "RelativePath": "grammars/tree-sitter-ssh-server-config",
       "IsRust": true,
+      "ClippyPedanticUnclean": true,
       "ClippyUnclean": true
     },
     {


### PR DESCRIPTION
# PR Summary

This change updates the JSON Schemas for the project data files (`.project.data.json` and `build.data.json`) to recognize the new `ClippyPedanticUnclean` option.

This change also updates the `build.data.json` file with the latest project data. This doesn't affect the build, which always checks the individual project data files first, but does make it easier to check the project options as a maintainer.

## PR Context

#1314 added a new build option to the `.project.data.json` files which wasn't captured in the JSON Schema. This change ensures the schema understands that option and presents it to maintainers for validation and IntelliSense in VS Code.
