### PR TITLE
Fix type in building win-arm64 so vcruntime is statically linked

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -12,7 +12,7 @@ global-credential-providers = ["cargo:token"]
 [target.x86_64-pc-windows-msvc]
 rustflags = ["-Ccontrol-flow-guard", "-Ctarget-feature=+crt-static", "-Clink-args=/DYNAMICBASE /CETCOMPAT"]
 
-[target.aarch64-windows-msvc]
+[target.aarch64-pc-windows-msvc]
 rustflags = ["-Ccontrol-flow-guard", "-Ctarget-feature=+crt-static", "-Clink-args=/DYNAMICBASE"]
 
 # The following is only needed for release builds


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Backport https://github.com/PowerShell/DSC/pull/1462 so that `dsc.exe` is statically linked to vcruntime on win-arm64