### PR TITLE
Add deprecation message to use of `copy`

### DIFF
--- a/dsc/tests/dsc_copy.tests.ps1
+++ b/dsc/tests/dsc_copy.tests.ps1
@@ -458,6 +458,6 @@ resources:
         $out.results.Count | Should -Be 1
         $out.results[0].name | Should -Be 'Test-0'
         $out.results[0].result.actualState.output | Should -Be 'Hello'
-        (Get-Content $testdrive/error.log -Raw) | Should -Match "Copy for resource 'testLoop' is deprecated and will be removed in a future release. See https://github.com/PowerShell/DSC/issues/1429 for more details."
+        (Get-Content $testdrive/error.log -Raw) | Should -BeLike "*WARN*Copy for loop 'testLoop' is deprecated and will be removed in a future release. See https://github.com/PowerShell/DSC/issues/1429 for more details.*"
     }
 }

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -94,7 +94,7 @@ metadataRefreshEnvFound = "Resource returned '_refreshEnv' which indicates envir
 metadataRefreshEnvOnlyAffectsSet = "Resource returned '_refreshEnv' which indicates environment variable refresh is needed but current operation is '%{operation}' which is not 'set', so ignoring"
 metadataRefreshEnvNoOperationContext = "Resource returned '_refreshEnv' which indicates environment variable refresh is needed but no operation context is available"
 metadataRefreshEnvNoContext = "Resource returned '_refreshEnv' which indicates environment variable refresh is needed but no context is available"
-copyDeprecated = "Copy for resource '%{name}' is deprecated and will be removed in a future release. See https://github.com/PowerShell/DSC/issues/1429 for more details."
+copyDeprecated = "Copy for loop '%{name}' is deprecated and will be removed in a future release. See https://github.com/PowerShell/DSC/issues/1429 for more details."
 
 [configure.parameters]
 importingParametersFromComplexInput = "Importing parameters from complex input"

--- a/lib/dsc-lib/src/configure/depends_on.rs
+++ b/lib/dsc-lib/src/configure/depends_on.rs
@@ -10,7 +10,7 @@ use crate::types::FullyQualifiedTypeName;
 use rust_i18n::t;
 use serde_json::{Map, Value};
 use super::context::Context;
-use tracing::debug;
+use tracing::{debug, warn};
 
 /// Gets the invocation order of resources based on their dependencies
 ///
@@ -141,6 +141,7 @@ fn unroll_and_push(order: &mut Vec<Resource>, resource: &Resource, parser: &mut 
   // if the resource contains `Copy`, unroll it
   if let Some(copy) = &resource.copy {
       debug!("{}", t!("configure.mod.unrollingCopy", name = &copy.name, count = copy.count));
+      warn!("{}", t!("configure.mod.copyDeprecated", name = &copy.name));
       context.process_mode = ProcessMode::Copy;
       context.copy_current_loop_name.clone_from(&copy.name);
       let mut copy_resources = Vec::<Resource>::new();
@@ -214,7 +215,7 @@ fn unroll_and_push(order: &mut Vec<Resource>, resource: &Resource, parser: &mut 
                   other: Map::new(),
               }
           });
-          
+
           let mut microsoft = metadata.microsoft.clone().unwrap_or_default();
           let mut copy_loops = microsoft.copy_loops.clone().unwrap_or_default();
           copy_loops.insert(copy.name.clone(), Value::Number(i.into()));

--- a/lib/dsc-lib/src/configure/mod.rs
+++ b/lib/dsc-lib/src/configure/mod.rs
@@ -1195,7 +1195,6 @@ impl Configurator {
                 // defer actual unrolling until parameters are available
                 if let Some(copy) = &resource.copy {
                     debug!("{}", t!("configure.mod.validateCopy", name = &copy.name, count = copy.count));
-                    warn!("{}", t!("configure.mod.copyDeprecated", name = &copy.name));
                     if copy.mode.is_some() {
                         return Err(DscError::Validation(t!("configure.mod.copyModeNotSupported").to_string()));
                     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

As discussed in WG, mark `copy` as deprecated

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1429
