### PR TITLE
(MAINT) Fix Rust build script for `dsc-lib-jsonschema`

### DIFF
--- a/lib/dsc-lib-jsonschema/.versions.ps1
+++ b/lib/dsc-lib-jsonschema/.versions.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
@@ -32,7 +34,12 @@ begin {
         param()
 
         process {
-            $null = git fetch --all --tags
+            $allOut = git fetch --all --tags *>&1
+
+            if ($LASTEXITCODE -ne 0) {
+                throw "Unable to fetch git tags:`n`t$($allOut -join "`n`t")"
+            }
+            
             git tag -l
             | Where-Object -FilterScript {$_ -match '^v\d+(\.\d+){2}$' }
             | ForEach-Object -Process { [semver]($_.Substring(1)) }


### PR DESCRIPTION
# PR Summary

This change makes a few changes for debugging and fixing the `build.rs` script in the `dsc-lib-jsonschema` crate for improved debugging and usage:

- Adds a shebang to `.versions.ps1` (which is called by `build.rs`) for easier interactive invocation.
- Sets the permissions for `.versions.ps1` to `755`.
- Throws an error in `.versions.ps1` when unable to fetch git tags.
- Enhances the error message for an unparseable data file to include the file text instead of simply saying it couldn't be parsed.
- Only rebuilds the version data for `debug` builds, not release.

## PR Context

Attempting to debug pipelines failure on the build script for the `dsc-lib-jsonschema` crate.