### PR TITLE
Fix order of diff for delete

### DIFF
--- a/dsc/src/resource_command.rs
+++ b/dsc/src/resource_command.rs
@@ -181,7 +181,7 @@ pub fn set(dsc: &mut DscManager, resource_type: &str, version: Option<&str>, inp
             }
         };
 
-        let diff = get_diff(&after_state, &before_state);
+        let diff = get_diff(&before_state, &after_state);
 
         let result = SetResult::Resource(ResourceSetResponse {
             before_state,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

In the PR to enable `delete` for `set` for a resource invocation, the calculated diff should be from the point of view of what it was before and what is is now instead of the reverse.