### PR TITLE
Fix tree-sitter not found after cargo install

### DIFF
--- a/helpers.build.psm1
+++ b/helpers.build.psm1
@@ -500,6 +500,19 @@ function Install-TreeSitter {
         if ($LASTEXITCODE -ne 0) {
             throw "Failed to install tree-sitter-cli"
         }
+
+        # Ensure cargo bin directory is in PATH so tree-sitter can be found
+        if (!$IsWindows) {
+            $cargoBin = "$env:HOME/.cargo/bin"
+            if ($env:PATH -notlike "*$cargoBin*") {
+                $env:PATH += ":$cargoBin"
+            }
+        } else {
+            $cargoBin = "$env:USERPROFILE\.cargo\bin"
+            if ($env:PATH -notlike "*$cargoBin*") {
+                $env:PATH += ";$cargoBin"
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- `Install-TreeSitter` does not add `~/.cargo/bin` to `$env:PATH` after `cargo install`, unlike `Install-Rust` which does.
- When Rust is already present (so `Install-Rust` is a no-op) and `~/.cargo/bin` is not in the inherited PATH, the `tree-sitter` binary cannot be found by `Export-GrammarBinding`.
- Adds the same PATH update logic that `Install-Rust` already uses.

### Repro

Build from Linux where `~/.cargo/bin` is not in the shell's default PATH. The build fails with:

```
Invoke-Expression: The term 'tree-sitter' is not recognized as a name of a cmdlet,
function, script file, or executable program.
```

### Fix

```powershell
# Ensure cargo bin directory is in PATH so tree-sitter can be found
if (!$IsWindows) {
    $cargoBin = "$env:HOME/.cargo/bin"
    if ($env:PATH -notlike "*$cargoBin*") {
        $env:PATH += ":$cargoBin"
    }
} else {
    $cargoBin = "$env:USERPROFILE\.cargo\bin"
    if ($env:PATH -notlike "*$cargoBin*") {
        $env:PATH += ";$cargoBin"
    }
}
```

Contact: johan.kallio@teamtech.se for questions.