### PR TITLE
Fix discovery tests due to trace change

### DIFF
--- a/dsc/tests/dsc_discovery.tests.ps1
+++ b/dsc/tests/dsc_discovery.tests.ps1
@@ -84,7 +84,7 @@ Describe 'tests for resource discovery' {
             $resources.Count | Should -Be 0
         }
 
-        It 'warns on invalid semver' {
+        It 'info on invalid semver' {
             $manifest = @'
             {
                 "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
@@ -102,7 +102,9 @@ Describe 'tests for resource discovery' {
 '@
             Set-Content -Path "$testdrive/test.dsc.resource.json" -Value $manifest
             $null = dsc -l info resource list 2> "$testdrive/error.txt"
-            (Get-Content -Raw "$testdrive/error.txt") | Should -Match 'INFO.*?invalid semantic version' -Because (Get-Content -Raw "$testdrive/error.txt")
+            $LASTEXITCODE | Should -Be 0
+            $errorTxt = Get-Content -Raw "$testdrive/error.txt"
+            $errorTxt | Should -Match 'INFO.*?invalid semantic version' -Because $errorTxt
         }
     }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

After merging both the change of version typing and not failing discovery, there seems to be a bad merge so that the test was out of date.  The change from previous PR is that the trace is an INFO not a WARN, so test needed to be updated.
