### PR TITLE
Flush traces before `dsc` exits

### DIFF
--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -10,6 +10,7 @@ use rust_i18n::{i18n, t};
 use std::{io, process::exit};
 use sysinfo::{Process, RefreshKind, System, get_current_pid, ProcessRefreshKind};
 use tracing::{error, info, warn, debug};
+use util::flush_and_shutdown_tracing;
 
 use crate::util::{EXIT_INVALID_INPUT, get_input};
 
@@ -68,6 +69,7 @@ fn main() {
                         Ok(merged) => Some(merged),
                         Err(err) => {
                             error!("{}: {err}", t!("main.failedMergingParameters"));
+                            flush_and_shutdown_tracing();
                             exit(EXIT_INVALID_INPUT);
                         }
                     }
@@ -88,8 +90,10 @@ fn main() {
         SubCommand::Mcp => {
             if let Err(err) = start_mcp_server() {
                 error!("{}", t!("main.failedToStartMcpServer", error = err));
+                flush_and_shutdown_tracing();
                 exit(util::EXIT_MCP_FAILED);
             }
+            flush_and_shutdown_tracing();
             exit(util::EXIT_SUCCESS);
         }
         SubCommand::Resource { subcommand } => {
@@ -101,6 +105,7 @@ fn main() {
                 Ok(json) => json,
                 Err(err) => {
                     error!("JSON: {err}");
+                    flush_and_shutdown_tracing();
                     exit(util::EXIT_JSON_ERROR);
                 }
             };
@@ -108,6 +113,7 @@ fn main() {
         },
     }
 
+    flush_and_shutdown_tracing();
     exit(util::EXIT_SUCCESS);
 }
 
@@ -119,15 +125,18 @@ fn ctrlc_handler() {
     info!("{}: {}", t!("main.foundProcesses"), sys.processes().len());
     let Ok(current_pid) = get_current_pid() else {
         error!("{}", t!("main.failedToGetPid"));
+        flush_and_shutdown_tracing();
         exit(util::EXIT_CTRL_C);
     };
     info!("{}: {}", t!("main.currentPid"), current_pid);
     let Some(current_process) = sys.process(current_pid) else {
         error!("{}", t!("main.failedToGetProcess"));
+        flush_and_shutdown_tracing();
         exit(util::EXIT_CTRL_C);
     };
 
     terminate_subprocesses(&sys, current_process);
+    flush_and_shutdown_tracing();
     exit(util::EXIT_CTRL_C);
 }
 
@@ -192,6 +201,7 @@ fn check_store() {
         eprintln!("{}", t!("main.storeMessage"));
         // wait for keypress
         let _ = io::stdin().read(&mut [0u8]).unwrap();
+        flush_and_shutdown_tracing();
         exit(util::EXIT_INVALID_ARGS);
     }
 }

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -11,7 +11,7 @@ use std::io;
 use sysinfo::{Process, RefreshKind, System, get_current_pid, ProcessRefreshKind};
 use tracing::{error, info, warn, debug};
 
-use crate::util::{enable_tracing, exit, EXIT_INVALID_INPUT, EXIT_INVALID_ARGS, get_input, get_schema, merge_parameters, write_object};
+use crate::util::{enable_tracing, exit, EXIT_CTRL_C, EXIT_INVALID_INPUT, EXIT_JSON_ERROR, EXIT_MCP_FAILED, EXIT_SUCCESS, get_input, get_schema, merge_parameters, write_object};
 
 #[cfg(debug_assertions)]
 use crossterm::event;

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -7,10 +7,10 @@ use clap_complete::generate;
 use dsc_lib::progress::ProgressFormat;
 use mcp::start_mcp_server;
 use rust_i18n::{i18n, t};
-use std::{io, process::exit};
+use std::io;
 use sysinfo::{Process, RefreshKind, System, get_current_pid, ProcessRefreshKind};
 use tracing::{error, info, warn, debug};
-use util::flush_and_shutdown_tracing;
+use util::exit;
 
 use crate::util::{EXIT_INVALID_INPUT, get_input};
 
@@ -69,7 +69,6 @@ fn main() {
                         Ok(merged) => Some(merged),
                         Err(err) => {
                             error!("{}: {err}", t!("main.failedMergingParameters"));
-                            flush_and_shutdown_tracing();
                             exit(EXIT_INVALID_INPUT);
                         }
                     }
@@ -90,10 +89,8 @@ fn main() {
         SubCommand::Mcp => {
             if let Err(err) = start_mcp_server() {
                 error!("{}", t!("main.failedToStartMcpServer", error = err));
-                flush_and_shutdown_tracing();
                 exit(util::EXIT_MCP_FAILED);
             }
-            flush_and_shutdown_tracing();
             exit(util::EXIT_SUCCESS);
         }
         SubCommand::Resource { subcommand } => {
@@ -105,7 +102,6 @@ fn main() {
                 Ok(json) => json,
                 Err(err) => {
                     error!("JSON: {err}");
-                    flush_and_shutdown_tracing();
                     exit(util::EXIT_JSON_ERROR);
                 }
             };
@@ -113,7 +109,6 @@ fn main() {
         },
     }
 
-    flush_and_shutdown_tracing();
     exit(util::EXIT_SUCCESS);
 }
 
@@ -125,18 +120,15 @@ fn ctrlc_handler() {
     info!("{}: {}", t!("main.foundProcesses"), sys.processes().len());
     let Ok(current_pid) = get_current_pid() else {
         error!("{}", t!("main.failedToGetPid"));
-        flush_and_shutdown_tracing();
         exit(util::EXIT_CTRL_C);
     };
     info!("{}: {}", t!("main.currentPid"), current_pid);
     let Some(current_process) = sys.process(current_pid) else {
         error!("{}", t!("main.failedToGetProcess"));
-        flush_and_shutdown_tracing();
         exit(util::EXIT_CTRL_C);
     };
 
     terminate_subprocesses(&sys, current_process);
-    flush_and_shutdown_tracing();
     exit(util::EXIT_CTRL_C);
 }
 
@@ -201,7 +193,6 @@ fn check_store() {
         eprintln!("{}", t!("main.storeMessage"));
         // wait for keypress
         let _ = io::stdin().read(&mut [0u8]).unwrap();
-        flush_and_shutdown_tracing();
         exit(util::EXIT_INVALID_ARGS);
     }
 }

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -169,6 +169,7 @@ fn check_debug() {
 #[cfg(windows)]
 fn check_store() {
     use std::io::Read;
+    use util::EXIT_INVALID_ARGS;
 
     let sys = System::new_with_specifics(RefreshKind::nothing().with_processes(ProcessRefreshKind::everything()));
     // get current process

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -10,9 +10,8 @@ use rust_i18n::{i18n, t};
 use std::io;
 use sysinfo::{Process, RefreshKind, System, get_current_pid, ProcessRefreshKind};
 use tracing::{error, info, warn, debug};
-use util::exit;
 
-use crate::util::{EXIT_INVALID_INPUT, get_input};
+use crate::util::{enable_tracing, exit, EXIT_INVALID_INPUT, EXIT_INVALID_ARGS, get_input, get_schema, merge_parameters, write_object};
 
 #[cfg(debug_assertions)]
 use crossterm::event;
@@ -42,7 +41,7 @@ fn main() {
 
     let args = Args::parse();
 
-    util::enable_tracing(args.trace_level.as_ref(), args.trace_format.as_ref());
+    enable_tracing(args.trace_level.as_ref(), args.trace_format.as_ref());
 
     debug!("{}: {}", t!("main.usingDscVersion"), env!("CARGO_PKG_VERSION"));
 
@@ -65,7 +64,7 @@ fn main() {
             let merged_parameters = match (file_params, parameters) {
                 (Some(file_content), Some(inline_content)) => {
                     info!("{}", t!("main.mergingParameters"));
-                    match util::merge_parameters(&file_content, &inline_content) {
+                    match merge_parameters(&file_content, &inline_content) {
                         Ok(merged) => Some(merged),
                         Err(err) => {
                             error!("{}: {err}", t!("main.failedMergingParameters"));
@@ -89,27 +88,27 @@ fn main() {
         SubCommand::Mcp => {
             if let Err(err) = start_mcp_server() {
                 error!("{}", t!("main.failedToStartMcpServer", error = err));
-                exit(util::EXIT_MCP_FAILED);
+                exit(EXIT_MCP_FAILED);
             }
-            exit(util::EXIT_SUCCESS);
+            exit(EXIT_SUCCESS);
         }
         SubCommand::Resource { subcommand } => {
             subcommand::resource(&subcommand, progress_format);
         },
         SubCommand::Schema { dsc_type , output_format } => {
-            let schema = util::get_schema(dsc_type);
+            let schema = get_schema(dsc_type);
             let json = match serde_json::to_string(&schema) {
                 Ok(json) => json,
                 Err(err) => {
                     error!("JSON: {err}");
-                    exit(util::EXIT_JSON_ERROR);
+                    exit(EXIT_JSON_ERROR);
                 }
             };
-            util::write_object(&json, output_format.as_ref(), false);
+            write_object(&json, output_format.as_ref(), false);
         },
     }
 
-    exit(util::EXIT_SUCCESS);
+    exit(EXIT_SUCCESS);
 }
 
 fn ctrlc_handler() {
@@ -120,16 +119,16 @@ fn ctrlc_handler() {
     info!("{}: {}", t!("main.foundProcesses"), sys.processes().len());
     let Ok(current_pid) = get_current_pid() else {
         error!("{}", t!("main.failedToGetPid"));
-        exit(util::EXIT_CTRL_C);
+        exit(EXIT_CTRL_C);
     };
     info!("{}: {}", t!("main.currentPid"), current_pid);
     let Some(current_process) = sys.process(current_pid) else {
         error!("{}", t!("main.failedToGetProcess"));
-        exit(util::EXIT_CTRL_C);
+        exit(EXIT_CTRL_C);
     };
 
     terminate_subprocesses(&sys, current_process);
-    exit(util::EXIT_CTRL_C);
+    exit(EXIT_CTRL_C);
 }
 
 fn terminate_subprocesses(sys: &System, process: &Process) {
@@ -193,6 +192,6 @@ fn check_store() {
         eprintln!("{}", t!("main.storeMessage"));
         // wait for keypress
         let _ = io::stdin().read(&mut [0u8]).unwrap();
-        exit(util::EXIT_INVALID_ARGS);
+        exit(EXIT_INVALID_ARGS);
     }
 }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -53,6 +53,7 @@ use std::env;
 use std::io::{IsTerminal, Read, stdout, Write};
 use std::path::Path;
 use std::process::exit;
+use std::sync::Once;
 use syntect::{
     easy::HighlightLines,
     highlighting::ThemeSet,
@@ -689,4 +690,24 @@ pub fn merge_parameters(file_params: &str, inline_params: &str) -> Result<String
 
     let merged = Value::Object(file_map);
     Ok(serde_json::to_string(&merged)?)
+}
+
+static FLUSH_ONCE: Once = Once::new();
+
+/// Flush and shutdown tracing to ensure all traces are written before exit.
+/// This function ensures that any pending trace writes are completed and
+/// background writer threads have time to finish their work.
+pub fn flush_and_shutdown_tracing() {
+    FLUSH_ONCE.call_once(|| {
+        // Force any pending writes to complete
+        if let Err(e) = std::io::stderr().flush() {
+            eprintln!("Failed to flush stderr: {}", e);
+        }
+        if let Err(e) = std::io::stdout().flush() {
+            eprintln!("Failed to flush stdout: {}", e);
+        }
+
+        // Small delay to ensure async writes complete
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    });
 }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -52,8 +52,6 @@ use std::collections::HashMap;
 use std::env;
 use std::io::{IsTerminal, Read, stdout, Write};
 use std::path::Path;
-use std::process::exit;
-use std::sync::Once;
 use syntect::{
     easy::HighlightLines,
     highlighting::ThemeSet,
@@ -692,22 +690,17 @@ pub fn merge_parameters(file_params: &str, inline_params: &str) -> Result<String
     Ok(serde_json::to_string(&merged)?)
 }
 
-static FLUSH_ONCE: Once = Once::new();
+/// Exit the process with the given code after flushing and shutting down tracing.
+pub fn exit(code: i32) -> ! {
+    // Force any pending writes to complete
+    if let Err(e) = std::io::stderr().flush() {
+        eprintln!("Failed to flush stderr: {}", e);
+    }
+    if let Err(e) = std::io::stdout().flush() {
+        eprintln!("Failed to flush stdout: {}", e);
+    }
 
-/// Flush and shutdown tracing to ensure all traces are written before exit.
-/// This function ensures that any pending trace writes are completed and
-/// background writer threads have time to finish their work.
-pub fn flush_and_shutdown_tracing() {
-    FLUSH_ONCE.call_once(|| {
-        // Force any pending writes to complete
-        if let Err(e) = std::io::stderr().flush() {
-            eprintln!("Failed to flush stderr: {}", e);
-        }
-        if let Err(e) = std::io::stdout().flush() {
-            eprintln!("Failed to flush stdout: {}", e);
-        }
-
-        // Small delay to ensure async writes complete
-        std::thread::sleep(std::time::Duration::from_millis(50));
-    });
+    // Small delay to ensure async writes complete
+    std::thread::sleep(std::time::Duration::from_millis(50));
+    std::process::exit(code);
 }

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -697,6 +697,7 @@ pub fn merge_parameters(file_params: &str, inline_params: &str) -> Result<String
 /// * `code` - The exit code to use when exiting the process
 pub fn exit(code: i32) -> ! {
     // Small delay to ensure async writes complete
+    // Due to use of indicatif for progress bars, we can't use the tracing crate guard until indicatif adds its own guard
     std::thread::sleep(std::time::Duration::from_millis(50));
 
     // Force any pending writes to complete

--- a/dsc/src/util.rs
+++ b/dsc/src/util.rs
@@ -690,17 +690,28 @@ pub fn merge_parameters(file_params: &str, inline_params: &str) -> Result<String
     Ok(serde_json::to_string(&merged)?)
 }
 
-/// Exit the process with the given code after flushing and shutting down tracing.
+/// Exit the process with the given code after flushing outputs
+///
+/// # Arguments
+///
+/// * `code` - The exit code to use when exiting the process
 pub fn exit(code: i32) -> ! {
-    // Force any pending writes to complete
-    if let Err(e) = std::io::stderr().flush() {
-        eprintln!("Failed to flush stderr: {}", e);
-    }
-    if let Err(e) = std::io::stdout().flush() {
-        eprintln!("Failed to flush stdout: {}", e);
-    }
-
     // Small delay to ensure async writes complete
     std::thread::sleep(std::time::Duration::from_millis(50));
+
+    // Force any pending writes to complete
+    if let Err(e) = std::io::stderr().flush() {
+        // Ignore BrokenPipe on stderr to avoid noisy exits in piped scenarios
+        if e.kind() != std::io::ErrorKind::BrokenPipe {
+            eprintln!("Failed to flush stderr: {}", e);
+        }
+    }
+    if let Err(e) = std::io::stdout().flush() {
+        // Ignore BrokenPipe on stdout to avoid noisy exits in piped scenarios
+        if e.kind() != std::io::ErrorKind::BrokenPipe {
+            eprintln!("Failed to flush stdout: {}", e);
+        }
+    }
+
     std::process::exit(code);
 }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There's a race condition where a trace may be received before it is written.  This shows up in tracing tests which fail intermittently due to the expected trace not showing up.

Fix is to ensure that stderr and stdout is flushed and give async threads time before `dsc` process exits by having custom `exit()` function that drops the tracing guard which flushes and then also flush stdout/stderr.

Some syntax changes to be consistent removing the crate name with `use` statements.