### PR TITLE
Add manifest patterns for DSC resource discovery

### DIFF
--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -26,7 +26,7 @@ Describe 'Discover extension tests' {
         if ($IsWindows) {
             $out.Count | Should -Be 3 -Because ($out | Out-String)
             $out[0].type | Should -BeExactly 'Microsoft.PowerShell/Discover'
-            $out[0].version | Should -BeExactly '0.1.0'
+            $out[0].version | Should -BeExactly '0.1.1'
             $out[0].capabilities | Should -BeExactly @('discover')
             $out[0].manifest | Should -Not -BeNullOrEmpty
             $out[1].type | Should -BeExactly 'Microsoft.Windows.Appx/Discover'

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -40,7 +40,7 @@ Describe 'Discover extension tests' {
         } else {
             $out.Count | Should -Be 2 -Because ($out | Out-String)
             $out[0].type | Should -BeExactly 'Microsoft.PowerShell/Discover'
-            $out[0].version | Should -BeExactly '0.1.0'
+            $out[0].version | Should -BeExactly '0.1.1'
             $out[0].capabilities | Should -BeExactly @('discover')
             $out[0].manifest | Should -Not -BeNullOrEmpty
             $out[1].type | Should -BeExactly 'Test/Discover'

--- a/extensions/powershell/powershell.discover.ps1
+++ b/extensions/powershell/powershell.discover.ps1
@@ -81,6 +81,9 @@ function Invoke-DscResourceDiscovery {
                     '*.dsc.adaptedresource.json'
                     '*.dsc.adaptedresource.yaml'
                     '*.dsc.adaptedresource.yml'
+                    '*.dsc.manifests.json'
+                    '*.dsc.manifests.yaml'
+                    '*.dsc.manifests.yml'
                 )
                 $enumOptions = [System.IO.EnumerationOptions]@{ IgnoreInaccessible = $true; RecurseSubdirectories = $true }
                 foreach ($pattern in $searchPatterns) {

--- a/extensions/powershell/powershell.discover.tests.ps1
+++ b/extensions/powershell/powershell.discover.tests.ps1
@@ -47,6 +47,39 @@ BeforeAll {
     $adaptedManifestPath = Join-Path $TestDrive "fake.dsc.adaptedresource.json"
     $fakeAdaptedManifest | ConvertTo-Json -Depth 10 | Set-Content -Path $adaptedManifestPath
 
+    $fakeManifestList = @{
+        '$schema'        = "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json"
+        resources        = @(
+            @{
+                type    = "Test/FakeListedResource"
+                version = "0.1.0"
+                kind    = "resource"
+                get     = @{
+                    executable = "fakeListedResource"
+                    args       = @(
+                        "get",
+                        @{
+                            jsonInputArg = "--input"
+                            mandatory    = $true
+                        }
+                    )
+                }
+            }
+        )
+        adaptedResources = @(
+            @{
+                type           = "Test/FakeListedAdaptedResource"
+                kind           = "resource"
+                version        = "0.1.0"
+                requireAdapter = "Microsoft.Adapter/PowerShell"
+                path           = "FakeAdapted.psd1"
+            }
+        )
+    }
+
+    $manifestListPath = Join-Path $TestDrive "fake.dsc.manifests.json"
+    $fakeManifestList | ConvertTo-Json -Depth 10 | Set-Content -Path $manifestListPath
+
     $fakePsd1Path = Join-Path $TestDrive "FakeAdapted.psd1"
     Set-Content -Path $fakePsd1Path -Value "@{ ModuleVersion = '0.1.0' }"
     $script:OldPSModulePath = $env:PSModulePath
@@ -161,5 +194,11 @@ Describe 'Tests for PowerShell resource discovery' {
         Remove-Item -Force -ErrorAction SilentlyContinue -Path $script:cacheFilePath
         $out = & $script:discoverScript | ConvertFrom-Json
         $out.manifestPath | Should -Contain $adaptedManifestPath
+    }
+
+    It 'Should discover *.dsc.manifests.* manifest-list files' {
+        Remove-Item -Force -ErrorAction SilentlyContinue -Path $script:cacheFilePath
+        $out = & $script:discoverScript | ConvertFrom-Json
+        $out.manifestPath | Should -Contain $manifestListPath
     }
 }

--- a/extensions/powershell/powershell.dsc.extension.json
+++ b/extensions/powershell/powershell.dsc.extension.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
   "type": "Microsoft.PowerShell/Discover",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Discovers DSC resources packaged in PowerShell 7 modules.",
   "condition": "[not(equals(tryWhich('pwsh'), null()))]",
   "discover": {


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds the `*.dsc.manifests.*` to discover `adaptedresources` through the extension.

## PR Context

Fixes #1504 
