### PR TITLE
Fix rustflags for Windows arm64

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,7 +27,7 @@ rustflags = [
     "-Dwarnings"
 ]
 
-[target.aarch64-windows-msvc]
+[target.aarch64-pc-windows-msvc]
 rustflags = [
     "-Ccontrol-flow-guard",
     "-Ctarget-feature=+crt-static",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Typo in the config.toml was missing the full actual name for the architecture
