### PR TITLE
Remove unused async-stream package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,28 +115,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -740,7 +718,6 @@ dependencies = [
 name = "dsc-bicep-ext"
 version = "0.1.0"
 dependencies = [
- "async-stream",
  "clap",
  "dsc-lib",
  "prost",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -149,8 +149,6 @@ darling = { version = "0.23" }
 derive_builder = { version = "0.20" }
 # dsc, dsc-lib
 indicatif = { version = "0.18" }
-# dsc-bicep-ext
-async-stream = { version = "0.3" }
 # dsc-lib-security_context::windows
 is_elevated = { version = "0.1" }
 # dsc, dsc-lib

--- a/dsc-bicep-ext/Cargo.toml
+++ b/dsc-bicep-ext/Cargo.toml
@@ -10,7 +10,6 @@ path = "src/main.rs"
 [dependencies]
 dsc-lib = { workspace = true }
 
-async-stream = { workspace = true }
 clap = { workspace = true }
 prost = { workspace = true }
 rust-i18n = { workspace = true }


### PR DESCRIPTION
It was briefly used when attempting to wire up the named pipes on Windows, but ended up not being used and I forgot to delete it.