### PR TITLE
Add explicit arg for enclosing resource path in quotes

### DIFF
--- a/adapters/powershell/PowerShell_adapter.dsc.resource.json
+++ b/adapters/powershell/PowerShell_adapter.dsc.resource.json
@@ -41,7 +41,8 @@
                 "resourceTypeArg": "-ResourceType"
             },
             {
-                "resourcePathArg": "-ResourcePath"
+                "resourcePathArg": "-ResourcePath",
+                "includeQuotes": true
             }
         ],
         "input": "stdin"
@@ -61,7 +62,8 @@
                 "resourceTypeArg": "-ResourceType"
             },
             {
-                "resourcePathArg": "-ResourcePath"
+                "resourcePathArg": "-ResourcePath",
+                "includeQuotes": true
             }
         ],
         "input": "stdin",
@@ -83,7 +85,8 @@
                 "resourceTypeArg": "-ResourceType"
             },
             {
-                "resourcePathArg": "-ResourcePath"
+                "resourcePathArg": "-ResourcePath",
+                "includeQuotes": true
             }
         ],
         "input": "stdin",
@@ -104,7 +107,8 @@
                 "resourceTypeArg": "-ResourceType"
             },
             {
-                "resourcePathArg": "-ResourcePath"
+                "resourcePathArg": "-ResourcePath",
+                "includeQuotes": true
             }
         ],
         "input": "stdin",

--- a/adapters/powershell/Tests/PSAdapted.tests.ps1
+++ b/adapters/powershell/Tests/PSAdapted.tests.ps1
@@ -19,4 +19,19 @@ Describe 'Tests for PS adapted manifests' {
         $out.actualState.Name | Should -BeExactly 'hello' -Because ($out | ConvertTo-Json)
         $out.actualState.Value | Should -Be 42
     }
+
+    It 'Get operation works if adapted resource is in a path with spaces' {
+        $resourcePath = Join-Path -Path $TestDrive -ChildPath 'Path with spaces'
+        New-Item -Path $resourcePath -ItemType Directory | Out-Null
+        Copy-Item -Path (Join-Path -Path $PSScriptRoot -ChildPath 'PSAdaptedTestClassResource*') -Destination $resourcePath
+        $oldPath = $env:PATH
+        try {
+            $env:PATH = $resourcePath + [System.IO.Path]::PathSeparator + $env:PATH
+            $out = dsc resource get -r 'PSAdaptedTestClassResource/PSAdaptedTestClass' -i '{"name":"hello"}' | ConvertFrom-Json
+            $LASTEXITCODE | Should -Be 0
+            $out.actualState.Name | Should -BeExactly 'hello'
+        } finally {
+            $env:PATH = $oldPath
+        }
+    }
 }

--- a/dsc/tests/dsc_adapter.tests.ps1
+++ b/dsc/tests/dsc_adapter.tests.ps1
@@ -183,7 +183,7 @@ Describe 'Tests for adapter support' {
             $out = dsc -l trace resource set -r Adapted/Two -i '{"two":"2"}' 2>$TestDrive/error.log | ConvertFrom-Json -Depth 10
             $errorLog = Get-Content $TestDrive/error.log -Raw
             $LASTEXITCODE | Should -Be 0 -Because $errorLog
-            $errorLog | Should -BeLike '*Invoking command ''dsctest'' with args Some(`["adapter", "--operation", "set", "--input", "{\"two\":\"2\"}", "--resource-type", "Adapted/Two", "--resource-path", "\"*\\adaptedTest.dsc.adaptedResource.json\""`])*' -Because $errorLog
+            $errorLog | Should -BeLike '*Invoking command ''dsctest'' with args Some(`["adapter", "--operation", "set", "--input", "{\"two\":\"2\"}", "--resource-type", "Adapted/Two", "--resource-path", "\"*adaptedTest.dsc.adaptedResource.json\""`])*' -Because $errorLog
             $out.afterState.two | Should -BeExactly 'value2' -Because $errorLog
         }
 

--- a/dsc/tests/dsc_adapter.tests.ps1
+++ b/dsc/tests/dsc_adapter.tests.ps1
@@ -179,6 +179,14 @@ Describe 'Tests for adapter support' {
             $out.schema | Should -Not -BeNullOrEmpty
         }
 
+        It 'Specifying includeQuotes should include quotes for path' {
+            $out = dsc -l trace resource set -r Adapted/Two -i '{"two":"2"}' 2>$TestDrive/error.log | ConvertFrom-Json -Depth 10
+            $errorLog = Get-Content $TestDrive/error.log -Raw
+            $LASTEXITCODE | Should -Be 0 -Because $errorLog
+            $errorLog | Should -BeLike '*Invoking command ''dsctest'' with args Some(`["adapter", "--operation", "set", "--input", "{\"two\":\"2\"}", "--resource-type", "Adapted/Two", "--resource-path", "\"*\\adaptedTest.dsc.adaptedResource.json\""`])*' -Because $errorLog
+            $out.afterState.two | Should -BeExactly 'value2' -Because $errorLog
+        }
+
         It 'Adapted resource with condition false should not be returned' {
             $out = dsc -l debug resource list 'Adapted/Four' 2>$TestDrive/error.log
             $errorLog = Get-Content $TestDrive/error.log -Raw

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -966,7 +966,7 @@ pub fn process_get_args(args: Option<&Vec<GetArgKind>>, input: &str, command_res
             GetArgKind::ResourcePath { resource_path_arg, include_quotes} => {
                 if let Some(path) = &command_resource_info.path {
                     processed_args.push(resource_path_arg.clone());
-                    if include_quotes.unwrap_or(false) {
+                    if *include_quotes {
                         processed_args.push(format!("\"{}\"", path.to_string_lossy()));
                     } else {
                         processed_args.push(path.to_string_lossy().to_string());
@@ -1035,7 +1035,7 @@ fn process_set_delete_args(args: Option<&Vec<SetDeleteArgKind>>, input: &str, co
             SetDeleteArgKind::ResourcePath { resource_path_arg, include_quotes} => {
                 if let Some(path) = &command_resource_info.path {
                     processed_args.push(resource_path_arg.clone());
-                    if include_quotes.unwrap_or(false) {
+                    if *include_quotes {
                         processed_args.push(format!("\"{}\"", path.to_string_lossy()));
                     } else {
                         processed_args.push(path.to_string_lossy().to_string());

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -963,7 +963,7 @@ pub fn process_get_args(args: Option<&Vec<GetArgKind>>, input: &str, command_res
                 processed_args.push(resource_type_arg.clone());
                 processed_args.push(command_resource_info.type_name.to_string());
             },
-            GetArgKind::ResourcePath { resource_path_arg , include_quotes} => {
+            GetArgKind::ResourcePath { resource_path_arg, include_quotes} => {
                 if let Some(path) = &command_resource_info.path {
                     processed_args.push(resource_path_arg.clone());
                     if include_quotes.unwrap_or(false) {
@@ -1032,7 +1032,7 @@ fn process_set_delete_args(args: Option<&Vec<SetDeleteArgKind>>, input: &str, co
                 processed_args.push(json_input_arg.clone());
                 processed_args.push(input.to_string());
             },
-            SetDeleteArgKind::ResourcePath { resource_path_arg , include_quotes} => {
+            SetDeleteArgKind::ResourcePath { resource_path_arg, include_quotes} => {
                 if let Some(path) = &command_resource_info.path {
                     processed_args.push(resource_path_arg.clone());
                     if include_quotes.unwrap_or(false) {

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -963,10 +963,14 @@ pub fn process_get_args(args: Option<&Vec<GetArgKind>>, input: &str, command_res
                 processed_args.push(resource_type_arg.clone());
                 processed_args.push(command_resource_info.type_name.to_string());
             },
-            GetArgKind::ResourcePath { resource_path_arg } => {
+            GetArgKind::ResourcePath { resource_path_arg , include_quotes} => {
                 if let Some(path) = &command_resource_info.path {
                     processed_args.push(resource_path_arg.clone());
-                    processed_args.push(path.to_string_lossy().to_string());
+                    if include_quotes.unwrap_or(false) {
+                        processed_args.push(format!("\"{}\"", path.to_string_lossy()));
+                    } else {
+                        processed_args.push(path.to_string_lossy().to_string());
+                    }
                 }
             },
         }
@@ -1028,10 +1032,14 @@ fn process_set_delete_args(args: Option<&Vec<SetDeleteArgKind>>, input: &str, co
                 processed_args.push(json_input_arg.clone());
                 processed_args.push(input.to_string());
             },
-            SetDeleteArgKind::ResourcePath { resource_path_arg } => {
+            SetDeleteArgKind::ResourcePath { resource_path_arg , include_quotes} => {
                 if let Some(path) = &command_resource_info.path {
                     processed_args.push(resource_path_arg.clone());
-                    processed_args.push(path.to_string_lossy().to_string());
+                    if include_quotes.unwrap_or(false) {
+                        processed_args.push(format!("\"{}\"", path.to_string_lossy()));
+                    } else {
+                        processed_args.push(path.to_string_lossy().to_string());
+                    }
                 }
             },
             SetDeleteArgKind::ResourceType { resource_type_arg } => {

--- a/lib/dsc-lib/src/dscresources/resource_manifest.rs
+++ b/lib/dsc-lib/src/dscresources/resource_manifest.rs
@@ -112,17 +112,17 @@ pub enum GetArgKind {
         /// Indicates if argument is mandatory which will pass an empty string if no JSON input is provided.  Default is false.
         mandatory: Option<bool>,
     },
+    #[serde(rename_all = "camelCase")]
     ResourcePath {
         /// The argument that accepts the resource path.
-        #[serde(rename = "resourcePathArg")]
         resource_path_arg: String,
         /// Indicates if the argument should be wrapped in quotes.  Default is false.
-        #[serde(rename = "includeQuotes")]
-        include_quotes: Option<bool>,
+        #[serde(default)]
+        include_quotes: bool,
     },
+    #[serde(rename_all = "camelCase")]
     ResourceType {
         /// The argument that accepts the resource type name.
-        #[serde(rename = "resourceTypeArg")]
         resource_type_arg: String,
     },
 }
@@ -141,23 +141,23 @@ pub enum SetDeleteArgKind {
         /// Indicates if argument is mandatory which will pass an empty string if no JSON input is provided.  Default is false.
         mandatory: Option<bool>,
     },
+    #[serde(rename_all = "camelCase")]
     ResourcePath {
         /// The argument that accepts the resource path.
-        #[serde(rename = "resourcePathArg")]
         resource_path_arg: String,
         /// Indicates if the resource path should be passed with quotes.  Default is false.
-        #[serde(rename = "includeQuotes")]
-        include_quotes: Option<bool>,
+        #[serde(default)]
+        include_quotes: bool,
     },
+    #[serde(rename_all = "camelCase")]
     ResourceType {
         /// The argument that accepts the resource type name.
-        #[serde(rename = "resourceTypeArg")]
         resource_type_arg: String,
     },
     /// The argument is passed when the resource is invoked in what-if mode.
+    #[serde(rename_all = "camelCase")]
     WhatIf {
         /// The argument to pass when in what-if mode.
-        #[serde(rename = "whatIfArg")]
         what_if_arg: String,
     }
 }

--- a/lib/dsc-lib/src/dscresources/resource_manifest.rs
+++ b/lib/dsc-lib/src/dscresources/resource_manifest.rs
@@ -116,6 +116,7 @@ pub enum GetArgKind {
         /// The argument that accepts the resource path.
         #[serde(rename = "resourcePathArg")]
         resource_path_arg: String,
+        /// Indicates if the argument should be wrapped in quotes.  Default is false.
         #[serde(rename = "includeQuotes")]
         include_quotes: Option<bool>,
     },
@@ -144,6 +145,7 @@ pub enum SetDeleteArgKind {
         /// The argument that accepts the resource path.
         #[serde(rename = "resourcePathArg")]
         resource_path_arg: String,
+        /// Indicates if the resource path should be passed with quotes.  Default is false.
         #[serde(rename = "includeQuotes")]
         include_quotes: Option<bool>,
     },

--- a/lib/dsc-lib/src/dscresources/resource_manifest.rs
+++ b/lib/dsc-lib/src/dscresources/resource_manifest.rs
@@ -116,6 +116,8 @@ pub enum GetArgKind {
         /// The argument that accepts the resource path.
         #[serde(rename = "resourcePathArg")]
         resource_path_arg: String,
+        #[serde(rename = "includeQuotes")]
+        include_quotes: Option<bool>,
     },
     ResourceType {
         /// The argument that accepts the resource type name.
@@ -142,6 +144,8 @@ pub enum SetDeleteArgKind {
         /// The argument that accepts the resource path.
         #[serde(rename = "resourcePathArg")]
         resource_path_arg: String,
+        #[serde(rename = "includeQuotes")]
+        include_quotes: Option<bool>,
     },
     ResourceType {
         /// The argument that accepts the resource type name.

--- a/tools/dsctest/dsctest.dsc.manifests.json
+++ b/tools/dsctest/dsctest.dsc.manifests.json
@@ -966,6 +966,10 @@
           },
           {
             "resourceTypeArg": "--resource-type"
+          },
+          {
+            "resourcePathArg": "--resource-path",
+            "includeQuotes": true
           }
         ]
       },


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

If a PowerShell resource is in a folder that has spaces (like `OneDrive`), then the code flow:

```mermaid
sequenceDiagram
    dsc->>pwsh: pwsh -c powershell.resource.ps1 --resourcePath "c:\users\test\OneDrive - Test\resource.psm1"
    pwsh->>script: powershell.resource.ps1 --resourcePath c:\users\tests\OneDrive - Test\resource.psm1
```

`dsc` sends the path with quotes to `pwsh`, but when `pwsh` receives it, the correct value is sent, but the quotes have been stripped.  So when `pwsh` sends the path to `powershell.resource.ps1` the lack of quotes means it thinks they are positional parameters and fails.

The fix is to introduce a new optional property for:

```json
{
  "resourcePathArg": "--foo",
  "includeQuotes": true
}
```

This will add additional quotes:

```mermaid
sequenceDiagram
    dsc->>pwsh: pwsh -c powershell.resource.ps1 --resourcePath "\"c:\users\test\OneDrive - Test\resource.psm1\""
    pwsh->>script: powershell.resource.ps1 --resourcePath "c:\users\tests\OneDrive - Test\resource.psm1"
```

So when the outer quotes are stripped, the inner quotes remain and get passed correctly to `powershell.resource.ps1`.

The test verifies that the correct escaped inner quotes are sent to the resource process.