### PR TITLE
Fix not failing discovery when finding unsupported manifests

### DIFF
--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -364,7 +364,7 @@ Describe 'tests for resource discovery' {
             $LASTEXITCODE | Should -Be 0
             $out | Should -BeNullOrEmpty -Because (Get-Content -Raw -Path "$testdrive/error.txt")
             $errorLog = Get-Content -Raw -Path "$testdrive/error.txt"
-            $errorLog | Should -Match "INFO Failed to load manifest '.*test.dsc.resource.json':" -Because $errorLog
+            $errorLog | Should -BeLike "*INFO Failed to load manifest: Invalid manifest for resource '*test.dsc.resource.json'*" -Because $errorLog
         } finally {
             $env:DSC_RESOURCE_PATH = $null
         }

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -199,7 +199,7 @@ Describe 'Discover extension tests' {
             foreach ($resource in $out) {
                 $resource.type | Should -Not -Be 'Test/InvalidManifest'
             }
-            (Get-Content -Path "$TestDrive/error.log" -Raw) | Should -BeLike "*Extension 'Test/DiscoverInvalid' failed to load manifest '*invalidManifest.dsc.resource.json':*" -Because (Get-Content -Path "$TestDrive/error.log" -Raw | Out-String)
+            (Get-Content -Path "$TestDrive/error.log" -Raw) | Should -BeLike "*INFO Extension 'Test/DiscoverInvalid' failed to load manifest: Invalid manifest for resource '*invalidManifest.dsc.resource.json'*" -Because (Get-Content -Path "$TestDrive/error.log" -Raw | Out-String)
         } finally {
             $env:DSC_RESOURCE_PATH = $null
             $env:TestDrive = $null

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -140,7 +140,7 @@ conditionNotBoolean = "Condition '%{condition}' did not evaluate to a boolean"
 conditionNotMet = "Condition '%{condition}' not met, skipping manifest at '%{path}' for resource '%{resource}'"
 adaptedResourcePathNotFound = "Adapted resource '%{resource}' path not found: %{path}"
 invalidManifestFileName = "Invalid manifest file name '%{path}'"
-failedLoadManifest = "Failed to load manifest '%{path}': %{err}"
+failedLoadManifest = "Failed to load manifest: %{err}"
 
 [dscresources.commandResource]
 invokeGet = "Invoking get for '%{resource}'"
@@ -253,7 +253,7 @@ importNoResults = "Extension '%{extension}' returned no results for import"
 secretMultipleLinesReturned = "Extension '%{extension}' returned multiple lines which is not supported for secrets"
 importProcessingOutput = "Processing output from extension '%{extension}'"
 deprecationMessage = "Extension '%{extension}' is deprecated: %{message}"
-failedLoadManifest = "Extension '%{extension}' failed to load manifest '%{path}': %{err}"
+failedLoadManifest = "Extension '%{extension}' failed to load manifest: %{err}"
 
 [extensions.extension_manifest]
 extensionManifestSchemaTitle = "Extension manifest schema URI"

--- a/lib/dsc-lib/src/discovery/command_discovery.rs
+++ b/lib/dsc-lib/src/discovery/command_discovery.rs
@@ -278,7 +278,7 @@ impl ResourceDiscovery for CommandDiscovery {
                                         // resource that is requested by resource/config operation
                                         // if it is, then "ResouceNotFound" error will be issued later
                                         // and here we just write as info
-                                        info!("{}", t!("discovery.commandDiscovery.failedLoadManifest", path = path.to_string_lossy(), err = e));
+                                        info!("{}", t!("discovery.commandDiscovery.failedLoadManifest", err = e));
                                         continue;
                                     },
                                 };

--- a/lib/dsc-lib/src/extensions/discover.rs
+++ b/lib/dsc-lib/src/extensions/discover.rs
@@ -102,7 +102,7 @@ impl DscExtension {
                     let manifests = match load_manifest(&discover_result.manifest_path) {
                         Ok(manifests) => manifests,
                         Err(err) => {
-                            info!("{}", t!("extensions.dscextension.failedLoadManifest", extension = self.type_name, path = discover_result.manifest_path.to_string_lossy(), err = err));
+                            info!("{}", t!("extensions.dscextension.failedLoadManifest", extension = self.type_name, err = err));
                             continue;
                         }
                     };


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

When DSC encounters a resource manifest it can't deserialize, it fails discovery completely.  This was not intended.  This can occur when we update the manifests with new fields that an older DSC does not understand.  Instead, DSC should only support resources it can deserialize and emit `info` messages (so they don't show by default) for resources it can't use.
