### PR TITLE
(GH-538) Define date version

### DIFF
--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -825,6 +825,14 @@ failedToAbsolutizePath = "Failed to absolutize path '%{path}'"
 executableNotFoundInWorkingDirectory = "Executable '%{executable}' not found with working directory '%{cwd}'"
 executableNotFound = "Executable '%{executable}' not found"
 
+[types.date_version]
+invalidDay = "Day `%{day}` for month `%{month}` is invalid - the day for that month must be between `01` and `%{max_days}`."
+invalidLeapDay = "Invalid version date '%{year}-%{month}-%{day}' - the specified date is for a leap day in a year that doesn't have a leap day. Only leap years, like 2024 and 2028, have February 29th. %{year} is not a leap year."
+invalidMonth = "Month `%{month}` is invalid. Date version months must be between `01` and `12` inclusive."
+invalidYear = "Year `%{year}` is invalid. Date version years must be between `1000` and `9999` inclusive."
+notMatchPattern = "Input string '%{text}' didn't match the validating pattern '%{pattern}'"
+parseError = "Unable to parse '%{text}' as a date version: %{details}"
+
 [types.exit_codes_map]
 successText = "Success"
 failureText = "Error"

--- a/lib/dsc-lib/locales/schemas.definitions.yaml
+++ b/lib/dsc-lib/locales/schemas.definitions.yaml
@@ -1,6 +1,62 @@
 _version: 2
 schemas:
   definitions:
+    dateVersion:
+      title:
+        en-us: Date version
+      description:
+        en-us: >-
+          Defines the version for a resource as a date instead of a semantic version.
+      markdownDescription:
+        en-us: |-
+          Defines the version for a resource as a date instead of a semantic version. DSC supports
+          date versions for compatibility. Unless required for compatibility scenarios, resources
+          should use semantic versioning.
+
+          A date version is represented as one of two string forms, both conforming to ISO8601 for
+          dates:
+
+          - `YYYY-MM-DD`, like `2026-02-11` or `2027-11-01`. These date versions are defined without
+            the optional `prerelease` segment.
+          - `YYYY-MM-DD-PRE`, like `2026-02-11-preview` or `2027-11-01-rc`. These date versions are
+            defined with the optional `prerelease` segment.
+
+          A date version _must_ represent a valid date. Defining an invalid month, like `00` or `15`,
+          raises a parsing error. Defining an invalid day of the month, like `00` or `33`, raises a
+          parsing error. For February, `29` is only a valid day for leap years.
+
+          The year for a date version must not be defined with a leading zero. Defining a date with
+          a leading zero for the year, like `0123`, raises a parsing error.
+
+          If the date version is for a prerelease, the prerelease segment must be a string of ASCII
+          alphabetic characters (`[a-zA-Z]`).
+
+          The following list shows a set of input strings and whether they're valid for this pattern.
+          If the input string is invalid, the list item explains why that input is invalid.
+
+          - `2026-07-15` - valid input, defining the year as `2026`, the month as July, and the day
+            of the month as `15`.
+          - `2026-07-15-preview` - valid input, defining the year as `2026`, the month as July, the
+            day of the month as `15`, and the prerelease segment as `preview`.
+          - `2026-00-01` - invalid input. The month segment must not be defined as `00`.
+          - `2026-15-01` - invalid input. The month segment is defined as `15`, which isn't a valid
+            month.
+          - `0123-11-01` - invalid input. The year segment must not begin with a leading zero.
+          - `2026-05-00` - invalid input. The day segment must not be defined as `00`.
+          - `2026-03-38` - invalid input. The day segment must not be defined as a number greater
+            than `31`.
+          - `2026-07-15-rc.1` - invalid input. The prerelease segment must be a string consisting of
+            only ASCII alphabetic characters.
+          - `2026-02-29` - valid pattern, invalid input. While this construction is valid for the
+            regular expression, defining this value for a [`DateVersion`] fails parsing. It defines
+            the date as February 29, 2026. 2026 isn't a leap year and February 29 isn't a valid date
+            for a non-leap year.
+
+      patternErrorMessage:
+        en-us: >-
+          Invalid date version. A date version must be defined as a string containing an ISO8601
+          date, like `2026-02-12`. The version may define an optional prerelease segment, like
+          `2026-03-15-rc`.
     exitCodes:
       title:
         en-us: Exit codes

--- a/lib/dsc-lib/src/dscerror.rs
+++ b/lib/dsc-lib/src/dscerror.rs
@@ -52,6 +52,9 @@ pub enum DscError {
     #[error("{t} '{0}', {t2} {1}, {t3} {2}", t = t!("dscerror.invalidFunctionParameterCount"), t2 = t!("dscerror.expected"), t3 = t!("dscerror.got"))]
     InvalidFunctionParameterCount(String, usize, usize),
 
+    #[error("{0}")]
+    InvalidDateVersion(String),
+
     #[error("{t} '{0}': {1}", t = t!("dscerror.invalidExitCode"))]
     InvalidExitCode(String, core::num::ParseIntError),
 

--- a/lib/dsc-lib/src/types/date_version.rs
+++ b/lib/dsc-lib/src/types/date_version.rs
@@ -1,0 +1,714 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use std::{
+    fmt::Display,
+    str::FromStr,
+    sync::OnceLock,
+};
+
+use chrono::{Datelike, NaiveDate};
+use regex::Regex;
+use rust_i18n::t;
+use schemars::{JsonSchema, json_schema};
+use serde::{Deserialize, Serialize};
+
+use crate::{
+    dscerror::{DscError, DscError::InvalidDateVersion},
+    schemas::dsc_repo::DscRepoSchema,
+};
+
+/// Defines a version as an ISO8601 formatted date string for compatibility scenarios.
+///
+/// DSC supports date versions for compatibility. Unless required for compatibility scenarios,
+/// resources should use semantic versioning.
+///
+/// A date version is represented as one of two string forms, both conforming to ISO8601 for
+/// dates:
+///
+/// - `YYYY-MM-DD`, like `2026-02-11` or `2027-11-01`. These date versions are defined without
+///   the optional `prerelease` segment.
+/// - `YYYY-MM-DD-PRE`, like `2026-02-11-preview` or `2027-11-01-rc`. These date versions are
+///   defined with the optional `prerelease` segment.
+///
+/// A date version _must_ represent a valid date. Defining an invalid month, like `00` or `15`,
+/// raises a parsing error. Defining an invalid day of the month, like `00` or `33`, raises a
+/// parsing error. For February, `29` is only a valid day for leap years.
+///
+/// The year for a date version must not be defined with a leading zero. Defining a date with a
+/// leading zero for the year, like `0123`, raises a parsing error.
+///
+/// If the date version is for a prerelease, the prerelease segment must be a string of ASCII
+/// alphabetic characters (`[a-zA-Z]`).
+#[derive(Debug, Clone, Serialize, Deserialize, DscRepoSchema)]
+#[serde(try_from = "String", into = "String")]
+#[dsc_repo_schema(base_name = "dateVersion", folder_path = "definitions")]
+pub struct DateVersion(NaiveDate, Option<String>);
+
+/// This static lazily defines the validating regex for [`DateVersion`]. It enables the
+/// [`Regex`] instance to be constructed once, the first time it's used, and then reused on all
+/// subsequent validation calls. It's kept private, since the API usage is to invoke the
+/// [`DateVersion::parse()`] method to validate and parse a string into a date version.
+static VALIDATING_PATTERN_REGEX: OnceLock<Regex> = OnceLock::new();
+
+impl DateVersion {
+    /// Parses string input into a [`DateVersion`], raising an error if the input isn't a valid
+    /// string representation.
+    ///
+    /// A date version is represented as one of two string forms, both conforming to ISO8601 for
+    /// dates:
+    ///
+    /// - `YYYY-MM-DD`, like `2026-02-11` or `2027-11-01`. These date versions are defined without
+    ///   the optional `prerelease` segment.
+    /// - `YYYY-MM-DD-PRE`, like `2026-02-11-preview` or `2027-11-01-rc`. These date versions are
+    ///   defined with the optional `prerelease` segment.
+    ///
+    /// A date version _must_ represent a valid date. Defining an invalid month, like `00` or `15`,
+    /// raises a parsing error. Defining an invalid day of the month, like `00` or `33`, raises a
+    /// parsing error. For February, `29` is only a valid day for leap years.
+    ///
+    /// The year for a date version must not be defined with a leading zero. Defining a date with
+    /// a leading zero for the year, like `0123`, raises a parsing error.
+    ///
+    /// If the date version is for a prerelease, the prerelease segment must be a string of ASCII
+    /// alphabetic characters (`[a-zA-Z]`).
+    ///
+    /// A date version is parsed from an input string with the following regular expression:
+    ///
+    /// ```regex
+    /// ^(?<year>[1-9][0-9]{3})-(?<month>0[1-9]|1[0-2])-(?<day>0[1-9]|[1-2][0-9]|3[0-1])(?:-(?<prerelease>[a-zA-Z]+))?$
+    /// ```
+    ///
+    /// For more information about the pattern, see [`VALIDATING_PATTERN`].
+    ///
+    /// # Examples
+    ///
+    /// The following example shows how you can parse a date version from a string.
+    ///
+    /// ```rust
+    /// # use dsc_lib::types::DateVersion;
+    /// # use chrono::Datelike;
+    /// # use pretty_assertions::assert_eq;
+    /// let version = DateVersion::parse("2026-02-03").unwrap();
+    ///
+    /// assert_eq!(version.year(), 2026);
+    /// assert_eq!(version.month(), 2);
+    /// assert_eq!(version.day(), 3);
+    /// assert_eq!(version.prerelease(), None);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// The following list shows example inputs that raise parse errors and includes the reasons
+    /// each input fails to parse:
+    ///
+    /// - `2026-00-01` - The month segment must not be defined as `00`.
+    /// - `2026-15-01` - The month segment is defined as `15`, which isn't a valid month.
+    /// - `0123-11-01` - The year segment must not begin with a leading zero.
+    /// - `2026-05-00` - The day segment must not be defined as `00`.
+    /// - `2026-03-38` - The day segment must not be defined as a number greater than `31`.
+    /// - `2026-07-15-rc.1` - The prerelease segment must be a string consisting of only ASCII
+    ///   alphabetic characters.
+    /// - `2026-02-29` - Defines the date as February 29, 2026. 2026 isn't a leap year and
+    ///   February 29 isn't a valid date for a non-leap year.
+    ///
+    /// [`VALIDATING_PATTERN`]: DateVersion::VALIDATING_PATTERN
+    pub fn parse(text: &str) -> Result<Self, DscError> {
+        let pattern = VALIDATING_PATTERN_REGEX.get_or_init(Self::init_pattern);
+        let Some(captures) = pattern.captures(text) else {
+            return Err(InvalidDateVersion(
+                t!(
+                    "types.date_version.notMatchPattern",
+                    "text" => text,
+                    "pattern" => DateVersion::VALIDATING_PATTERN,
+                ).to_string()
+            ));
+        };
+
+        let year: i32 = captures
+            .name("year")
+            .expect("year is always defined")
+            .as_str()
+            .parse()
+            .expect("year is always a valid non-zero i32");
+
+        let month: u32 = captures
+            .name("month")
+            .expect("month is always defined")
+            .as_str()
+            .parse()
+            .expect("month is always a valid non-zero u32");
+
+        let day: u32 = captures
+            .name("day")
+            .expect("day is always defined")
+            .as_str()
+            .parse()
+            .expect("day is always a valid non-zero u32");
+
+        Self::validate_date(year, month, day, text)?;
+        let date = NaiveDate::from_ymd_opt(year, month, day)
+            .expect("date is pre-validated");
+
+        match captures.name("prerelease") {
+            None => Ok(Self(date, None)),
+            Some(prerelease_match) => Ok(Self(
+                date,
+                Some(prerelease_match.as_str().to_string())
+            )),
+        }
+    }
+
+    /// Returns the underlying [`NaiveDate`] representation for an instance of [`DateVersion`].
+    ///
+    /// # Examples
+    ///
+    /// The following snippet shows how a [`DateVersion`] without the optional `prerelease` segment
+    /// returns the underlying naive date.
+    ///
+    /// ```rust
+    /// # use chrono::{Datelike, NaiveDate};
+    /// # use dsc_lib::types::DateVersion;
+    /// # use pretty_assertions::assert_eq;
+    /// let version: DateVersion = "2026-02-01".parse().unwrap();
+    /// let expected: NaiveDate = "2026-02-01".parse().unwrap();
+    /// assert_eq!(version.as_naive_date(), expected);
+    /// ```
+    ///
+    /// The next snippet shows how the same [`DateVersion`] compares to another instance that
+    /// does define the `prerelease` segment.
+    ///
+    /// ```rust
+    /// # use chrono::{Datelike, NaiveDate};
+    /// # use dsc_lib::types::DateVersion;
+    /// # use pretty_assertions::{assert_eq, assert_ne};
+    /// let stable_version: DateVersion = "2026-02-01".parse().unwrap();
+    /// let preview_version: DateVersion = "2026-02-01-preview".parse().unwrap();
+    /// // Comparing the versions as naive dates shows they are apparently equal
+    /// assert_eq!(
+    ///     stable_version.as_naive_date(),
+    ///     preview_version.as_naive_date()
+    /// );
+    /// // Comparing the versions as date versions shows they are _not_ equal
+    /// assert_ne!(
+    ///     stable_version,
+    ///     preview_version
+    /// );
+    /// ```
+    pub fn as_naive_date(&self) -> NaiveDate {
+        self.0
+    }
+
+    /// Indicates whether the originally parsed date version defined the `prerelease` segment.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use dsc_lib::types::DateVersion;
+    /// let stable_version: DateVersion = "2026-02-01".parse().unwrap();
+    /// assert_eq!(
+    ///     stable_version.is_prerelease(),
+    ///     false
+    /// );
+    ///
+    /// let preview_version: DateVersion = "2026-02-01-preview".parse().unwrap();
+    /// assert_eq!(
+    ///     preview_version.is_prerelease(),
+    ///     true
+    /// );
+    /// ```
+    pub fn is_prerelease(&self) -> bool {
+        self.1.is_some()
+    }
+
+    /// Returns a reference to the prerelease segment string for the date version, if defined.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use dsc_lib::types::DateVersion;
+    /// let preview_version: DateVersion = "2026-02-01-preview".parse().unwrap();
+    /// assert_eq!(
+    ///     preview_version.prerelease(),
+    ///     Some(&"preview".to_string())
+    /// );
+    ///
+    /// let stable_version: DateVersion = "2026-02-01".parse().unwrap();
+    /// assert_eq!(
+    ///     stable_version.prerelease(),
+    ///     None
+    /// );
+    /// ```
+    pub fn prerelease(&self) -> Option<&String> {
+        self.1.as_ref()
+    }
+
+    /// Defines the pattern that validates the string representation of a [`DateVersion`].
+    ///
+    /// This pattern is used both to validate the string representation of a date version and to
+    /// capture segments of the string. This pattern:
+    ///
+    /// 1. Forbids leading and trailing spacing characters.
+    /// 1. Requires the first segment of the version to be a four-digit year, like `2026`. It
+    ///    forbids the year from starting with a leading zero.
+    /// 1. Requires a hyphen before the second segment. The second segment but be a two-digit
+    ///    month, like `02` or `11`. The first nine months require a leading zero. Defining the
+    ///    month as either zero or greater than twelve is invalid.
+    /// 1. Requires a hyphen before the third segment. The third segment must be a two-digit day of
+    ///    the month, like `07` or `29`. The first nine days of the month require a leading zero.
+    ///    Defining the day of the month as either zero or greater than thirty-one is invalid.
+    /// 1. Allows an optional fourth segment. If defined, the fourth segment must be preceded by
+    ///    a hyphen. The fourth segment must define a prerelease string as one or more ASCII
+    ///    alphabetic characters (`[a-zA-Z]`), like `rc` or `preview`.
+    ///
+    /// The full pattern is:
+    ///
+    /// ```regex
+    /// ^(?<year>[1-9][0-9]{3})-(?<month>0[1-9]|1[0-2])-(?<day>0[1-9]|[1-2][0-9]|3[0-1])(?:-(?<prerelease>[a-zA-Z]+))?$
+    /// ```
+    ///
+    /// The following list shows a set of input strings and whether they're valid for this pattern.
+    /// If the input string is invalid, the list item explains why that input is invalid.
+    ///
+    /// - `2026-07-15` - valid input, defining the year as `2026`, the month as July, and the day
+    ///   of the month as `15`.
+    /// - `2026-07-15-preview` - valid input, defining the year as `2026`, the month as July, the
+    ///   day of the month as `15`, and the prerelease segment as `preview`.
+    /// - `2026-00-01` - invalid input. The month segment must not be defined as `00`.
+    /// - `2026-15-01` - invalid input. The month segment is defined as `15`, which isn't a valid
+    ///   month.
+    /// - `0123-11-01` - invalid input. The year segment must not begin with a leading zero.
+    /// - `2026-05-00` - invalid input. The day segment must not be defined as `00`.
+    /// - `2026-03-38` - invalid input. The day segment must not be defined as a number greater
+    ///   than `31`.
+    /// - `2026-07-15-rc.1` - invalid input. The prerelease segment must be a string consisting of
+    ///   only ASCII alphabetic characters.
+    /// - `2026-02-29` - valid pattern, invalid input. While this construction is valid for the
+    ///   regular expression, defining this value for a [`DateVersion`] fails parsing. It defines
+    ///   the date as February 29, 2026. 2026 isn't a leap year and February 29 isn't a valid date
+    ///   for a non-leap year.
+    pub const VALIDATING_PATTERN: &str = const_str::concat!(
+        "^",                  // Anchor to start of string
+        "(?<year>",           // Open named capture group for year segment
+            "[1-9]",          //   First numeral in year must be greater than 0
+            "[0-9]{3}",       //   Remaining numerals in year can be any digit
+        ")",                  // Close named capture group
+        "-",                  // Require a hyphen before the month segment
+        "(?<month>",          // Open named capture group for month segment
+            "0[1-9]",         //   The first nine months must have a leading 0
+            "|",              //   or
+            "1[0-2]",         //   The last three months must be 10, 11, or 12
+        ")",                  // Close named capture group for month segment
+        "-",                  // Require a hyphen before the day segment
+        "(?<day>",            // Open named capture group for the day segment
+            "0[1-9]",         //   The first 9 days of a month must have a leading 0
+            "|",              //   or
+            "[1-2][0-9]",     //   The day is between 10 and 29
+            "|",              //   or
+            "3[0-1]",         //   The day is 30 or 31
+        ")",                  // Close named capture group for the day segment
+        r"(?:",               // Open non-capture group for optional prerelease substring
+            "-",              //   Require a hyphen before the segment
+            "(?<prerelease>", //   Open named capture group for the prerelease segment
+            "[a-zA-Z]+",      //   Require the segment to contain only alphabetic ASCII
+            ")",              //   Close named capture group for the prerelease segment
+        ")?",                 // Close non-capture group for optional prerelease substring
+        "$",                  // Anchor to end of string
+    );
+
+    /// Returns the [`Regex`] for [`VALIDATING_PATTERN`].
+    ///
+    /// This private method is used to initialize the [`VALIDATING_PATTERN_REGEX`] private
+    /// static to reduce the number of times the regular expression is compiled from the pattern
+    /// string.
+    ///
+    /// [`VALIDATING_PATTERN`]: Self::VALIDATING_PATTERN
+    fn init_pattern() -> Regex {
+        Regex::new(Self::VALIDATING_PATTERN).expect("pattern is valid")
+    }
+
+    /// Validates the numerically parsed values for the string representation of a [`DateVersion`].
+    ///
+    /// The [`VALIDATING_PATTERN`] alone isn't able to verify whether a given date is valid. For
+    /// example, the date string `2026-04-31` isn't valid because the maximum number of days in
+    /// April is `30`. Similarly, `2028-02-29` defines a leap day in a valid leap year, but the
+    /// date `2026-02-29` is invalid because 2026 isn't a leap year.
+    ///
+    /// This validation function enables the type to validate the input for a date version beyond
+    /// what a regular expression can quickly and performantly parse while capturing the various
+    /// segments.
+    ///
+    /// [`VALIDATING_PATTERN`]: Self::VALIDATING_PATTERN
+    fn validate_date(year: i32, month: u32, day: u32, text: &str) -> Result<(), DscError> {
+        let max_days_in_month = match month {
+            1 | 3 | 5 | 7 | 8 | 10 | 12 => 31u32,
+            4 | 6 | 9 | 11 => 30u32,
+            2 => {
+                //  Gregorian leap year rule: divisible by 4, except centuries not divisible by 400.
+                if (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0) {
+                    29u32
+                } else {
+                    28u32
+                }
+            },
+            _ => unreachable!()
+        };
+
+        let details = if year > 9999 || year < 1000 {
+            Some(t!(
+                "types.date_version.invalidYear",
+                "year" => year
+            ).to_string())
+        } else if month > 12 {
+            Some(t!(
+                "types.date_version.invalidMonth",
+                "month" => month : {:02},
+            ).to_string())
+        } else if day > max_days_in_month {
+            if month == 2 && day == 29 {
+                Some(t!(
+                    "types.date_version.invalidLeapDay",
+                    "year" => year,
+                    "month" => month : {:02},
+                    "day" => day : {:02},
+                ).to_string())
+            } else {
+                Some(t!(
+                    "types.date_version.invalidDay",
+                    "day" => day : {:02},
+                    "month" => month : {:02},
+                    "max_days" => max_days_in_month,
+                ).to_string())
+            }
+        } else {
+            None
+        };
+
+        match details {
+            None => Ok(()),
+            Some(details) => Err(InvalidDateVersion(
+                t!(
+                    "types.date_version.parseError",
+                    "text" => text,
+                    "details" => details,
+                ).to_string()
+            )),
+        }
+    }
+}
+
+impl JsonSchema for DateVersion {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        Self::default_schema_id_uri().into()
+    }
+    fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        json_schema!({
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$id": Self::default_schema_id_uri(),
+            "title": t!("schemas.definitions.dateVersion.title"),
+            "description": t!("schemas.definitions.dateVersion.description"),
+            "markdownDescription": t!("schemas.definitions.dateVersion.markdownDescription"),
+            "type": "string",
+            "pattern": Self::VALIDATING_PATTERN,
+            "patternErrorMessage": t!("schemas.definitions.dateVersion.patternErrorMessage"),
+        })
+    }
+}
+
+impl Datelike for DateVersion {
+    fn day(&self) -> u32 {
+        self.as_ref().day()
+    }
+    fn day0(&self) -> u32 {
+        self.as_ref().day0()
+    }
+    fn year(&self) -> i32 {
+        self.as_ref().year()
+    }
+    fn month(&self) -> u32 {
+        self.as_ref().month()
+    }
+    fn month0(&self) -> u32 {
+        self.as_ref().month0()
+    }
+    fn ordinal(&self) -> u32 {
+        self.as_ref().ordinal()
+    }
+    fn ordinal0(&self) -> u32 {
+        self.as_ref().ordinal0()
+    }
+    fn weekday(&self) -> chrono::Weekday {
+        self.as_ref().weekday()
+    }
+    fn iso_week(&self) -> chrono::IsoWeek {
+        self.as_ref().iso_week()
+    }
+    fn with_year(&self, year: i32) -> Option<Self> {
+        match self.as_ref().with_year(year) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+    fn with_month(&self, month: u32) -> Option<Self> {
+        match self.as_ref().with_month(month) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+    fn with_month0(&self, month0: u32) -> Option<Self> {
+        match self.as_ref().with_month0(month0) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+    fn with_day(&self, day: u32) -> Option<Self> {
+        match self.as_ref().with_day(day) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+    fn with_day0(&self, day0: u32) -> Option<Self> {
+        match self.as_ref().with_day0(day0) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+    fn with_ordinal(&self, ordinal: u32) -> Option<Self> {
+        match self.as_ref().with_ordinal(ordinal) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+    fn with_ordinal0(&self, ordinal0: u32) -> Option<Self> {
+        match self.as_ref().with_ordinal0(ordinal0) {
+            None => None,
+            Some(new_date) => Some(Self(new_date, self.1.clone()))
+        }
+    }
+}
+
+impl Display for DateVersion {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(prerelease) = &self.1 {
+            write!(f, "{}-{}", self.0.format("%Y-%m-%d"), prerelease)
+        } else {
+            write!(f, "{}", self.0.format("%Y-%m-%d"))
+        }
+    }
+}
+
+// Reference a date version as a naive date
+impl AsRef<NaiveDate> for DateVersion {
+    fn as_ref(&self) -> &NaiveDate {
+        &self.0
+    }
+}
+
+impl FromStr for DateVersion {
+    type Err = DscError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl TryFrom<&str> for DateVersion {
+    type Error = DscError;
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        Self::parse(value)
+    }
+}
+
+impl TryFrom<String> for DateVersion {
+    type Error = DscError;
+    fn try_from(value: String) -> Result<Self, Self::Error> {
+        Self::parse(value.as_str())
+    }
+}
+
+impl From<DateVersion> for String {
+    fn from(value: DateVersion) -> Self {
+        value.to_string()
+    }
+}
+
+impl TryFrom<NaiveDate> for DateVersion {
+    type Error = DscError;
+    fn try_from(value: NaiveDate) -> Result<Self, Self::Error> {
+        Self::validate_date(value.year(), value.month(), value.day(), value.to_string().as_str())?;
+
+        Ok(Self(value, None))
+    }
+}
+
+impl From<DateVersion> for NaiveDate {
+    fn from(value: DateVersion) -> Self {
+        value.0
+    }
+}
+
+impl Eq for DateVersion {}
+
+impl PartialEq for DateVersion {
+    fn eq(&self, other: &Self) -> bool {
+        let self_is_prerelease = self.is_prerelease();
+        let other_is_prerelease = other.is_prerelease();
+        let both_are_prerelease = self_is_prerelease && other_is_prerelease;
+        let neither_are_prerelease = !self_is_prerelease && !other_is_prerelease;
+
+        if both_are_prerelease {
+            self.0.eq(&other.0) && self.1.eq(&other.1)
+        } else if neither_are_prerelease {
+            self.0.eq(&other.0)
+        } else {
+            false
+        }
+    }
+}
+
+impl PartialEq<NaiveDate> for DateVersion {
+    fn eq(&self, other: &NaiveDate) -> bool {
+        self.0.eq(other)
+    }
+}
+
+impl PartialEq<DateVersion> for NaiveDate {
+    fn eq(&self, other: &DateVersion) -> bool {
+        self.eq(&other.0)
+    }
+}
+
+impl PartialEq<String> for DateVersion {
+    fn eq(&self, other: &String) -> bool {
+        match Self::parse(other.as_str()) {
+            Ok(other_version) => self.eq(&other_version),
+            Err(_) => false,
+        }
+    }
+}
+
+impl PartialEq<DateVersion> for String {
+    fn eq(&self, other: &DateVersion) -> bool {
+        match DateVersion::parse(self.as_str()) {
+            Ok(version) => version.eq(other),
+            Err(_) => false
+        }
+    }
+}
+
+impl PartialEq<str> for DateVersion {
+    fn eq(&self, other: &str) -> bool {
+        match Self::parse(other) {
+            Ok(other_version) => self.eq(&other_version),
+            Err(_) => false,
+        }
+    }
+}
+
+impl PartialEq<DateVersion> for str {
+    fn eq(&self, other: &DateVersion) -> bool {
+        match DateVersion::parse(self) {
+            Ok(version) => version.eq(other),
+            Err(_) => false
+        }
+    }
+}
+
+impl PartialEq<&str> for DateVersion {
+    fn eq(&self, other: &&str) -> bool {
+        match Self::parse(*other) {
+            Ok(other_version) => self.eq(&other_version),
+            Err(_) => false,
+        }
+    }
+}
+
+impl PartialEq<DateVersion> for &str {
+    fn eq(&self, other: &DateVersion) -> bool {
+        match DateVersion::parse(*self) {
+            Ok(version) => version.eq(other),
+            Err(_) => false
+        }
+    }
+}
+
+impl Ord for DateVersion {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        let self_is_prerelease = self.is_prerelease();
+        let other_is_prerelease = other.is_prerelease();
+        let both_are_prerelease = self_is_prerelease && other_is_prerelease;
+
+        if self.0 == other.0 {
+            if both_are_prerelease {
+                self.1.as_ref().cmp(&other.1.as_ref())
+            } else if self_is_prerelease {
+                std::cmp::Ordering::Less
+            } else if other_is_prerelease {
+                std::cmp::Ordering::Greater
+            } else {
+                std::cmp::Ordering::Equal
+            }
+        } else {
+            self.0.cmp(&other.0)
+        }
+    }
+}
+
+impl PartialOrd for DateVersion {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialOrd<NaiveDate> for DateVersion {
+    fn partial_cmp(&self, other: &NaiveDate) -> Option<std::cmp::Ordering> {
+        match Self::try_from(*other) {
+            Ok(_) => self.0.partial_cmp(other),
+            Err(_) => None,
+        }
+    }
+}
+
+impl PartialOrd<DateVersion> for NaiveDate {
+    fn partial_cmp(&self, other: &DateVersion) -> Option<std::cmp::Ordering> {
+        match DateVersion::try_from(*self) {
+            Ok(_) => self.partial_cmp(&other.0),
+            Err(_) => None,
+        }
+    }
+}
+
+impl PartialOrd<String> for DateVersion {
+    fn partial_cmp(&self, other: &String) -> Option<std::cmp::Ordering> {
+        match Self::parse(other.as_str()) {
+            Ok(other_version) => self.partial_cmp(&other_version),
+            Err(_) => None,
+        }
+    }
+}
+
+impl PartialOrd<DateVersion> for String {
+    fn partial_cmp(&self, other: &DateVersion) -> Option<std::cmp::Ordering> {
+        match DateVersion::parse(self.as_str()) {
+            Ok(version) => version.partial_cmp(other),
+            Err(_) => None,
+        }
+    }
+}
+
+impl PartialOrd<str> for DateVersion {
+    fn partial_cmp(&self, other: &str) -> Option<std::cmp::Ordering> {
+        match Self::parse(other) {
+            Ok(other_version) => self.partial_cmp(&other_version),
+            Err(_) => None,
+        }
+    }
+}
+
+impl PartialOrd<DateVersion> for str {
+    fn partial_cmp(&self, other: &DateVersion) -> Option<std::cmp::Ordering> {
+        match DateVersion::parse(self) {
+            Ok(version) => version.partial_cmp(other),
+            Err(_) => None,
+        }
+    }
+}

--- a/lib/dsc-lib/src/types/mod.rs
+++ b/lib/dsc-lib/src/types/mod.rs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+mod date_version;
+pub use date_version::DateVersion;
 mod exit_code;
 pub use exit_code::ExitCode;
 mod exit_codes_map;

--- a/lib/dsc-lib/tests/integration/types/date_version.rs
+++ b/lib/dsc-lib/tests/integration/types/date_version.rs
@@ -1,0 +1,701 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod methods {
+    use chrono::NaiveDate;
+    use dsc_lib::{dscerror::DscError, types::DateVersion};
+    use test_case::test_case;
+
+    #[test_case("2026-02-28" => matches Ok(_); "ISO8601 date is valid")]
+    #[test_case("2026-02-28-rc" => matches Ok(_); "ISO8601 date with prerelease is valid")]
+    #[test_case("2028-02-29" => matches Ok(_); "leap day in leap year is valid")]
+    #[test_case("2026-02-29" => matches Err(_); "leap day in non leap year is invalid")]
+    #[test_case("123-02-03" => matches Err(_); "year with less than four digits is invalid")]
+    #[test_case("1234-2-03" => matches Err(_); "month with less than two digits is invalid")]
+    #[test_case("1234-02-3" => matches Err(_); "day with less than two digits is invalid")]
+    #[test_case("0123-02-03" => matches Err(_); "year with leading zero is invalid")]
+    #[test_case("1234-2-03" => matches Err(_); "month without leading zero is invalid")]
+    #[test_case("1234-02-3" => matches Err(_); "day without leading zero is invalid")]
+    #[test_case("1234-00-03" => matches Err(_); "zero month is invalid")]
+    #[test_case("1234-02-00" => matches Err(_); "zero day is invalid")]
+    #[test_case("1234-14-21" => matches Err(_); "impossible month is invalid")]
+    #[test_case("1234-01-32" => matches Err(_); "impossible january date is invalid")]
+    #[test_case("1234-02-30" => matches Err(_); "impossible february date is invalid")]
+    #[test_case("1234-03-32" => matches Err(_); "impossible march date is invalid")]
+    #[test_case("1234-04-31" => matches Err(_); "impossible april date is invalid")]
+    #[test_case("1234-05-32" => matches Err(_); "impossible may date is invalid")]
+    #[test_case("1234-06-31" => matches Err(_); "impossible june date is invalid")]
+    #[test_case("1234-07-32" => matches Err(_); "impossible july date is invalid")]
+    #[test_case("1234-08-32" => matches Err(_); "impossible august date is invalid")]
+    #[test_case("1234-09-31" => matches Err(_); "impossible september date is invalid")]
+    #[test_case("1234-10-32" => matches Err(_); "impossible october date is invalid")]
+    #[test_case("1234-11-31" => matches Err(_); "impossible november date is invalid")]
+    #[test_case("1234-12-32" => matches Err(_); "impossible december date is invalid")]
+    #[test_case("2026-02-28-rc.1" => matches Err(_); "prerelease with non-ASCII alphabetic characters is invalid")]
+    fn parse(text: &str) -> Result<DateVersion, DscError> {
+        DateVersion::parse(text)
+    }
+
+    #[test_case("2026-02-03", "2026-02-03"; "version without prerelease returns same naive date")]
+    #[test_case("2026-02-03-rc", "2026-02-03"; "version with prerelease returns same naive date")]
+    fn as_naive_date(date_version_text: &str, expected_naive_date_text: &str) {
+        let version: DateVersion = date_version_text.parse().unwrap();
+        let expected: NaiveDate = expected_naive_date_text.parse().unwrap();
+
+        pretty_assertions::assert_eq!(version.as_naive_date(), expected);
+    }
+
+    #[test_case("2026-02-03" => false; "version without prerelease segment")]
+    #[test_case("2026-02-03-rc" => true; "version with prerelease segment")]
+    fn is_prerelease(text: &str) -> bool {
+        DateVersion::parse(text).unwrap().is_prerelease()
+    }
+
+    #[test_case("2026-02-03", None; "version without prerelease segment")]
+    #[test_case("2026-02-03-rc", Some(&"rc".to_string()); "version with prerelease segment")]
+    fn prerelease_segment(text: &str, expected: Option<&String>) {
+        pretty_assertions::assert_eq!(
+            DateVersion::parse(text).unwrap().prerelease(),
+            expected
+        );
+    }
+}
+
+#[cfg(test)]
+mod schema {
+    use std::sync::LazyLock;
+
+    use dsc_lib::types::DateVersion;
+    use dsc_lib_jsonschema::schema_utility_extensions::SchemaUtilityExtensions;
+    use jsonschema::Validator;
+    use regex::Regex;
+    use schemars::{schema_for, Schema};
+    use serde_json::{json, Value};
+    use test_case::test_case;
+
+    static SCHEMA: LazyLock<Schema> = LazyLock::new(|| schema_for!(DateVersion));
+    static VALIDATOR: LazyLock<Validator> =
+        LazyLock::new(|| Validator::new((&*SCHEMA).as_value()).unwrap());
+    static KEYWORD_PATTERN: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"^\w+(\.\w+)+$").expect("pattern is valid"));
+
+    #[test_case("title")]
+    #[test_case("description")]
+    #[test_case("markdownDescription")]
+    #[test_case("patternErrorMessage")]
+    fn has_documentation_keyword(keyword: &str) {
+        let schema = &*SCHEMA;
+        let value = schema
+            .get_keyword_as_str(keyword)
+            .expect(format!("expected keyword '{keyword}' to be defined").as_str());
+
+        assert!(
+            !(&*KEYWORD_PATTERN).is_match(value),
+            "Expected keyword '{keyword}' to be defined in translation, but was set to i18n key '{value}'"
+        );
+    }
+
+    #[test_case(&json!("2026-02-28") => matches true; "string value as ISO8601 date is valid")]
+    #[test_case(&json!("2026-02-28-rc") => matches true; "string value as ISO8601 date with prerelease is valid")]
+    #[test_case(&json!("2028-02-29") => matches true; "string value with leap day in leap year is valid")]
+    #[test_case(&json!("2026-02-29") => matches true; "string value with leap day in non leap year is apparently valid")]
+    #[test_case(&json!("123-02-03") => matches false; "string value with year with less than four digits is invalid")]
+    #[test_case(&json!("1234-2-03") => matches false; "string value with month with less than two digits is invalid")]
+    #[test_case(&json!("1234-02-3") => matches false; "string value with day with less than two digits is invalid")]
+    #[test_case(&json!("0123-02-03") => matches false; "string value with year with leading zero is invalid")]
+    #[test_case(&json!("1234-2-03") => matches false; "string value with month without leading zero is invalid")]
+    #[test_case(&json!("1234-02-3") => matches false; "string value with day without leading zero is invalid")]
+    #[test_case(&json!("1234-00-03") => matches false; "string value with zero month is invalid")]
+    #[test_case(&json!("1234-02-00") => matches false; "string value with zero day is invalid")]
+    #[test_case(&json!("1234-14-21") => matches false; "string value with impossible month is invalid")]
+    #[test_case(&json!("1234-01-32") => matches false; "string value with impossible january date is invalid")]
+    #[test_case(&json!("1234-02-30") => matches true; "string value with impossible february date is apparently valid")]
+    #[test_case(&json!("1234-03-32") => matches false; "string value with impossible march date is invalid")]
+    #[test_case(&json!("1234-04-31") => matches true; "string value with impossible april date is apparently valid")]
+    #[test_case(&json!("1234-05-32") => matches false; "string value with impossible may date is invalid")]
+    #[test_case(&json!("1234-06-31") => matches true; "string value with impossible june date is apparently valid")]
+    #[test_case(&json!("1234-07-32") => matches false; "string value with impossible july date is invalid")]
+    #[test_case(&json!("1234-08-32") => matches false; "string value with impossible august date is invalid")]
+    #[test_case(&json!("1234-09-31") => matches true; "string value with impossible september date is apparently valid")]
+    #[test_case(&json!("1234-10-32") => matches false; "string value with impossible october date is invalid")]
+    #[test_case(&json!("1234-11-31") => matches true; "string value with impossible november date is apparently valid")]
+    #[test_case(&json!("1234-12-32") => matches false; "string value with impossible december date is invalid")]
+    #[test_case(&json!("2026-02-28-rc.1") => matches false; "prerelease with non-ASCII alphabetic characters is invalid")]
+    #[test_case(&json!(true) => false; "boolean value is invalid")]
+    #[test_case(&json!(1) => false; "integer value is invalid")]
+    #[test_case(&json!(1.2) => false; "float value is invalid")]
+    #[test_case(&json!({"req": "1.2.3"}) => false; "object value is invalid")]
+    #[test_case(&json!(["1.2.3"]) => false; "array value is invalid")]
+    #[test_case(&serde_json::Value::Null => false; "null value is invalid")]
+    fn validation(input_json: &Value) -> bool {
+        (&*VALIDATOR).validate(input_json).is_ok()
+    }
+}
+
+#[cfg(test)]
+mod serde {
+    use dsc_lib::types::DateVersion;
+    use serde_json::{json, Value};
+    use test_case::test_case;
+
+    #[test_case("2026-02-03", json!("2026-02-03"))]
+    #[test_case("2026-02-03-rc", json!("2026-02-03-rc"))]
+    fn serializing(version: &str, expected: Value) {
+        let actual = serde_json::to_value(
+            &DateVersion::parse(version).expect("parse should never fail"),
+        )
+        .expect("serialization should never fail");
+
+        pretty_assertions::assert_eq!(actual, expected);
+    }
+
+    #[test_case(json!("2026-02-28") => matches Ok(_); "string value as ISO8601 date is valid")]
+    #[test_case(json!("2026-02-28-rc") => matches Ok(_); "string value as ISO8601 date with prerelease is valid")]
+    #[test_case(json!("2028-02-29") => matches Ok(_); "string value with leap day in leap year is valid")]
+    #[test_case(json!("2026-02-29") => matches Err(_); "string value with leap day in non leap year is invalid")]
+    #[test_case(json!("123-02-03") => matches Err(_); "string value with year with less than four digits is invalid")]
+    #[test_case(json!("1234-2-03") => matches Err(_); "string value with month with less than two digits is invalid")]
+    #[test_case(json!("1234-02-3") => matches Err(_); "string value with day with less than two digits is invalid")]
+    #[test_case(json!("0123-02-03") => matches Err(_); "string value with year with leading zero is invalid")]
+    #[test_case(json!("1234-2-03") => matches Err(_); "string value with month without leading zero is invalid")]
+    #[test_case(json!("1234-02-3") => matches Err(_); "string value with day without leading zero is invalid")]
+    #[test_case(json!("1234-00-03") => matches Err(_); "string value with zero month is invalid")]
+    #[test_case(json!("1234-02-00") => matches Err(_); "string value with zero day is invalid")]
+    #[test_case(json!("1234-14-21") => matches Err(_); "string value with impossible month is invalid")]
+    #[test_case(json!("1234-01-32") => matches Err(_); "string value with impossible january date is invalid")]
+    #[test_case(json!("1234-02-30") => matches Err(_); "string value with impossible february date is invalid")]
+    #[test_case(json!("1234-03-32") => matches Err(_); "string value with impossible march date is invalid")]
+    #[test_case(json!("1234-04-31") => matches Err(_); "string value with impossible april date is invalid")]
+    #[test_case(json!("1234-05-32") => matches Err(_); "string value with impossible may date is invalid")]
+    #[test_case(json!("1234-06-31") => matches Err(_); "string value with impossible june date is invalid")]
+    #[test_case(json!("1234-07-32") => matches Err(_); "string value with impossible july date is invalid")]
+    #[test_case(json!("1234-08-32") => matches Err(_); "string value with impossible august date is invalid")]
+    #[test_case(json!("1234-09-31") => matches Err(_); "string value with impossible september date is invalid")]
+    #[test_case(json!("1234-10-32") => matches Err(_); "string value with impossible october date is invalid")]
+    #[test_case(json!("1234-11-31") => matches Err(_); "string value with impossible november date is invalid")]
+    #[test_case(json!("1234-12-32") => matches Err(_); "string value with impossible december date is invalid")]
+    #[test_case(json!("2026-02-28-rc.1") => matches Err(_); "prerelease with non-ASCII alphabetic characters is invalid")]
+    #[test_case(json!(true) => matches Err(_); "boolean value is invalid")]
+    #[test_case(json!(1) => matches Err(_); "integer value is invalid")]
+    #[test_case(json!(1.2) => matches Err(_); "float value is invalid")]
+    #[test_case(json!({"req": "1.2.3"}) => matches Err(_); "object value is invalid")]
+    #[test_case(json!(["1.2.3"]) => matches Err(_); "array value is invalid")]
+    #[test_case(serde_json::Value::Null => matches Err(_); "null value is invalid")]
+    fn deserializing(value: Value) -> Result<DateVersion, serde_json::Error> {
+        serde_json::from_value::<DateVersion>(value)
+    }
+}
+
+#[cfg(test)]
+mod traits {
+    #[cfg(test)]
+    mod date_like {
+        use chrono::{Datelike, NaiveDate};
+        use dsc_lib::types::DateVersion;
+        use test_case::test_case;
+
+        #[test_case("2026-02-03" => 3; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 3; "date version with prerelease")]
+        fn day(version: &str) -> u32 {
+            DateVersion::parse(version).unwrap().day()
+        }
+
+        #[test_case("2026-02-03" => 2; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 2; "date version with prerelease")]
+        fn day0(version: &str) -> u32 {
+            DateVersion::parse(version).unwrap().day0()
+        }
+
+        #[test_case("2026-02-03" => 2026; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 2026; "date version with prerelease")]
+        fn year(version: &str) -> i32 {
+            DateVersion::parse(version).unwrap().year()
+        }
+
+        #[test_case("2026-02-03" => 2; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 2; "date version with prerelease")]
+        fn month(version: &str) -> u32 {
+            DateVersion::parse(version).unwrap().month()
+        }
+
+        #[test_case("2026-02-03" => 1; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 1; "date version with prerelease")]
+        fn month0(version: &str) -> u32 {
+            DateVersion::parse(version).unwrap().month0()
+        }
+
+        #[test_case("2026-02-03" => 34; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 34; "date version with prerelease")]
+        fn ordinal(version: &str) -> u32 {
+            DateVersion::parse(version).unwrap().ordinal()
+        }
+
+        #[test_case("2026-02-03" => 33; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => 33; "date version with prerelease")]
+        fn ordinal0(version: &str) -> u32 {
+            DateVersion::parse(version).unwrap().ordinal0()
+        }
+
+        #[test_case("2026-02-03" => chrono::Weekday::Tue; "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => chrono::Weekday::Tue; "date version with prerelease")]
+        fn weekday(version: &str) -> chrono::Weekday {
+            DateVersion::parse(version).unwrap().weekday()
+        }
+
+        #[test_case("2026-02-03" => NaiveDate::from_ymd_opt(2026, 2, 3).unwrap().iso_week(); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => NaiveDate::from_ymd_opt(2026, 2, 3).unwrap().iso_week(); "date version with prerelease")]
+        fn iso_week(version: &str) -> chrono::IsoWeek {
+            DateVersion::parse(version).unwrap().iso_week()
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2028-02-03").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2028-02-03-rc").unwrap()); "date version with prerelease")]
+        fn with_year(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_year(2028)
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2026-01-03").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2026-01-03-rc").unwrap()); "date version with prerelease")]
+        fn with_month(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_month(1)
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2026-04-03").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2026-04-03-rc").unwrap()); "date version with prerelease")]
+        fn with_month0(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_month0(3)
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2026-02-01").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2026-02-01-rc").unwrap()); "date version with prerelease")]
+        fn with_day(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_day(1)
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2026-02-04").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2026-02-04-rc").unwrap()); "date version with prerelease")]
+        fn with_day0(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_day0(3)
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2026-02-11").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2026-02-11-rc").unwrap()); "date version with prerelease")]
+        fn with_ordinal(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_ordinal(42)
+        }
+
+        #[test_case("2026-02-03" => Some(DateVersion::parse("2026-02-14").unwrap()); "date version without prerelease")]
+        #[test_case("2026-02-03-rc" => Some(DateVersion::parse("2026-02-14-rc").unwrap()); "date version with prerelease")]
+        fn with_ordinal0(version: &str) -> Option<DateVersion> {
+            DateVersion::parse(version).unwrap().with_ordinal0(44)
+        }
+    }
+
+    #[cfg(test)]
+    mod display {
+        use dsc_lib::types::DateVersion;
+        use test_case::test_case;
+
+        #[test_case("2026-02-03", "2026-02-03"; "date version without prerelease")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc"; "date version with prerelease")]
+        fn format(version: &str, expected: &str) {
+            pretty_assertions::assert_eq!(
+                format!("version: '{}'", DateVersion::parse(version).unwrap()),
+                format!("version: '{}'", expected)
+            )
+        }
+
+        #[test_case("2026-02-03", "2026-02-03"; "date version without prerelease")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc"; "date version with prerelease")]
+        fn to_string(version: &str, expected: &str) {
+            pretty_assertions::assert_eq!(
+                DateVersion::parse(version).unwrap().to_string(),
+                expected.to_string()
+            )
+        }
+    }
+
+    #[cfg(test)]
+    mod from_str {
+        use std::str::FromStr;
+
+        use dsc_lib::{dscerror::DscError, types::DateVersion};
+        use test_case::test_case;
+
+        #[test_case("2026-02-28" => matches Ok(_); "ISO8601 date is valid")]
+        #[test_case("2026-02-28-rc" => matches Ok(_); "ISO8601 date with prerelease is valid")]
+        #[test_case("2028-02-29" => matches Ok(_); "leap day in leap year is valid")]
+        #[test_case("2026-02-29" => matches Err(_); "leap day in non leap year is invalid")]
+        #[test_case("123-02-03" => matches Err(_); "year with less than four digits is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month with less than two digits is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day with less than two digits is invalid")]
+        #[test_case("0123-02-03" => matches Err(_); "year with leading zero is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month without leading zero is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day without leading zero is invalid")]
+        #[test_case("1234-00-03" => matches Err(_); "zero month is invalid")]
+        #[test_case("1234-02-00" => matches Err(_); "zero day is invalid")]
+        #[test_case("1234-14-21" => matches Err(_); "impossible month is invalid")]
+        #[test_case("1234-01-32" => matches Err(_); "impossible january date is invalid")]
+        #[test_case("1234-02-30" => matches Err(_); "impossible february date is invalid")]
+        #[test_case("1234-03-32" => matches Err(_); "impossible march date is invalid")]
+        #[test_case("1234-04-31" => matches Err(_); "impossible april date is invalid")]
+        #[test_case("1234-05-32" => matches Err(_); "impossible may date is invalid")]
+        #[test_case("1234-06-31" => matches Err(_); "impossible june date is invalid")]
+        #[test_case("1234-07-32" => matches Err(_); "impossible july date is invalid")]
+        #[test_case("1234-08-32" => matches Err(_); "impossible august date is invalid")]
+        #[test_case("1234-09-31" => matches Err(_); "impossible september date is invalid")]
+        #[test_case("1234-10-32" => matches Err(_); "impossible october date is invalid")]
+        #[test_case("1234-11-31" => matches Err(_); "impossible november date is invalid")]
+        #[test_case("1234-12-32" => matches Err(_); "impossible december date is invalid")]
+        #[test_case("2026-02-28-rc.1" => matches Err(_); "prerelease with non-ASCII alphabetic characters is invalid")]
+        fn from_str(text: &str) -> Result<DateVersion, DscError> {
+            DateVersion::from_str(text)
+        }
+
+        #[test_case("2026-02-28" => matches Ok(_); "ISO8601 date is valid")]
+        #[test_case("2026-02-28-rc" => matches Ok(_); "ISO8601 date with prerelease is valid")]
+        #[test_case("2028-02-29" => matches Ok(_); "leap day in leap year is valid")]
+        #[test_case("2026-02-29" => matches Err(_); "leap day in non leap year is invalid")]
+        #[test_case("123-02-03" => matches Err(_); "year with less than four digits is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month with less than two digits is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day with less than two digits is invalid")]
+        #[test_case("0123-02-03" => matches Err(_); "year with leading zero is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month without leading zero is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day without leading zero is invalid")]
+        #[test_case("1234-00-03" => matches Err(_); "zero month is invalid")]
+        #[test_case("1234-02-00" => matches Err(_); "zero day is invalid")]
+        #[test_case("1234-14-21" => matches Err(_); "impossible month is invalid")]
+        #[test_case("1234-01-32" => matches Err(_); "impossible january date is invalid")]
+        #[test_case("1234-02-30" => matches Err(_); "impossible february date is invalid")]
+        #[test_case("1234-03-32" => matches Err(_); "impossible march date is invalid")]
+        #[test_case("1234-04-31" => matches Err(_); "impossible april date is invalid")]
+        #[test_case("1234-05-32" => matches Err(_); "impossible may date is invalid")]
+        #[test_case("1234-06-31" => matches Err(_); "impossible june date is invalid")]
+        #[test_case("1234-07-32" => matches Err(_); "impossible july date is invalid")]
+        #[test_case("1234-08-32" => matches Err(_); "impossible august date is invalid")]
+        #[test_case("1234-09-31" => matches Err(_); "impossible september date is invalid")]
+        #[test_case("1234-10-32" => matches Err(_); "impossible october date is invalid")]
+        #[test_case("1234-11-31" => matches Err(_); "impossible november date is invalid")]
+        #[test_case("1234-12-32" => matches Err(_); "impossible december date is invalid")]
+        #[test_case("2026-02-28-rc.1" => matches Err(_); "prerelease with non-ASCII alphabetic characters is invalid")]
+        fn parse(text: &str) -> Result<DateVersion, DscError> {
+            text.parse()
+        }
+    }
+
+    #[cfg(test)]
+    mod try_from {
+        use chrono::NaiveDate;
+        use dsc_lib::{dscerror::DscError, types::DateVersion};
+        use test_case::test_case;
+
+        #[test_case("2026-02-03".parse().unwrap() => matches Ok(_); "date with year greater than 999 is valid")]
+        #[test_case("0999-02-03".parse().unwrap() => matches Err(_); "date with year less than 1000 is invalid")]
+        fn naive_date(date: NaiveDate) -> Result<DateVersion, DscError> {
+            DateVersion::try_from(date)
+        }
+
+        #[test_case("2026-02-28" => matches Ok(_); "ISO8601 date is valid")]
+        #[test_case("2026-02-28-rc" => matches Ok(_); "ISO8601 date with prerelease is valid")]
+        #[test_case("2028-02-29" => matches Ok(_); "leap day in leap year is valid")]
+        #[test_case("2026-02-29" => matches Err(_); "leap day in non leap year is invalid")]
+        #[test_case("123-02-03" => matches Err(_); "year with less than four digits is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month with less than two digits is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day with less than two digits is invalid")]
+        #[test_case("0123-02-03" => matches Err(_); "year with leading zero is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month without leading zero is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day without leading zero is invalid")]
+        #[test_case("1234-00-03" => matches Err(_); "zero month is invalid")]
+        #[test_case("1234-02-00" => matches Err(_); "zero day is invalid")]
+        #[test_case("1234-14-21" => matches Err(_); "impossible month is invalid")]
+        #[test_case("1234-01-32" => matches Err(_); "impossible january date is invalid")]
+        #[test_case("1234-02-30" => matches Err(_); "impossible february date is invalid")]
+        #[test_case("1234-03-32" => matches Err(_); "impossible march date is invalid")]
+        #[test_case("1234-04-31" => matches Err(_); "impossible april date is invalid")]
+        #[test_case("1234-05-32" => matches Err(_); "impossible may date is invalid")]
+        #[test_case("1234-06-31" => matches Err(_); "impossible june date is invalid")]
+        #[test_case("1234-07-32" => matches Err(_); "impossible july date is invalid")]
+        #[test_case("1234-08-32" => matches Err(_); "impossible august date is invalid")]
+        #[test_case("1234-09-31" => matches Err(_); "impossible september date is invalid")]
+        #[test_case("1234-10-32" => matches Err(_); "impossible october date is invalid")]
+        #[test_case("1234-11-31" => matches Err(_); "impossible november date is invalid")]
+        #[test_case("1234-12-32" => matches Err(_); "impossible december date is invalid")]
+        #[test_case("2026-02-28-rc.1" => matches Err(_); "prerelease with non-ASCII alphabetic characters is invalid")]
+        fn string(text: &str) -> Result<DateVersion, DscError> {
+            DateVersion::try_from(text.to_string())
+        }
+
+        #[test_case("2026-02-28" => matches Ok(_); "ISO8601 date is valid")]
+        #[test_case("2026-02-28-rc" => matches Ok(_); "ISO8601 date with prerelease is valid")]
+        #[test_case("2028-02-29" => matches Ok(_); "leap day in leap year is valid")]
+        #[test_case("2026-02-29" => matches Err(_); "leap day in non leap year is invalid")]
+        #[test_case("123-02-03" => matches Err(_); "year with less than four digits is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month with less than two digits is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day with less than two digits is invalid")]
+        #[test_case("0123-02-03" => matches Err(_); "year with leading zero is invalid")]
+        #[test_case("1234-2-03" => matches Err(_); "month without leading zero is invalid")]
+        #[test_case("1234-02-3" => matches Err(_); "day without leading zero is invalid")]
+        #[test_case("1234-00-03" => matches Err(_); "zero month is invalid")]
+        #[test_case("1234-02-00" => matches Err(_); "zero day is invalid")]
+        #[test_case("1234-14-21" => matches Err(_); "impossible month is invalid")]
+        #[test_case("1234-01-32" => matches Err(_); "impossible january date is invalid")]
+        #[test_case("1234-02-30" => matches Err(_); "impossible february date is invalid")]
+        #[test_case("1234-03-32" => matches Err(_); "impossible march date is invalid")]
+        #[test_case("1234-04-31" => matches Err(_); "impossible april date is invalid")]
+        #[test_case("1234-05-32" => matches Err(_); "impossible may date is invalid")]
+        #[test_case("1234-06-31" => matches Err(_); "impossible june date is invalid")]
+        #[test_case("1234-07-32" => matches Err(_); "impossible july date is invalid")]
+        #[test_case("1234-08-32" => matches Err(_); "impossible august date is invalid")]
+        #[test_case("1234-09-31" => matches Err(_); "impossible september date is invalid")]
+        #[test_case("1234-10-32" => matches Err(_); "impossible october date is invalid")]
+        #[test_case("1234-11-31" => matches Err(_); "impossible november date is invalid")]
+        #[test_case("1234-12-32" => matches Err(_); "impossible december date is invalid")]
+        #[test_case("2026-02-28-rc.1" => matches Err(_); "prerelease with non-ASCII alphabetic characters is invalid")]
+        fn str(text: &str) -> Result<DateVersion, DscError> {
+            DateVersion::try_from(text)
+        }
+    }
+
+    #[cfg(test)]
+    mod into {
+        use chrono::NaiveDate;
+        use dsc_lib::types::DateVersion;
+        use test_case::test_case;
+
+        #[test_case("2026-02-03", "2026-02-03".parse().unwrap(); "date version without prerelease")]
+        #[test_case("2026-02-03-rc", "2026-02-03".parse().unwrap(); "date version with prerelease")]
+        fn naive_date(version: &str, expected: NaiveDate) {
+            let actual: NaiveDate = DateVersion::parse(version).unwrap().into();
+
+            pretty_assertions::assert_eq!(
+                actual,
+                expected
+            )
+        }
+
+        #[test_case("2026-02-03", "2026-02-03".to_string(); "date version without prerelease")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc".to_string(); "date version with prerelease")]
+        fn string(version: &str, expected: String) {
+            let actual: String = DateVersion::parse(version).unwrap().into();
+
+            pretty_assertions::assert_eq!(
+                actual,
+                expected
+            )
+        }
+    }
+
+    #[cfg(test)]
+    mod partial_eq {
+        use dsc_lib::types::DateVersion;
+        use test_case::test_case;
+
+        #[test_case("2026-02-03", "2026-02-03", true; "identical date versions without prerelease")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc", true; "identical date versions with prerelease")]
+        #[test_case("2026-02-03", "2026-02-13", false; "date versions with different days")]
+        #[test_case("2026-02-03", "2026-12-03", false; "date versions with different months")]
+        #[test_case("2026-02-03", "2027-02-03", false; "date versions with different years")]
+        #[test_case("2026-02-03-alpha", "2026-02-03-beta", false; "date versions with different prerelease segments")]
+        fn date_version(lhs: &str, rhs: &str, should_be_equal: bool) {
+            if should_be_equal {
+                pretty_assertions::assert_eq!(
+                    DateVersion::parse(lhs).unwrap(),
+                    DateVersion::parse(rhs).unwrap()
+                )
+            } else {
+                pretty_assertions::assert_ne!(
+                    DateVersion::parse(lhs).unwrap(),
+                    DateVersion::parse(rhs).unwrap()
+                )
+            }
+        }
+
+        #[test_case("2026-02-03", "2026-02-03", true; "date version without prerelease and identical string")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc", true; "date version with prerelease and identical string")]
+        #[test_case("2026-02-03", "2026-02-13", false; "date version and string with different days")]
+        #[test_case("2026-02-03", "2026-12-03", false; "date version and string with different months")]
+        #[test_case("2026-02-03", "2027-02-03", false; "date version and string with different years")]
+        #[test_case("2026-02-03-alpha", "2026-02-03-beta", false; "date version and string with different prerelease segments")]
+        #[test_case("2026-02-03", "2026.02.03", false; "date version and non-parseable string")]
+        fn string(date_version_string: &str, string_slice: &str, should_be_equal: bool) {
+            let date_version = DateVersion::parse(date_version_string).unwrap();
+            let string = string_slice.to_string();
+
+            // Test equivalency bidirectionally
+            pretty_assertions::assert_eq!(
+                date_version == string,
+                should_be_equal,
+                "expected comparison of {date_version} and {string} to be {should_be_equal}"
+            );
+
+            pretty_assertions::assert_eq!(
+                string == date_version,
+                should_be_equal,
+                "expected comparison of {string} and {date_version} to be {should_be_equal}"
+            );
+        }
+
+        #[test_case("2026-02-03", "2026-02-03", true; "date version without prerelease and identical string slice")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc", true; "date version with prerelease and identical string slice")]
+        #[test_case("2026-02-03", "2026-02-13", false; "date version and string slice with different days")]
+        #[test_case("2026-02-03", "2026-12-03", false; "date version and string slice with different months")]
+        #[test_case("2026-02-03", "2027-02-03", false; "date version and string slice with different years")]
+        #[test_case("2026-02-03-alpha", "2026-02-03-beta", false; "date version and string slice with different prerelease segments")]
+        #[test_case("2026-02-03", "2026.02.03", false; "date version and non-parseable string slice")]
+        fn str(date_version_string: &str, string_slice: &str, should_be_equal: bool) {
+            let date_version = DateVersion::parse(date_version_string).unwrap();
+
+            // Test equivalency bidirectionally
+            pretty_assertions::assert_eq!(
+                date_version == string_slice,
+                should_be_equal,
+                "expected comparison of {date_version} and {string_slice} to be {should_be_equal}"
+            );
+
+            pretty_assertions::assert_eq!(
+                string_slice == date_version,
+                should_be_equal,
+                "expected comparison of {string_slice} and {date_version} to be {should_be_equal}"
+            );
+        }
+    }
+
+    #[cfg(test)]
+    mod ord {
+        use std::cmp::Ordering;
+
+        use dsc_lib::types::DateVersion;
+        use test_case::test_case;
+
+        #[test_case("2026-02-03", "2026-02-03", Ordering::Equal; "equal stable versions")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc", Ordering::Equal; "equal prerelease versions")]
+        #[test_case("2026-02-04", "2026-02-03", Ordering::Greater; "newer stable is greater than older stable")]
+        #[test_case("2026-02-03", "2026-02-04", Ordering::Less; "older stable is less than newer stable")]
+        #[test_case("2026-02-03", "2026-02-03-rc", Ordering::Greater; "stable is greater than prerelease")]
+        #[test_case("2026-02-03-alpha", "2026-02-03-beta", Ordering::Less; "prerelease sorts lexicographically")]
+        #[test_case("2026-02-03-PREVIEW", "2026-02-03-preview", Ordering::Less; "prerelease uppercase is less than lowercase")]
+        fn date_version(lhs: &str, rhs: &str, expected_order: Ordering) {
+            pretty_assertions::assert_eq!(
+                DateVersion::parse(lhs)
+                    .expect("parsing for lhs should not fail")
+                    .partial_cmp(&DateVersion::parse(rhs).expect("parsing for rhs should not fail"))
+                    .expect("comparison should always be an ordering"),
+                expected_order,
+                "expected '{lhs}' compared to '{rhs}' to be {expected_order:#?}"
+            )
+        }
+    }
+
+    #[cfg(test)]
+    mod partial_ord {
+        use std::cmp::Ordering;
+
+        use chrono::NaiveDate;
+        use dsc_lib::types::DateVersion;
+        use test_case::test_case;
+
+        #[test_case("2026-02-03", "2026-02-03", Some(Ordering::Equal); "equal stable version and date")]
+        #[test_case("2026-02-03-rc", "2026-02-03", Some(Ordering::Equal); "prerelease versions and same date")]
+        #[test_case("2026-02-04", "2026-02-03", Some(Ordering::Greater); "newer version is greater than older date")]
+        #[test_case("2026-02-03", "2026-02-04", Some(Ordering::Less); "older version is less than newer date")]
+        #[test_case("2026-02-03", "0999-02-03", None; "version and invalid date are not comparable")]
+        fn naive_date(version_string: &str, date_string: &str, expected_order: Option<Ordering>) {
+            let version: DateVersion = version_string.parse().unwrap();
+            let date: NaiveDate = date_string.parse().unwrap();
+
+            // Test comparison bidirectionally
+            pretty_assertions::assert_eq!(
+                version.partial_cmp(&date),
+                expected_order,
+                "expected comparison of {version} and {date} to be #{expected_order:#?}"
+            );
+
+            let expected_inverted_order = match expected_order {
+                None => None,
+                Some(o) => match o {
+                    Ordering::Equal => Some(Ordering::Equal),
+                    Ordering::Greater => Some(Ordering::Less),
+                    Ordering::Less => Some(Ordering::Greater),
+                },
+            };
+
+            pretty_assertions::assert_eq!(
+                date.partial_cmp(&version),
+                expected_inverted_order,
+                "expected comparison of {date} and {version} to be #{expected_inverted_order:#?}"
+            );
+        }
+
+        #[test_case("2026-02-03", "2026-02-03", Some(Ordering::Equal); "equal stable version and date")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc", Some(Ordering::Equal); "prerelease version and same string")]
+        #[test_case("2026-02-04", "2026-02-03", Some(Ordering::Greater); "newer version is greater than older string")]
+        #[test_case("2026-02-03", "2026-02-04", Some(Ordering::Less); "older version is less than newer string")]
+        #[test_case("2026-02-03", "0999-02-03", None; "version and invalid string are not comparable")]
+        fn string(
+            version_string: &str,
+            string_slice: &str,
+            expected_order: Option<Ordering>,
+        ) {
+            let version: DateVersion = version_string.parse().unwrap();
+            let string = string_slice.to_string();
+
+            // Test comparison bidirectionally
+            pretty_assertions::assert_eq!(
+                version.partial_cmp(&string),
+                expected_order,
+                "expected comparison of {version} and {string} to be #{expected_order:#?}"
+            );
+
+            let expected_inverted_order = match expected_order {
+                None => None,
+                Some(o) => match o {
+                    Ordering::Equal => Some(Ordering::Equal),
+                    Ordering::Greater => Some(Ordering::Less),
+                    Ordering::Less => Some(Ordering::Greater),
+                },
+            };
+
+            pretty_assertions::assert_eq!(
+                string.partial_cmp(&version),
+                expected_inverted_order,
+                "expected comparison of {string} and {version} to be #{expected_inverted_order:#?}"
+            );
+        }
+
+        #[test_case("2026-02-03", "2026-02-03", Some(Ordering::Equal); "equal stable version and date")]
+        #[test_case("2026-02-03-rc", "2026-02-03-rc", Some(Ordering::Equal); "prerelease version and same string")]
+        #[test_case("2026-02-04", "2026-02-03", Some(Ordering::Greater); "newer version is greater than older string")]
+        #[test_case("2026-02-03", "2026-02-04", Some(Ordering::Less); "older version is less than newer string")]
+        #[test_case("2026-02-03", "0999-02-03", None; "version and invalid string are not comparable")]
+        fn str(
+            version_string: &str,
+            string_slice: &str,
+            expected_order: Option<Ordering>,
+        ) {
+            let version: DateVersion = version_string.parse().unwrap();
+
+            // Test comparison bidirectionally
+            pretty_assertions::assert_eq!(
+                version.partial_cmp(string_slice),
+                expected_order,
+                "expected comparison of {version} and {string_slice} to be #{expected_order:#?}"
+            );
+
+            let expected_inverted_order = match expected_order {
+                None => None,
+                Some(o) => match o {
+                    Ordering::Equal => Some(Ordering::Equal),
+                    Ordering::Greater => Some(Ordering::Less),
+                    Ordering::Less => Some(Ordering::Greater),
+                },
+            };
+
+            pretty_assertions::assert_eq!(
+                string_slice.partial_cmp(&version),
+                expected_inverted_order,
+                "expected comparison of {string_slice} and {version} to be #{expected_inverted_order:#?}"
+            );
+        }
+    }
+}

--- a/lib/dsc-lib/tests/integration/types/mod.rs
+++ b/lib/dsc-lib/tests/integration/types/mod.rs
@@ -2,6 +2,8 @@
 // Licensed under the MIT License.
 
 #[cfg(test)]
+mod date_version;
+#[cfg(test)]
 mod exit_code;
 #[cfg(test)]
 mod exit_code_map;


### PR DESCRIPTION
# PR Summary

This change defines the `DateVersion` type to replace the arbitrary string version. It adheres to the practices for `apiVersion` definitions in ARM templates by:

- Serializing to/from a string
- Defining the version as an ISO8601 date with an optional prerelease segment.

While the _validating schema_ for `apiVersion` only checks that the value is a string, in practice every resource type defines `apiVersion` as an ISO8601 date. Some of them define a fourth segment to indicate a prerelease version, like `2026-02-03-preview`. The prerelease segment for every currently available resource type are defined with only upper and lowercase ASCII alphabetics.

This implementation:

- Parses a string containing an ISO8601 date and optional prerelease segment.
- Uses a regular expression for initial validation and extracting the date components.
- Forbids leading and trailing spaces for the string.
- Forbids the year for the date from starting with zero.
- Forbids invalid dates, like a leap day on a non-leap year.
- Implements the `Datelike` trait from the `chrono` crate, simplifying the extraction of date components like `version.month()`.
- Implements ordering and equivalency traits.

This change doesn't update the implementation for `ResourceVersion` to replace the arbitrary string version. This will need to be addressed in a future change.

## PR Context

Prior to this change, DSC allowed resources to define their version as either a semantic version or an arbitrary string. The WG decided to more formally define the compatibility version for a resource to suit the compatibility usage.
