### PR TITLE
Fix build by updating apt catalog

### DIFF
--- a/helpers.build.psm1
+++ b/helpers.build.psm1
@@ -718,6 +718,7 @@ function Install-Protobuf {
                 Install-ProtobufRelease -arch $arch
             } elseif (Test-CommandAvailable -Name 'apt') {
                 Write-Verbose -Verbose "Using apt to install Protobuf"
+                sudo apt update
                 sudo apt install -y protobuf-compiler
                 Write-Verbose -Verbose (Get-Command protoc | Out-String)
                 Write-Verbose -Verbose "protoc version: $(protoc --version)"


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Build fails because `protobuf` doesn't get installed, fix is to update the apt catalog