### PR TITLE
Implement routing to delete operation for resources with _exist set to false

### DIFF
--- a/dsc/locales/en-us.toml
+++ b/dsc/locales/en-us.toml
@@ -107,6 +107,7 @@ invalidOperationOnAdapter = "Can not perform this operation on the adapter itsel
 setInputEmpty = "Desired input is empty"
 testInputEmpty = "Expected input is required"
 jsonError = "JSON: %{err}"
+routingToDelete = "Routing to delete operation because _exist is false"
 
 [subcommand]
 actualStateNotObject = "actual_state is not an object"

--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -5,9 +5,11 @@ use crate::args::{GetOutputFormat, OutputFormat};
 use crate::util::{EXIT_DSC_ERROR, EXIT_INVALID_ARGS, EXIT_JSON_ERROR, EXIT_DSC_RESOURCE_NOT_FOUND, write_object};
 use dsc_lib::configure::config_doc::{Configuration, ExecutionKind};
 use dsc_lib::configure::add_resource_export_results_to_configuration;
-use dsc_lib::dscresources::{resource_manifest::Kind, invoke_result::{GetResult, ResourceGetResponse}};
+use dsc_lib::dscresources::{resource_manifest::Kind, invoke_result::{GetResult, ResourceGetResponse, ResourceSetResponse, SetResult}};
+use dsc_lib::dscresources::dscresource::{Capability, get_diff};
 use dsc_lib::dscerror::DscError;
 use rust_i18n::t;
+use serde_json::Value;
 use tracing::{error, debug};
 
 use dsc_lib::{
@@ -140,6 +142,62 @@ pub fn set(dsc: &mut DscManager, resource_type: &str, version: Option<&str>, inp
     if resource.kind == Kind::Adapter {
         error!("{}: {}", t!("resource_command.invalidOperationOnAdapter"), resource.type_name);
         exit(EXIT_DSC_ERROR);
+    }
+
+    let exist = match serde_json::from_str::<Value>(input) {
+        Ok(v) => {
+            if let Some(exist_value) = v.get("_exist") {
+                !matches!(exist_value, Value::Bool(false))
+            } else {
+                true
+            }
+        },
+        Err(_) => true,
+    };
+
+    if !exist && resource.capabilities.contains(&Capability::Delete) && !resource.capabilities.contains(&Capability::SetHandlesExist) {
+        debug!("{}", t!("resource_command.routingToDelete"));
+
+        let before_state = match resource.get(input) {
+            Ok(GetResult::Resource(response)) => response.actual_state,
+            Ok(_) => unreachable!(),
+            Err(err) => {
+                error!("{err}");
+                exit(EXIT_DSC_ERROR);
+            }
+        };
+
+        if let Err(err) = resource.delete(input) {
+            error!("{err}");
+            exit(EXIT_DSC_ERROR);
+        }
+
+        let after_state = match resource.get(input) {
+            Ok(GetResult::Resource(response)) => response.actual_state,
+            Ok(_) => unreachable!(),
+            Err(err) => {
+                error!("{err}");
+                exit(EXIT_DSC_ERROR);
+            }
+        };
+
+        let diff = get_diff(&after_state, &before_state);
+
+        let result = SetResult::Resource(ResourceSetResponse {
+            before_state,
+            after_state,
+            changed_properties: Some(diff),
+        });
+
+        let json = match serde_json::to_string(&result) {
+            Ok(json) => json,
+            Err(err) => {
+                error!("{}", t!("resource_command.jsonError", err = err));
+                exit(EXIT_JSON_ERROR);
+            }
+        };
+        write_object(&json, format, false);
+        return;
     }
 
     match resource.set(input, true, &ExecutionKind::Actual) {

--- a/dsc/tests/dsc_resource_set.tests.ps1
+++ b/dsc/tests/dsc_resource_set.tests.ps1
@@ -14,4 +14,10 @@ Describe 'Invoke a resource set directly' {
         $out.afterState.version | Should -BeExactly '1.1.2'
         $out.changedProperties | Should -BeNullOrEmpty
     }
+
+    It '_exist false routes to delete operation' {
+        $out = dsc -l trace resource set --resource Test/Delete --input '{"_exist": false}' 2>&1
+        $LASTEXITCODE | Should -Be 0
+        $out | Out-String | Should -Match 'Routing to delete operation because _exist is false'
+    }
 }


### PR DESCRIPTION


# PR Summary

Fixes `dsc resource set` to route to the delete operation when `_exist` is set to `false` for resources that have the `Delete` capability but not `SetHandlesExist`.

The implementation mirrors the existing logic from configuration documents and reuses the `get_diff` function for calculating the `changedProperties`. I've decided to manually construct the `SetResult` response since `delete()` returns `()` rather than state info as a design decision.

## PR Context

Fixes #1268.
