### PR TITLE
Fix dism resources to work on Windows arm64

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -200,6 +200,11 @@ process {
             Install-Clippy -UseCFS:$UseCFS -Architecture $Architecture @VerboseParam
         }
 
+        if (!$SkipBuild -and !$SkipLinkCheck -and $IsWindows) {
+            Write-BuildProgress @progressParams -Status "Ensuring Windows C++ build tools are available"
+            Install-WindowsCPlusPlusBuildTools @VerboseParam
+        }
+
         if (-not ($SkipBuild -and $Test -and $ExcludeRustTests)) {
             Write-BuildProgress @progressParams -Status 'Ensuring Protobuf is available'
             Install-Protobuf @VerboseParam
@@ -212,10 +217,6 @@ process {
         }
     }
 
-    if (!$SkipBuild -and !$SkipLinkCheck -and $IsWindows) {
-        Write-BuildProgress @progressParams -Status "Ensuring Windows C++ build tools are available"
-        Install-WindowsCPlusPlusBuildTools @VerboseParam
-    }
     #endregion Setup
 
     if (!$SkipBuild) {

--- a/resources/dism_dsc/src/dism.rs
+++ b/resources/dism_dsc/src/dism.rs
@@ -25,13 +25,13 @@ unsafe extern "system" {
     ) -> *mut c_void;
 }
 
-#[repr(C, packed(4))]
+#[repr(C, packed)]
 struct DismFeature {
     feature_name: *const u16,
     state: i32,
 }
 
-#[repr(C, packed(4))]
+#[repr(C, packed)]
 struct DismFeatureInfo {
     feature_name: *const u16,
     state: i32,
@@ -42,13 +42,13 @@ struct DismFeatureInfo {
     custom_property_count: u32,
 }
 
-#[repr(C, packed(4))]
+#[repr(C, packed)]
 struct DismCapability {
     name: *const u16,
     state: i32,
 }
 
-#[repr(C, packed(4))]
+#[repr(C, packed)]
 struct DismCapabilityDetail {
     name: *const u16,
     state: i32,


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- The use of `packed(4)` worked on x64, but fails on arm64.  Solution is to just use `packed` to align correctly.
- Move check for build tools on Windows above installer tree-sitter since compiling tree-sitter requires them

Validated on a arm64 VM