### PR TITLE
(MAINT) Fix packaging for `zip` and `tgz`

### DIFF
--- a/build.data.json
+++ b/build.data.json
@@ -218,10 +218,10 @@
       "IsRust": true
     },
     {
-        "Name": "dsc-lib-jsonschema-macros",
-        "Kind": "Library",
-        "RelativePath": "lib/dsc-lib-jsonschema-macros",
-        "IsRust": true
+      "Name": "dsc-lib-jsonschema-macros",
+      "Kind": "Library",
+      "RelativePath": "lib/dsc-lib-jsonschema-macros",
+      "IsRust": true
     },
     {
       "Name": "dsc-lib-osinfo",

--- a/build.helpers.psm1
+++ b/build.helpers.psm1
@@ -181,7 +181,10 @@ function Import-DscBuildData {
         | ConvertFrom-Json -AsHashtable
 
         if ($RefreshProjects) {
-            $data.Projects = Get-DscProjectData
+            [DscProjectDefinition[]]$rootProject = $data.Projects.Where({
+                $_.Name -eq 'root'
+            }, 'first')[0]
+            $data.Projects = $rootProject + (Get-DscProjectData)
         } else {
             $data.Projects = [DscProjectDefinition[]]$data.Projects
         }
@@ -1030,7 +1033,7 @@ function Get-ArtifactDirectoryPath {
             MsixBundle = Join-Path $PSScriptRoot 'bin' 'msix'
             MsixTarget = Join-Path $PSScriptRoot 'bin' $Architecture 'msix'
             ZipTarget  = Join-Path $PSScriptRoot 'bin' $Architecture 'zip'
-            $TgzTarget = Join-Path $PSScriptRoot 'bin' $Architecture 'tgz'
+            TgzTarget  = Join-Path $PSScriptRoot 'bin' $Architecture 'tgz'
         }
     }
 }
@@ -1333,7 +1336,7 @@ function Build-RustProject {
             } elseif ($Architecture -match 'darwin') {
                 'macOS'
             } elseif ($Architecture -match 'windows') {
-                'windows'
+                'Windows'
             } else {
                 throw "Unsupported architecture '$Architecture'"
             }
@@ -2072,7 +2075,7 @@ function Build-DscPackage {
         } elseif ($packageType -eq 'tgz') {
             Build-DscTgzPackage @buildParams
         } elseif ($packageType -eq 'zip') {
-            Build-DscTgzPackage
+            Build-DscZipPackage @buildParams
         } else {
             throw "Unhandled package type '$packageType'"
         }

--- a/build.ps1
+++ b/build.ps1
@@ -312,7 +312,11 @@ process {
 clean {
     $progressParams.Activity = 'Cleaning up'
     Write-BuildProgress @progressParams
-    Write-BuildProgress @progressParams -Status "Restoring rust environment"
-    Reset-RustEnvironment -PriorEnvironment $priorRustEnvironment @VerboseParam
+
+    if ($null -ne $priorRustEnvironment) {
+        Write-BuildProgress @progressParams -Status "Restoring rust environment"
+        Reset-RustEnvironment -PriorEnvironment $priorRustEnvironment @VerboseParam
+    }
+
     Write-BuildProgress -Completed
 }


### PR DESCRIPTION
# PR Summary

This change:

- Corrects the `Import-DscBuildData` function to retain the root project when refreshing the project data.
- Ensures the correct path is returned for `TgzTarget`.
- Ensures the `Build-RustProject` function selects the correct workspace member group when the user specifies an architecture.
- Ensures that `Build-DscPackage` calls `Build-DscZipPackage` with the required parameters when package type is `zip`.
- Fixes the `clean` section of the `build.ps1` script to only reset the Rust environment variables if the caching variable isn't null.

This change was tested locally to produce `.tar.gz` (WSL) and `.zip` (Windows 11) packages without errors.

## PR Context

Prior to this change, there were several issues that prevented the use of the `build.ps1` script to package builds for `zip` and `tgz`:

- The `Import-DscBuildData` function erroneously dropped the `root` project, which is used to add the `NOTICE.txt` file to the `bin` folder.
- The `Get-ArtifactDirectoryPath` failed to correctly define the `TgzTarget` property due to a mistaken key name (invalid `$` prefix).
- The `Build-RustProject` function had a bug in the implementation for specified (rather than `current`) architectures where incorrect casing caused the workspace member group to be an empty array.
- The `Build-DscPackage` function called `Build-DscTgzPackage` for the `zip` package type without passing any build parameters.
- The `clean` section of the `build.ps1` script always tried to reset the Rust environment variables, even when they hadn't been cached.
