### PR TITLE
Update Appx with improved display name and not have entries in Start Menu

### DIFF
--- a/helpers.build.psm1
+++ b/helpers.build.psm1
@@ -1475,7 +1475,7 @@ function Test-Clippy {
             Set-DefaultWorkspaceMemberGroup @workspaceParams
         }
     }
-    
+
     process {
         $clippyFlags = @(
             '--%'
@@ -2087,7 +2087,7 @@ function Build-DscMsixPackage {
             throw 'MSIX requires a specific architecture'
         }
 
-        $displayName = 'DesiredStateConfiguration'
+        $displayName = 'Desired State Configuration'
         $productName = 'DesiredStateConfiguration'
 
         if ($isPreview) {
@@ -2112,10 +2112,10 @@ function Build-DscMsixPackage {
             $productVersion = $productVersion -replace '(\d+)$', "$previewNumber.0"
 
             if ($isPrivate) {
-                $displayName += "-Private"
+                $displayName += " (Private)"
             }
             else {
-                $displayName += "-Preview"
+                $displayName += " (Preview)"
             }
         } else {
             # appx requires a version in the format of major.minor.build.revision with revision being 0

--- a/packaging/msix/AppxManifest.xml
+++ b/packaging/msix/AppxManifest.xml
@@ -36,7 +36,7 @@
           </uap3:AppExecutionAlias>
         </uap3:Extension>
       </Extensions>
-      <uap:VisualElements DisplayName="$DISPLAYNAME$" Description="DesiredStateConfiguration (DSC) enables a declarative model for configuration, also known as configuration as code." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
+      <uap:VisualElements AppListEntry="none" DisplayName="$DISPLAYNAME$" Description="DesiredStateConfiguration (DSC) enables a declarative model for configuration, also known as configuration as code." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
       </uap:VisualElements>
     </Application>
     <Application Id="BicepExt" Executable="dsc-bicep-ext.exe" EntryPoint="Windows.FullTrustApplication">
@@ -47,7 +47,7 @@
           </uap3:AppExecutionAlias>
         </uap3:Extension>
       </Extensions>
-      <uap:VisualElements DisplayName="DSC Bicep Extension" Description="gRPC server for Bicep extensibility with DSC." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
+      <uap:VisualElements AppListEntry="none" DisplayName="DSC Bicep Extension" Description="gRPC server for Bicep extensibility with DSC." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
       </uap:VisualElements>
     </Application>
     <Application Id="Y2J" Executable="y2j.exe" EntryPoint="Windows.FullTrustApplication">
@@ -58,7 +58,7 @@
           </uap3:AppExecutionAlias>
         </uap3:Extension>
       </Extensions>
-      <uap:VisualElements DisplayName="Yaml2Json" Description="Command-line tool to convert to/from YAML and JSON." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
+      <uap:VisualElements AppListEntry="none" DisplayName="Yaml2Json" Description="Command-line tool to convert to/from YAML and JSON." BackgroundColor="transparent" Square150x150Logo="assets\Square150x150Logo.png" Square44x44Logo="assets\Square44x44Logo.png">
       </uap:VisualElements>
     </Application>
   </Applications>


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Use `AppEntryList = "none"` so that those CLI tools aren't added as icons in Start Menu
- Update display name to be `Desired State Configuration` and `Desired State Configuration (Preview)`