### PR TITLE
Fix allowing empty string to be passed to resources

### DIFF
--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -505,4 +505,18 @@ resources:
       $out.results[0].name | Should -Be 'SERVICE-api'
     }
   }
+
+  It 'Expression that cannot be parsed is treated as string literal' {
+    $yaml = @'
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+- name: test
+  type: Microsoft.DSC.Debug/Echo
+  properties:
+    output: ''
+'@
+    $out = dsc config get -i $yaml 2>$TestDrive/error.log | ConvertFrom-Json
+    $LASTEXITCODE | Should -Be 0 -Because (Get-Content $TestDrive/error.log -Raw | Out-String)
+    $out.results[0].result.actualState.output | Should -BeNullOrEmpty
+  }
 }

--- a/dsc/tests/dsc_expressions.tests.ps1
+++ b/dsc/tests/dsc_expressions.tests.ps1
@@ -506,17 +506,21 @@ resources:
     }
   }
 
-  It 'Expression that cannot be parsed is treated as string literal' {
-    $yaml = @'
-$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+  It "Expression that cannot be parsed is treated as string literal: '<expression>'" -TestCases @(
+    @{ expression = '' }
+    @{ expression = ' ' }
+  ) {
+    param($expression)
+    $yaml = @"
+`$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
 - name: test
   type: Microsoft.DSC.Debug/Echo
   properties:
-    output: ''
-'@
+    output: '$expression'
+"@
     $out = dsc config get -i $yaml 2>$TestDrive/error.log | ConvertFrom-Json
     $LASTEXITCODE | Should -Be 0 -Because (Get-Content $TestDrive/error.log -Raw | Out-String)
-    $out.results[0].result.actualState.output | Should -BeNullOrEmpty
+    $out.results[0].result.actualState.output | Should -BeExactly $expression
   }
 }

--- a/lib/dsc-lib/src/parser/mod.rs
+++ b/lib/dsc-lib/src/parser/mod.rs
@@ -56,7 +56,8 @@ impl Statement {
         };
         let root_node = tree.root_node();
         if root_node.is_error() {
-            return Err(DscError::Parser(t!("parser.failedToParseRoot", statement = statement).to_string()));
+            // if root node is error, treat as string literal
+            return Ok(Value::String(statement.to_string()));
         }
         if root_node.kind() != "statement" {
             return Err(DscError::Parser(t!("parser.invalidStatement", statement = statement).to_string()));

--- a/lib/dsc-lib/src/parser/mod.rs
+++ b/lib/dsc-lib/src/parser/mod.rs
@@ -51,13 +51,17 @@ impl Statement {
             return Ok(Value::String(statement.to_string()));
         }
 
+        // if statement is empty or just whitespace, return as string without parsing
+        if statement.trim().is_empty() {
+            return Ok(Value::String(statement.to_string()));
+        }
+
         let Some(tree) = &mut self.parser.parse(statement, None) else {
             return Err(DscError::Parser(t!("parser.failedToParse", statement = statement).to_string()));
         };
         let root_node = tree.root_node();
         if root_node.is_error() {
-            // if root node is error, treat as string literal
-            return Ok(Value::String(statement.to_string()));
+            return Err(DscError::Parser(t!("parser.failedToParseRoot", statement = statement).to_string()));
         }
         if root_node.kind() != "statement" {
             return Err(DscError::Parser(t!("parser.invalidStatement", statement = statement).to_string()));


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The existing code always tries to parse a string as an expression and handles specific cases where it fails to have it as a literal.  In the case like an empty string, the parser fails immediately so there's no chance to pass an empty string. 

The fix checks if the trimmed statement is empty and if so, passes it back as a string literal instead of trying to parse.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1542
