### PR TITLE
Fix adding `what-if` capability to resources

### DIFF
--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -802,12 +802,13 @@ pub fn list_resources(
             let capability_types = [
                 (Capability::Get, "g"),
                 (Capability::Set, "s"),
+                (Capability::SetWhatIf, "w"),
                 (Capability::SetHandlesExist, "x"),
                 (Capability::Test, "t"),
                 (Capability::Delete, "d"),
+                (Capability::DeleteWhatIf, "W"),
                 (Capability::Export, "e"),
                 (Capability::Resolve, "r"),
-                (Capability::WhatIf, "w"),
             ];
             let mut capabilities = "-".repeat(capability_types.len());
 

--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -807,6 +807,7 @@ pub fn list_resources(
                 (Capability::Delete, "d"),
                 (Capability::Export, "e"),
                 (Capability::Resolve, "r"),
+                (Capability::WhatIf, "w"),
             ];
             let mut capabilities = "-".repeat(capability_types.len());
 

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -162,16 +162,17 @@ Describe 'Tests for listing resources' {
         }
     }
 
-    It 'What-if capability is added for resources supporting it' {
-        $out = dsc resource list 'Test/*' | ConvertFrom-Json
+    It 'What-if capability is added for resources supporting it for: <resource>' -TestCases @(
+        @{ resource = 'Test/WhatIf'; capability = 'SetWhatIf' }
+        @{ resource = 'Test/WhatIfArgKind'; capability = 'SetWhatIf' }
+        @{ resource = 'Test/WhatIfDelete'; capability = 'DeleteWhatIf' }
+        @{ resource = 'Test/WhatIfReturnDiff'; capability = 'SetWhatIf' }
+    ) {
+        param($resource, $capability)
+
+        $out = dsc resource list $resource | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
-        $out.Count | Should -BeGreaterThan 0
-        foreach ($resource in $out) {
-            if ($resource.type -like 'Test/WhatIf*') {
-                $resource.capabilities | Should -Contain 'whatIf'
-            } else {
-                $resource.capabilities | Should -Not -Contain 'whatIf'
-            }
-        }
+        $out.Count | Should -Be 1
+        $out.capabilities | Should -Contain $capability
     }
 }

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -165,6 +165,7 @@ Describe 'Tests for listing resources' {
     It 'What-if capability is added for resources supporting it' {
         $out = dsc resource list 'Test/*' | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0
+        $out.Count | Should -BeGreaterThan 0
         foreach ($resource in $out) {
             if ($resource.type -like 'Test/WhatIf*') {
                 $resource.capabilities | Should -Contain 'whatIf'

--- a/dsc/tests/dsc_resource_list.tests.ps1
+++ b/dsc/tests/dsc_resource_list.tests.ps1
@@ -161,4 +161,16 @@ Describe 'Tests for listing resources' {
             $env:DSC_RESOURCE_PATH = $oldPath
         }
     }
+
+    It 'What-if capability is added for resources supporting it' {
+        $out = dsc resource list 'Test/*' | ConvertFrom-Json
+        $LASTEXITCODE | Should -Be 0
+        foreach ($resource in $out) {
+            if ($resource.type -like 'Test/WhatIf*') {
+                $resource.capabilities | Should -Contain 'whatIf'
+            } else {
+                $resource.capabilities | Should -Not -Contain 'whatIf'
+            }
+        }
+    }
 }

--- a/lib/dsc-lib-jsonschema/.versions.json
+++ b/lib/dsc-lib-jsonschema/.versions.json
@@ -1,9 +1,11 @@
 {
   "latestMajor": "V3",
-  "latestMinor": "V3_1",
-  "latestPatch": "V3_1_3",
+  "latestMinor": "V3_2",
+  "latestPatch": "V3_2_0",
   "all": [
     "V3",
+    "V3_2",
+    "V3_2_0",
     "V3_1",
     "V3_1_3",
     "V3_1_2",

--- a/lib/dsc-lib/src/discovery/command_discovery.rs
+++ b/lib/dsc-lib/src/discovery/command_discovery.rs
@@ -800,7 +800,7 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
             capabilities.insert(Capability::SetHandlesExist);
         }
         if let Some(args) = &set.args && args_contains_what_if(args) {
-            capabilities.insert(Capability::WhatIf);
+            capabilities.insert(Capability::SetWhatIf);
         }
     }
     if let Some(test) = &manifest.test {
@@ -811,7 +811,7 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
         verify_executable(&manifest.resource_type, "delete", &delete.executable, path.parent().unwrap());
         capabilities.insert(Capability::Delete);
         if let Some(args) = &delete.args && args_contains_what_if(args) {
-            capabilities.insert(Capability::WhatIf);
+            capabilities.insert(Capability::DeleteWhatIf);
         }
     }
     if let Some(export) = &manifest.export {
@@ -827,7 +827,7 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
     }
     if let Some(what_if) = &manifest.what_if {
         verify_executable(&manifest.resource_type, "what-if", &what_if.executable, path.parent().unwrap());
-        capabilities.insert(Capability::WhatIf);
+        capabilities.insert(Capability::SetWhatIf);
     }
 
     let mut resource = DscResource::new();

--- a/lib/dsc-lib/src/discovery/command_discovery.rs
+++ b/lib/dsc-lib/src/discovery/command_discovery.rs
@@ -799,7 +799,7 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
         if set.handles_exist == Some(true) {
             capabilities.insert(Capability::SetHandlesExist);
         }
-        if let Some(args) = &set.args && args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
+        if let Some(args) = &set.args && args_contains_what_if(args) {
             capabilities.insert(Capability::WhatIf);
         }
     }
@@ -810,7 +810,7 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
     if let Some(delete) = &manifest.delete {
         verify_executable(&manifest.resource_type, "delete", &delete.executable, path.parent().unwrap());
         capabilities.insert(Capability::Delete);
-        if let Some(args) = &delete.args && args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
+        if let Some(args) = &delete.args && args_contains_what_if(args) {
             capabilities.insert(Capability::WhatIf);
         }
     }
@@ -831,18 +831,24 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
     }
 
     let mut resource = DscResource::new();
+    let mut capabilities: Vec<Capability> = capabilities.into_iter().collect();
+    capabilities.sort();
     resource.type_name = manifest.resource_type.clone();
     resource.kind = kind;
     resource.implemented_as = Some(ImplementedAs::Command);
     resource.deprecation_message = manifest.deprecation_message.clone();
     resource.description = manifest.description.clone();
     resource.version = manifest.version.clone();
-    resource.capabilities = capabilities.into_iter().collect();
+    resource.capabilities = capabilities;
     resource.path = path.to_path_buf();
     resource.directory = path.parent().unwrap().to_path_buf();
     resource.manifest = Some(manifest.clone());
 
     Ok(resource)
+}
+
+fn args_contains_what_if(args: &[SetDeleteArgKind]) -> bool {
+    args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ }))
 }
 
 fn load_extension_manifest(path: &Path, manifest: &ExtensionManifest) -> Result<DscExtension, DscError> {

--- a/lib/dsc-lib/src/discovery/command_discovery.rs
+++ b/lib/dsc-lib/src/discovery/command_discovery.rs
@@ -799,10 +799,8 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
         if set.handles_exist == Some(true) {
             capabilities.insert(Capability::SetHandlesExist);
         }
-        if let Some(args) = &set.args {
-            if args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
-                capabilities.insert(Capability::WhatIf);
-            }
+        if let Some(args) = &set.args && args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
+            capabilities.insert(Capability::WhatIf);
         }
     }
     if let Some(test) = &manifest.test {
@@ -812,10 +810,8 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
     if let Some(delete) = &manifest.delete {
         verify_executable(&manifest.resource_type, "delete", &delete.executable, path.parent().unwrap());
         capabilities.insert(Capability::Delete);
-        if let Some(args) = &delete.args {
-            if args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
-                capabilities.insert(Capability::WhatIf);
-            }
+        if let Some(args) = &delete.args && args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
+            capabilities.insert(Capability::WhatIf);
         }
     }
     if let Some(export) = &manifest.export {

--- a/lib/dsc-lib/src/discovery/command_discovery.rs
+++ b/lib/dsc-lib/src/discovery/command_discovery.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-use crate::{discovery::{DiscoveryExtensionCache, DiscoveryManifestCache, DiscoveryResourceCache, discovery_trait::{DiscoveryFilter, DiscoveryKind, ResourceDiscovery}, matches_adapter_requirement}, dscresources::adapted_resource_manifest::AdaptedDscResourceManifest, parser::Statement, types::{FullyQualifiedTypeName, TypeNameFilter}};
+use crate::{discovery::{DiscoveryExtensionCache, DiscoveryManifestCache, DiscoveryResourceCache, discovery_trait::{DiscoveryFilter, DiscoveryKind, ResourceDiscovery}, matches_adapter_requirement}, dscresources::{adapted_resource_manifest::AdaptedDscResourceManifest, resource_manifest::SetDeleteArgKind}, parser::Statement, types::{FullyQualifiedTypeName, TypeNameFilter}};
 use crate::{locked_clear, locked_is_empty, locked_extend, locked_clone, locked_get};
 use crate::configure::{config_doc::ResourceDiscoveryMode, context::Context};
 use crate::dscresources::dscresource::{Capability, DscResource, ImplementedAs};
@@ -788,36 +788,50 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
         Kind::Resource
     };
 
-    let mut capabilities: Vec<Capability> = vec![];
+    let mut capabilities: HashSet<Capability> = HashSet::new();
     if let Some(get) = &manifest.get {
         verify_executable(&manifest.resource_type, "get", &get.executable, path.parent().unwrap());
-        capabilities.push(Capability::Get);
+        capabilities.insert(Capability::Get);
     }
     if let Some(set) = &manifest.set {
         verify_executable(&manifest.resource_type, "set", &set.executable, path.parent().unwrap());
-        capabilities.push(Capability::Set);
+        capabilities.insert(Capability::Set);
         if set.handles_exist == Some(true) {
-            capabilities.push(Capability::SetHandlesExist);
+            capabilities.insert(Capability::SetHandlesExist);
+        }
+        if let Some(args) = &set.args {
+            if args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
+                capabilities.insert(Capability::WhatIf);
+            }
         }
     }
     if let Some(test) = &manifest.test {
         verify_executable(&manifest.resource_type, "test", &test.executable, path.parent().unwrap());
-        capabilities.push(Capability::Test);
+        capabilities.insert(Capability::Test);
     }
     if let Some(delete) = &manifest.delete {
         verify_executable(&manifest.resource_type, "delete", &delete.executable, path.parent().unwrap());
-        capabilities.push(Capability::Delete);
+        capabilities.insert(Capability::Delete);
+        if let Some(args) = &delete.args {
+            if args.iter().any(|arg| matches!(arg, SetDeleteArgKind::WhatIf{ what_if_arg: _ })) {
+                capabilities.insert(Capability::WhatIf);
+            }
+        }
     }
     if let Some(export) = &manifest.export {
         verify_executable(&manifest.resource_type, "export", &export.executable, path.parent().unwrap());
-        capabilities.push(Capability::Export);
+        capabilities.insert(Capability::Export);
     }
     if let Some(resolve) = &manifest.resolve {
         verify_executable(&manifest.resource_type, "resolve", &resolve.executable, path.parent().unwrap());
-        capabilities.push(Capability::Resolve);
+        capabilities.insert(Capability::Resolve);
     }
     if let Some(SchemaKind::Command(command)) = &manifest.schema {
         verify_executable(&manifest.resource_type, "schema", &command.executable, path.parent().unwrap());
+    }
+    if let Some(what_if) = &manifest.what_if {
+        verify_executable(&manifest.resource_type, "what-if", &what_if.executable, path.parent().unwrap());
+        capabilities.insert(Capability::WhatIf);
     }
 
     let mut resource = DscResource::new();
@@ -827,7 +841,7 @@ fn load_resource_manifest(path: &Path, manifest: &ResourceManifest) -> Result<Ds
     resource.deprecation_message = manifest.deprecation_message.clone();
     resource.description = manifest.description.clone();
     resource.version = manifest.version.clone();
-    resource.capabilities = capabilities;
+    resource.capabilities = capabilities.into_iter().collect();
     resource.path = path.to_path_buf();
     resource.directory = path.parent().unwrap().to_path_buf();
     resource.manifest = Some(manifest.clone());

--- a/lib/dsc-lib/src/dscresources/dscresource.rs
+++ b/lib/dsc-lib/src/dscresources/dscresource.rs
@@ -74,12 +74,14 @@ pub enum Capability {
     Set,
     /// The resource supports the `_exist` property directly.
     SetHandlesExist,
-    /// The resource supports simulating configuration directly.
-    WhatIf,
+    /// The resource supports simulating configuration directly for `set`
+    SetWhatIf,
     /// The resource supports validating configuration.
     Test,
     /// The resource supports deleting configuration.
     Delete,
+    /// The resource supports simulating configuration directly for `delete`
+    DeleteWhatIf,
     /// The resource supports exporting configuration.
     Export,
     /// The resource supports resolving imported configuration.

--- a/lib/dsc-lib/src/dscresources/dscresource.rs
+++ b/lib/dsc-lib/src/dscresources/dscresource.rs
@@ -63,7 +63,7 @@ pub struct DscResource {
     pub manifest: Option<ResourceManifest>,
 }
 
-#[derive(Clone, Debug, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]
 #[serde(rename_all = "camelCase")]
 #[schemars(transform = idiomaticize_string_enum)]
 #[dsc_repo_schema(base_name = "resourceCapabilities", folder_path = "definitions")]

--- a/lib/dsc-lib/src/dscresources/dscresource.rs
+++ b/lib/dsc-lib/src/dscresources/dscresource.rs
@@ -63,7 +63,7 @@ pub struct DscResource {
     pub manifest: Option<ResourceManifest>,
 }
 
-#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema, Ord, PartialOrd)]
 #[serde(rename_all = "camelCase")]
 #[schemars(transform = idiomaticize_string_enum)]
 #[dsc_repo_schema(base_name = "resourceCapabilities", folder_path = "definitions")]


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

There's 2 ways to detect if a resource supports `what-if`:

1. `set` or `delete` has the `whatIfArg` arg
2. resource has the old `whatIf` operation

Changed the code from using a `Vec` to using a `HashSet` to avoid having to check if `what-if` was already added to capabiltiies.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1501
