### PR TITLE
Fix registry resource manifest copy for packaging

### DIFF
--- a/data.build.json
+++ b/data.build.json
@@ -92,7 +92,7 @@
       "winpsscript.dsc.resource.json",
       "reboot_pending.dsc.resource.json",
       "reboot_pending.resource.ps1",
-      "registry.dsc.resource.json",
+      "registry.dsc.manifests.json",
       "registry.exe",
       "RunCommandOnSet.dsc.resource.json",
       "RunCommandOnSet.exe",
@@ -399,7 +399,7 @@
       ],
       "CopyFiles": {
         "Windows": [
-          "registry.dsc.resource.json"
+          "registry.dsc.manifests.json"
         ]
       }
     },


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

After adding the RegistryList resource and changing the manifest file, didn't update the data for packaging so it fails trying to find the old file when it should be `registry.dsc.manifests.json`
