### PR TITLE
Fix stdin inherited by child processes when no input provided

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -89,6 +89,7 @@ param(
     [switch]$Test,
     [string[]]$Project,
     [switch]$ExcludeRustTests,
+    [string]$RustTestFilter,
     [switch]$ExcludePesterTests,
     [ValidateSet("dsc", "adapters", "extensions", "grammars", "resources")]
     [string[]]$PesterTestGroup,
@@ -265,6 +266,9 @@ process {
                 Project      = $BuildData.Projects
                 Architecture = $Architecture
                 Release      = $Release
+            }
+            if (-not [string]::IsNullOrEmpty($RustTestFilter)) {
+                $rustTestParams.TestFilter = $RustTestFilter
             }
             Write-BuildProgress @progressParams -Status "Testing Rust projects"
             Test-RustProject @rustTestParams @VerboseParam

--- a/helpers.build.psm1
+++ b/helpers.build.psm1
@@ -1798,7 +1798,8 @@ function Test-RustProject {
         [ValidateSet('current','aarch64-pc-windows-msvc','x86_64-pc-windows-msvc','aarch64-apple-darwin','x86_64-apple-darwin','aarch64-unknown-linux-gnu','aarch64-unknown-linux-musl','x86_64-unknown-linux-gnu','x86_64-unknown-linux-musl')]
         $Architecture = 'current',
         [switch]$Release,
-        [switch]$Docs
+        [switch]$Docs,
+        [string]$TestFilter
     )
 
     begin {
@@ -1828,7 +1829,11 @@ function Test-RustProject {
         } else {
             Write-Verbose -Verbose "Testing rust projects: [$members]"
         }
-        cargo test @flags
+        if (-not [string]::IsNullOrEmpty($TestFilter)) {
+            cargo test @flags -- $TestFilter
+        } else {
+            cargo test @flags
+        }
 
         if ($null -ne $LASTEXITCODE -and $LASTEXITCODE -ne 0) {
             Write-Error "Last exit code is $LASTEXITCODE, rust tests failed"

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -767,6 +767,8 @@ async fn run_process_async(executable: &str, args: Option<Vec<String>>, input: O
     let mut command = Command::new(executable);
     if input.is_some() {
         command.stdin(Stdio::piped());
+    } else {
+        command.stdin(Stdio::null());
     }
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());

--- a/lib/dsc-lib/tests/integration/command_resource.rs
+++ b/lib/dsc-lib/tests/integration/command_resource.rs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#[cfg(test)]
+mod invoke_command {
+    use dsc_lib::{dscresources::command_resource::invoke_command, types::ExitCodesMap};
+
+    /// Verifies that when `invoke_command` is called with `input = None`, the child process
+    /// receives an immediate EOF on stdin (i.e., stdin is set to null) rather than inheriting
+    /// the parent's stdin handle.
+    ///
+    /// This is a regression test for the hang introduced in DSC 3.2.0 when the PowerShell
+    /// adapter changed from `"config": "full"` to `"config": "single"`. In single mode, the
+    /// adapter's export operation is called with no input, leaving stdin unset in the previous
+    /// code. Child processes that read from stdin would then block indefinitely when the parent
+    /// process itself had an open stdin handle — either a TTY in a terminal or a pipe in CI.
+    ///
+    /// The test uses a timed async read rather than a blocking read so that the child process
+    /// always exits within a bounded time. If stdin is null (the fix), `ReadAsync` completes
+    /// immediately returning 0 bytes (EOF), which maps to -1. If stdin is inherited (the bug),
+    /// `ReadAsync` blocks until the timeout fires and the test receives -2, which fails the
+    /// assertion.
+    #[test]
+    fn no_input_does_not_block_on_stdin() {
+        let exit_codes = ExitCodesMap::default();
+
+        // Use PowerShell's own async timeout so the child process always exits within ~5s,
+        // regardless of fix status. We never leave a hanging thread:
+        //   byte:-1  → ReadAsync got EOF immediately  → stdin was null  → PASS
+        //   byte:-2  → ReadAsync timed out (5 s)      → stdin was NOT null → FAIL
+        let ps_command = concat!(
+            "$reader = [Console]::OpenStandardInput();",
+            "$buf = [byte[]]::new(1);",
+            "$task = $reader.ReadAsync($buf, 0, 1);",
+            "$completed = $task.Wait(5000);",
+            "$b = if ($completed) { if ($task.Result -eq 0) { -1 } else { $buf[0] } } else { -2 };",
+            "Write-Output \"byte:$b\""
+        );
+
+        let result = invoke_command(
+            "pwsh",
+            Some(vec![
+                "-NonInteractive".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                ps_command.to_string(),
+            ]),
+            None,  // no input — the scenario that caused the hang
+            None,
+            None,
+            &exit_codes,
+        ).expect("invoke_command should succeed");
+
+        let (exit_code, stdout, _stderr) = result;
+        assert_eq!(exit_code, 0, "Command should exit 0");
+        // -1 means ReadAsync got EOF immediately, confirming stdin was set to null.
+        // -2 means stdin was open (inherited) and the read timed out after 5s.
+        assert!(
+            stdout.contains("byte:-1"),
+            "Expected EOF (byte:-1) from null stdin, got: {stdout:?}\n\
+             'byte:-2' means stdin was inherited from the parent rather than set to null."
+        );
+    }
+}

--- a/lib/dsc-lib/tests/integration/command_resource.rs
+++ b/lib/dsc-lib/tests/integration/command_resource.rs
@@ -24,15 +24,15 @@ mod invoke_command {
     fn no_input_does_not_block_on_stdin() {
         let exit_codes = ExitCodesMap::default();
 
-        // Use PowerShell's own async timeout so the child process always exits within ~5s,
+        // Use PowerShell's own async timeout so the child process always exits within ~2s,
         // regardless of fix status. We never leave a hanging thread:
         //   byte:-1  → ReadAsync got EOF immediately  → stdin was null  → PASS
-        //   byte:-2  → ReadAsync timed out (5 s)      → stdin was NOT null → FAIL
+        //   byte:-2  → ReadAsync timed out (2 s)      → stdin was NOT null → FAIL
         let ps_command = concat!(
             "$reader = [Console]::OpenStandardInput();",
             "$buf = [byte[]]::new(1);",
             "$task = $reader.ReadAsync($buf, 0, 1);",
-            "$completed = $task.Wait(5000);",
+            "$completed = $task.Wait(2000);",
             "$b = if ($completed) { if ($task.Result -eq 0) { -1 } else { $buf[0] } } else { -2 };",
             "Write-Output \"byte:$b\""
         );
@@ -54,7 +54,7 @@ mod invoke_command {
         let (exit_code, stdout, _stderr) = result;
         assert_eq!(exit_code, 0, "Command should exit 0");
         // -1 means ReadAsync got EOF immediately, confirming stdin was set to null.
-        // -2 means stdin was open (inherited) and the read timed out after 5s.
+        // -2 means stdin was open (inherited) and the read timed out after 2s.
         assert!(
             stdout.contains("byte:-1"),
             "Expected EOF (byte:-1) from null stdin, got: {stdout:?}\n\

--- a/lib/dsc-lib/tests/integration/main.rs
+++ b/lib/dsc-lib/tests/integration/main.rs
@@ -13,5 +13,6 @@
 //! minimize compilation times. If we defined the tests one level higher in the `tests` folder,
 //! Rust would generate numerous binaries to execute our tests.
 
+#[cfg(test)] mod command_resource;
 #[cfg(test)] mod schemas;
 #[cfg(test)] mod types;

--- a/resources/WindowsUpdate/tests/windowsupdate_export.tests.ps1
+++ b/resources/WindowsUpdate/tests/windowsupdate_export.tests.ps1
@@ -8,7 +8,7 @@ Describe 'Windows Update Export operation tests' {
 
     Context 'Export operation' {
         It 'should return UpdateList with array of updates' -Skip:(!$IsWindows) {
-            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -18,7 +18,7 @@ Describe 'Windows Update Export operation tests' {
         }
 
         It 'should work without input filter' -Skip:(!$IsWindows) {
-            $out = '' | dsc resource export -r $resourceType -o json 2>&1
+            $out = dsc resource export -r $resourceType -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -28,7 +28,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should filter by isInstalled=true' -Skip:(!$IsWindows) {
             $json = '{"updates":[{"isInstalled": true}]}'
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -42,7 +42,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should filter by isInstalled=false' -Skip:(!$IsWindows) {
             $json = '{"updates":[{"isInstalled": false}]}'
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -56,7 +56,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should filter by title with wildcard in middle' -Skip:(!$IsWindows) {
             $json = '{"updates":[{"title": "*Windows*"}]}'
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $config = $out | ConvertFrom-Json
@@ -70,7 +70,7 @@ Describe 'Windows Update Export operation tests' {
         }
 
         It 'should return proper structure for each update' -Skip:(!$IsWindows) {
-            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -92,7 +92,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should fail when wildcard filter has no matches' -Skip:(!$IsWindows) {
             $json = '{"updates":[{"title": "ThisUpdateShouldNeverExist99999*"}]}'
-            $stderr = $json | dsc resource export -r $resourceType -o json 2>&1
+            $stderr = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             # Should fail because the filter has criteria but no matches
             $LASTEXITCODE | Should -Not -Be 0
@@ -111,7 +111,7 @@ Describe 'Windows Update Export operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $stderr = $json | dsc resource export -r $resourceType 2>&1
+            $stderr = $json | dsc resource export -r $resourceType -f - 2>&1
             
             # Should fail because the filter has criteria but no matches
             $LASTEXITCODE | Should -Not -Be 0
@@ -128,7 +128,7 @@ Describe 'Windows Update Export operation tests' {
                     @{}
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -138,7 +138,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should fail if any filter with criteria has no matches' -Skip:(!$IsWindows) {
             # Get an actual update
-            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $allConfig = $allOut | ConvertFrom-Json
@@ -157,7 +157,7 @@ Describe 'Windows Update Export operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $stderr = $json | dsc resource export -r $resourceType 2>&1
+                    $stderr = $json | dsc resource export -r $resourceType -f - 2>&1
                     
                     # Should fail because second filter has no matches
                     $LASTEXITCODE | Should -Not -Be 0
@@ -171,7 +171,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should return results when all filters find matches' -Skip:(!$IsWindows) {
             # Get actual updates
-            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $allConfig = $allOut | ConvertFrom-Json
@@ -190,7 +190,7 @@ Describe 'Windows Update Export operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $out = $json | dsc resource export -r $resourceType -o json 2>&1
+                    $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
                     
                     $LASTEXITCODE | Should -Be 0
                     $config = $out | ConvertFrom-Json
@@ -205,7 +205,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should filter by msrcSeverity' -Skip:(!$IsWindows) {
             $json = '{"updates":[{"msrcSeverity": "Critical"}]}'
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $config = $out | ConvertFrom-Json
@@ -220,7 +220,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should filter by updateType Software' -Skip:(!$IsWindows) {
             $json = '{"updates":[{"updateType": "Software"}]}'
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $config = $out | ConvertFrom-Json
@@ -235,7 +235,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should support OR logic with multiple filters in array' -Skip:(!$IsWindows) {
             # Get some updates to use as filters
-            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $allConfig = $allOut | ConvertFrom-Json
@@ -245,7 +245,7 @@ Describe 'Windows Update Export operation tests' {
                     $id1 = $allResult.updates[0].id
                     $id2 = $allResult.updates[1].id
                     $json = "{`"updates`":[{`"id`": `"$id1`"}, {`"id`": `"$id2`"}]}"
-                    $out = $json | dsc resource export -r $resourceType -o json 2>&1
+                    $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
                     
                     $LASTEXITCODE | Should -Be 0
                     $config = $out | ConvertFrom-Json
@@ -267,7 +267,7 @@ Describe 'Windows Update Export operation tests' {
         It 'should support AND logic within single filter object' -Skip:(!$IsWindows) {
             # Multiple properties in one filter = AND logic
             $json = '{"updates":[{"isInstalled": true, "updateType": "Software"}]}'
-            $out = $json | dsc resource export -r $resourceType -o json 2>&1
+            $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $config = $out | ConvertFrom-Json
@@ -284,7 +284,7 @@ Describe 'Windows Update Export operation tests' {
 
         It 'should not return duplicates when multiple filters match same update' -Skip:(!$IsWindows) {
             # Get an update with known properties
-            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $allOut = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $allConfig = $allOut | ConvertFrom-Json
@@ -294,7 +294,7 @@ Describe 'Windows Update Export operation tests' {
                     # Use the same ID in both filters - this should only return one update
                     # Even though technically both filters specify the same criteria
                     $json = "{`"updates`":[{`"id`": `"$($testUpdate.id)`"}, {`"id`": `"$($testUpdate.id)`"}]}"
-                    $out = $json | dsc resource export -r $resourceType -o json 2>&1
+                    $out = $json | dsc resource export -r $resourceType -f - -o json 2>&1
                     
                     $LASTEXITCODE | Should -Be 0 -Because $out
                     $config = $out | ConvertFrom-Json
@@ -308,7 +308,7 @@ Describe 'Windows Update Export operation tests' {
         }
 
         It 'should return installationBehavior property when present' -Skip:(!$IsWindows) {
-            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json
@@ -326,7 +326,7 @@ Describe 'Windows Update Export operation tests' {
         }
 
         It 'should return valid installationBehavior enum values for all updates' -Skip:(!$IsWindows) {
-            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -o json 2>&1
+            $out = '{"updates":[{}]}' | dsc resource export -r $resourceType -f - -o json 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $config = $out | ConvertFrom-Json

--- a/resources/WindowsUpdate/tests/windowsupdate_get.tests.ps1
+++ b/resources/WindowsUpdate/tests/windowsupdate_get.tests.ps1
@@ -20,7 +20,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $getResult = $out | ConvertFrom-Json
@@ -45,7 +45,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $outLower = $jsonLower | dsc resource get -r $resourceType 2>&1
+            $outLower = $jsonLower | dsc resource get -r $resourceType -f - 2>&1
             
             # Test with uppercase version
             $jsonUpper = @{
@@ -55,7 +55,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $outUpper = $jsonUpper | dsc resource get -r $resourceType 2>&1
+            $outUpper = $jsonUpper | dsc resource get -r $resourceType -f - 2>&1
             
             # Both should succeed
             if ($outLower -and $outUpper) {
@@ -74,7 +74,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $null = $json | dsc resource get -r $resourceType 2>&1
+            $null = $json | dsc resource get -r $resourceType -f - 2>&1
             # This will likely fail unless there's an update with exact title "Windows"
             # which is unlikely
             $LASTEXITCODE | Should -Not -Be 0
@@ -89,7 +89,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $null = $json | dsc resource get -r $resourceType 2>&1
+            $null = $json | dsc resource get -r $resourceType -f - 2>&1
             $LASTEXITCODE | Should -Not -Be 0
         }
 
@@ -103,7 +103,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $result = $out | ConvertFrom-Json
@@ -121,7 +121,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $null = $json | dsc resource get -r $resourceType 2>&1
+            $null = $json | dsc resource get -r $resourceType -f - 2>&1
             
             # Should fail because id doesn't match
             $LASTEXITCODE | Should -Not -Be 0
@@ -137,7 +137,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $null = $json | dsc resource get -r $resourceType 2>&1
+            $null = $json | dsc resource get -r $resourceType -f - 2>&1
             
             # Should fail because title doesn't match
             $LASTEXITCODE | Should -Not -Be 0
@@ -151,7 +151,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             $LASTEXITCODE | Should -Be 0            
             $result = $out | ConvertFrom-Json
             $result.actualState.updates[0].isInstalled | Should -BeOfType [bool]
@@ -165,7 +165,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             $LASTEXITCODE | Should -Be 0            
             $result = $out | ConvertFrom-Json
             $result.actualState.updates[0].recommendedHardDiskSpace | Should -BeGreaterOrEqual 0
@@ -179,7 +179,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             $LASTEXITCODE | Should -Be 0            
             $result = $out | ConvertFrom-Json
             $result.actualState.updates[0].kbArticleIds.GetType().BaseType.Name | Should -Be 'Array'
@@ -193,7 +193,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             $LASTEXITCODE | Should -Be 0            
             $result = $out | ConvertFrom-Json
             $result.actualState.updates[0].updateType | Should -BeIn @('Software', 'Driver')
@@ -210,7 +210,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $out = $json | dsc resource get -r $resourceType 2>&1
+                $out = $json | dsc resource get -r $resourceType -f - 2>&1
                 $LASTEXITCODE | Should -Be 0
                 $result = $out | ConvertFrom-Json
                 $result.actualState.updates[0].msrcSeverity | Should -BeExactly $updateWithSeverity.msrcSeverity
@@ -225,7 +225,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
                     
             $LASTEXITCODE | Should -Be 0
             $result = $out | ConvertFrom-Json
@@ -242,7 +242,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
                     
             $LASTEXITCODE | Should -Be 0
             $result = $out | ConvertFrom-Json
@@ -265,7 +265,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $out = $json | dsc resource get -r $resourceType 2>&1
+                $out = $json | dsc resource get -r $resourceType -f - 2>&1
                 
                 $LASTEXITCODE | Should -Be 0
                 $getResult = $out | ConvertFrom-Json
@@ -290,7 +290,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $stderr = $json | dsc resource get -r $resourceType 2>&1
+            $stderr = $json | dsc resource get -r $resourceType -f - 2>&1
             
             # Should fail because second input has no match
             $LASTEXITCODE | Should -Not -Be 0
@@ -312,7 +312,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $out = $json | dsc resource get -r $resourceType 2>&1
+                $out = $json | dsc resource get -r $resourceType -f - 2>&1
                 
                 $LASTEXITCODE | Should -Be 0
                 $getResult = $out | ConvertFrom-Json
@@ -334,7 +334,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $out = $json | dsc resource get -r $resourceType 2>&1
+                $out = $json | dsc resource get -r $resourceType -f - 2>&1
                 
                 $LASTEXITCODE | Should -Be 0
                 $getResult = $out | ConvertFrom-Json
@@ -356,7 +356,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $out = $json | dsc resource get -r $resourceType 2>&1
+                $out = $json | dsc resource get -r $resourceType -f - 2>&1
                 
                 $LASTEXITCODE | Should -Be 0
                 $getResult = $out | ConvertFrom-Json
@@ -374,7 +374,7 @@ Describe 'Windows Update Get operation tests' {
                     }
                 )
             } | ConvertTo-Json -Depth 10 -Compress
-            $out = $json | dsc resource get -r $resourceType 2>&1
+            $out = $json | dsc resource get -r $resourceType -f - 2>&1
             
             $LASTEXITCODE | Should -Be 0
             $result = $out | ConvertFrom-Json
@@ -396,7 +396,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $out = $json | dsc resource get -r $resourceType 2>&1
+                $out = $json | dsc resource get -r $resourceType -f - 2>&1
                 
                 $LASTEXITCODE | Should -Be 0
                 $getResult = $out | ConvertFrom-Json
@@ -424,7 +424,7 @@ Describe 'Windows Update Get operation tests' {
                         }
                     )
                 } | ConvertTo-Json -Depth 10 -Compress
-                $stderr = $json | dsc resource get -r $resourceType 2>&1
+                $stderr = $json | dsc resource get -r $resourceType -f - 2>&1
                 
                 # If multiple updates match isInstalled=true, it should error
                 $installedCount = ($exportOut.updates | Where-Object { $_.isInstalled -eq $true }).Count
@@ -460,7 +460,7 @@ Describe 'Windows Update Get operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $stderr = $json | dsc resource get -r $resourceType 2>&1
+                    $stderr = $json | dsc resource get -r $resourceType -f - 2>&1
                     
                     # This may or may not fail depending on uniqueness
                     if ($LASTEXITCODE -ne 0) {

--- a/resources/WindowsUpdate/tests/windowsupdate_set.tests.ps1
+++ b/resources/WindowsUpdate/tests/windowsupdate_set.tests.ps1
@@ -17,7 +17,7 @@ Describe 'Windows Update Set operation tests' {
     Context 'Set operation' -Skip:(!$isAdmin -or !$IsWindows) {
         It 'should match when both title and id are correct' {
             # Get an actual installed update with both title and id
-            $exportOut = '{"updates": [{"isInstalled": true}]}' | dsc resource export -r $resourceType 2>&1
+            $exportOut = '{"updates": [{"isInstalled": true}]}' | dsc resource export -r $resourceType -f - 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $result = $exportOut | ConvertFrom-Json
@@ -32,7 +32,7 @@ Describe 'Windows Update Set operation tests' {
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
                     # Try to set (should detect already installed)
-                    $out = $json | dsc resource set -r $resourceType 2>&1
+                    $out = $json | dsc resource set -r $resourceType -f - 2>&1
                     
                     if ($LASTEXITCODE -eq 0) {
                         $result = $out | ConvertFrom-Json
@@ -50,7 +50,7 @@ Describe 'Windows Update Set operation tests' {
 
         It 'should fail when title matches but id does not' {
             # Get an actual update
-            $exportOut = '{"updates": []}' | dsc resource export -r $resourceType 2>&1
+            $exportOut = '{"updates": []}' | dsc resource export -r $resourceType -f - 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $result = $exportOut | ConvertFrom-Json
@@ -64,7 +64,7 @@ Describe 'Windows Update Set operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $out = $json | dsc resource set -r $resourceType 2>&1
+                    $out = $json | dsc resource set -r $resourceType -f - 2>&1
                     
                     # Should fail because id doesn't match
                     $LASTEXITCODE | Should -Not -Be 0
@@ -78,7 +78,7 @@ Describe 'Windows Update Set operation tests' {
 
         It 'should fail when id matches but title does not' {
             # Get an actual update
-            $exportOut = '{"updates": []}' | dsc resource export -r $resourceType 2>&1
+            $exportOut = '{"updates": []}' | dsc resource export -r $resourceType -f - 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $result = $exportOut | ConvertFrom-Json
@@ -92,7 +92,7 @@ Describe 'Windows Update Set operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $out = $json | dsc resource set -r $resourceType 2>&1
+                    $out = $json | dsc resource set -r $resourceType -f - 2>&1
                     
                     # Should fail because title doesn't match
                     $LASTEXITCODE | Should -Not -Be 0
@@ -106,7 +106,7 @@ Describe 'Windows Update Set operation tests' {
 
         It 'should verify all inputs have matches before installing' {
             # Get an actual update
-            $exportOut = '{"updates": []}' | dsc resource export -r $resourceType 2>&1
+            $exportOut = '{"updates": []}' | dsc resource export -r $resourceType -f - 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $result = $exportOut | ConvertFrom-Json
@@ -124,7 +124,7 @@ Describe 'Windows Update Set operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $stderr = $json | dsc resource set -r $resourceType 2>&1
+                    $stderr = $json | dsc resource set -r $resourceType -f - 2>&1
                     
                     # Should fail before attempting any installation
                     $LASTEXITCODE | Should -Not -Be 0
@@ -142,7 +142,7 @@ Describe 'Windows Update Set operation tests' {
 
         It 'should process multiple valid input objects' {
             # Get an actual update
-            $exportOut = '{"updates": [{"isInstalled": true}]}' | dsc resource export -r $resourceType 2>&1
+            $exportOut = '{"updates": [{"isInstalled": true}]}' | dsc resource export -r $resourceType -f - 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $result = $exportOut | ConvertFrom-Json
@@ -160,7 +160,7 @@ Describe 'Windows Update Set operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $out = $json | dsc resource set -r $resourceType 2>&1
+                    $out = $json | dsc resource set -r $resourceType -f - 2>&1
                     
                     if ($LASTEXITCODE -eq 0) {
                         $setResult = $out | ConvertFrom-Json
@@ -175,7 +175,7 @@ Describe 'Windows Update Set operation tests' {
 
         It 'should apply logical AND for all criteria in each input' {
             # Get an actual update
-            $exportOut = '{"updates": [{"isInstalled": true}]}' | dsc resource export -r $resourceType 2>&1
+            $exportOut = '{"updates": [{"isInstalled": true}]}' | dsc resource export -r $resourceType -f - 2>&1
             
             if ($LASTEXITCODE -eq 0) {
                 $result = $exportOut | ConvertFrom-Json
@@ -192,7 +192,7 @@ Describe 'Windows Update Set operation tests' {
                             }
                         )
                     } | ConvertTo-Json -Depth 10 -Compress
-                    $out = $json | dsc resource set -r $resourceType 2>&1
+                    $out = $json | dsc resource set -r $resourceType -f - 2>&1
                     
                     if ($LASTEXITCODE -eq 0) {
                         $setResult = $out | ConvertFrom-Json


### PR DESCRIPTION
When invoke_command is called with input = None, the child process previously inherited the parent's stdin handle. In CI environments where the parent has a redirected pipe for stdin, this caused PowerShell child processes to block indefinitely on `$Input` (reading from the inherited pipe that never closes).

The following was able to repro the problem minimally (choose any PS adapted resource):
```
& { while ($true) { Start-Sleep 5 } } | dsc resource export -r Microsoft.Windows.Settings/WindowsSettings
```

The fix sets stdin to Stdio::null() when no input is provided, ensuring the child process sees an immediate EOF rather than inheriting whatever stdin handle the parent holds.

Root cause: commit 1af2c8be changed the PowerShell adapter from "config": "full" to "config": "single", which routes export through a code path that calls invoke_command with no input. Previously, the full-config path always provided input so stdin was always piped.

Also adds:
- Integration test that detects this regression in all environments (terminal and CI) without leaving hanging threads
- A -RustTestFilter parameter to build.ps1 / Test-RustProject to allow running a specific Rust test by name via the build script