### PR TITLE
Fix build script to install protoc in ADO environment

### DIFF
--- a/helpers.build.psm1
+++ b/helpers.build.psm1
@@ -653,6 +653,10 @@ function Install-ProtobufRelease($arch) {
     Write-Host "Extracting protoc to $installDir..."
     Expand-Archive -Path $zipPath -DestinationPath $installDir -Force
 
+    # Clean up downloaded archive to avoid leaving temporary files behind
+    if (Test-Path $zipPath) {
+        Remove-Item -Path $zipPath -Force -ErrorAction SilentlyContinue
+    }
     $env:PATH = "$installDir" + [System.IO.Path]::DirectorySeparatorChar + "bin" + [System.IO.Path]::PathSeparator + $env:PATH
 
     Write-Host "Verifying protoc installation..."


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The Windows images used for release don't have winget so need to get the zip from GitHub and unpack and add to PATH.
The apt version of protoc is too old and doesn't work with the newer features used by the code, also install using the zip from GitHub for Linux.
