### PR TITLE
Fix Broken Docs Links, Docs Linting and Missing Functions

### DIFF
--- a/docs/concepts/resources/anatomy.md
+++ b/docs/concepts/resources/anatomy.md
@@ -39,7 +39,7 @@ If the JSON file validates against the schema, DSC can use the DSC Resource.
 
 At a minimum, the manifest must define:
 
-- The semantic version (semver) of the DSC resource manifest JSON schema it's compatible with.
+- The semantic version (SemVer) of the DSC resource manifest JSON schema it's compatible with.
 - The fully qualified name of the resource, like `Microsoft.Windows/Registry`. The fully qualified
   name syntax is `<owner>[.<group>][.<area>]/<name>`. The group and area components of the fully
   qualified name enable organizing resources into namespaces.

--- a/docs/concepts/resources/overview.md
+++ b/docs/concepts/resources/overview.md
@@ -138,7 +138,7 @@ Every resource implements the **Get** operation, which retrieves the actual stat
 instance. Use the `dsc resource get` command to invoke the operation.
 
 For example, you can use the `Microsoft.Windows/Registry` resource to get the actual state for a
-registry key value:
+registry key-value:
 
 ```powershell
 dsc resource get --resource Microsoft.Windows/Registry --input '{

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -427,13 +427,13 @@ subject matter experts.
 
 ### `dsc`
 
-The DSC command line tool that invokes resources and manages configuration documents.
+The DSC command-line tool that invokes resources and manages configuration documents.
 
 #### Guidelines
 
-- Specify the term as DSC when discussing the command line tool in general.
+- Specify the term as DSC when discussing the command-line tool in general.
 - Use code formatting when discussing running the command, a specific subcommand, or to distinguish
-  the command line tool from the conceptual platform.
+  the command-line tool from the conceptual platform.
 
 #### Examples
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -64,7 +64,7 @@ DSC differs from PowerShell Desired State Configuration (PSDSC) in a few importa
   PSDSC resources in Windows PowerShell. The resource is included in the DSC install packages for
   Windows only.
 - Because DSC doesn't depend on PowerShell, you can use DSC without PowerShell installed and manage
-  resources written in bash, Python, C#, Rust, or any other language.
+  resources written in Bash, Python, C#, Rust, or any other language.
 - DSC doesn't include a local configuration manager. DSC is invoked as a command. It doesn't
   run as a service.
 - New DSC resources define their schemas with JSON or YAML files, not MOF files. Self-contained

--- a/docs/reference/cli/config/index.md
+++ b/docs/reference/cli/config/index.md
@@ -76,7 +76,7 @@ The data file must contain an object with the `parameters` key. The value of the
 must be an object where each key is the name of a defined parameter and each value is a valid value
 for that parameter.
 
-This option is mutually exclusive with the `--parameters` option.
+This option can be used with the `--parameters` option, where parameters specified with `--parameters` will take precedence over `--parameters-file`.
 
 Starting with DSC version 3.1.0, you can pass the parameters data to a subcommand over stdin. When
 you do, you must pass the configuration document as an input string or the path to a file on the
@@ -108,7 +108,7 @@ The data string must contain an object with the `parameters` key. The value of t
 must be an object where each key is the name of a defined parameter and each value is a valid value
 for that parameter.
 
-This option is mutually exclusive with the `--parameters_file` option.
+This option can be used with the `--parameters_file` option, where parameters specified with `--parameters` will take precedence over `--parameters-file`.
 
 For more information about defining parameters in a configuration document, see
 [DSC Configuration document parameter schema][06]. For more information about using parameters in

--- a/docs/reference/cli/config/index.md
+++ b/docs/reference/cli/config/index.md
@@ -108,7 +108,7 @@ The data string must contain an object with the `parameters` key. The value of t
 must be an object where each key is the name of a defined parameter and each value is a valid value
 for that parameter.
 
-This option can be used with the `--parameters_file` option, where parameters specified with `--parameters` will take precedence over `--parameters-file`.
+This option can be used with the `--parameters-file` option, where parameters specified with `--parameters` will take precedence over `--parameters-file`.
 
 For more information about defining parameters in a configuration document, see
 [DSC Configuration document parameter schema][06]. For more information about using parameters in

--- a/docs/reference/resources/DSC/PackageManagement/Brew/examples/install-a-package-with-brew.md
+++ b/docs/reference/resources/DSC/PackageManagement/Brew/examples/install-a-package-with-brew.md
@@ -9,7 +9,7 @@ title:       Install a package with Brew
 # Install a package with Brew
 
 This example demonstrates how to use the `DSC.PackageManagement/Brew` resource to install a package
-on MacOS systems using Brew.
+on macOS systems using Brew.
 
 ## Test if package is installed
 

--- a/docs/reference/resources/DSC/PackageManagement/Brew/examples/remove-a-package.md
+++ b/docs/reference/resources/DSC/PackageManagement/Brew/examples/remove-a-package.md
@@ -9,7 +9,7 @@ title:       Remove a package with Brew
 # Remove a package with Brew
 
 This example demonstrates how to use the `DSC.PackageManagement/Brew` resource to remove a package
-on MacOS systems using Brew.
+on macOS systems using Brew.
 
 ## Test if package is installed
 

--- a/docs/reference/resources/Microsoft/Adapter/PowerShell/examples/configure-a-machine.md
+++ b/docs/reference/resources/Microsoft/Adapter/PowerShell/examples/configure-a-machine.md
@@ -46,8 +46,9 @@ resources:
 
 ## Setup
 
-This example installs the WinGet software packages for the Windows Terminal and VS Code. The output
-in this example shows the behavior when these packages aren't already installed on the system.
+This example installs the WinGet software packages for the Windows Terminal and Visual Studio Code. 
+The output in this example shows the behavior when these packages aren't already installed on the 
+system.
 
 This example depends on the **Microsoft.WinGet.DSC** PowerShell module at version `1.12.440`. To
 install the module, open a PowerShell session and invoke the following command:

--- a/docs/reference/resources/Microsoft/Adapter/PowerShell/examples/configure-a-machine.md
+++ b/docs/reference/resources/Microsoft/Adapter/PowerShell/examples/configure-a-machine.md
@@ -230,5 +230,5 @@ dsc config --parameters $params set --file dev-tools.dsc.yaml
 ```
 
 <!-- Link references -->
-[01]: ../../../../../../cli/config/test.md
-[02]: ../../../../../../cli/config/set.md
+[01]: ../../../../../cli/config/test.md
+[02]: ../../../../../cli/config/set.md

--- a/docs/reference/resources/Microsoft/Adapter/PowerShell/index.md
+++ b/docs/reference/resources/Microsoft/Adapter/PowerShell/index.md
@@ -198,4 +198,4 @@ failure.
 [04]: /powershell/scripting/install/installing-powershell
 [05]: examples/invoke-a-resource.md
 [06]: examples/configure-a-machine.md
-[07]: ../../../../concepts/type-names.md
+[07]: ../../../../schemas/definitions/resourceType.md

--- a/docs/reference/resources/Microsoft/DSC/Debug/echo/examples/basic-echo-example.md
+++ b/docs/reference/resources/Microsoft/DSC/Debug/echo/examples/basic-echo-example.md
@@ -95,4 +95,4 @@ changedProperties: []
 - [Microsoft.DSC.Debug/Echo resource](../index.md)
 
 <!-- Link reference definitions -->
-[01]: ../../../../../cli/resource/test.md
+[01]: ../../../../../../cli/resource/test.md

--- a/docs/reference/resources/Microsoft/DSC/Debug/echo/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Debug/echo/index.md
@@ -161,7 +161,7 @@ non validating keywords are omitted.
 - [DSC resource capabilities][01]
 
 <!-- Link definitions -->
-[01]: ../../../../../concepts/resources/capabilities.md
-[02]: ../../../../../concepts/resources/properties.md#required-resource-properties
-[03]: ../../../../../concepts/resources/properties.md#key-resource-properties
-[04]: ../../osinfo/index.md
+[01]: ../../../../../../concepts/resources/capabilities.md
+[02]: ../../../../../../concepts/resources/properties.md#required-resource-properties
+[03]: ../../../../../../concepts/resources/properties.md#key-resource-properties
+[04]: ../../../../Microsoft/OSInfo/index.md

--- a/docs/reference/resources/Microsoft/DSC/PowerShell/index.md
+++ b/docs/reference/resources/Microsoft/DSC/PowerShell/index.md
@@ -202,10 +202,10 @@ The resource uses the following exit codes to report success and errors:
 
 ## See also
 
-- [Microsoft.Windows/WindowsPowerShell](../../windows/windowspowershell/resource.md)
+- [Microsoft.Windows/WindowsPowerShell](../../../Microsoft/Windows/WindowsPowerShell/index.md)
 
 <!-- Link references -->
-[01]: ../../../concepts/resources.md#test-operations
-[02]: examples/validate-with-dsc-resource.md
-[03]: examples/validate-in-a-configuration.md
+[01]: ../../../../schemas/definitions/resourceType.md
+[02]: ./examples/invoke-a-resource.md
+[03]: ./examples/configure-a-machine.md
 [04]: cli/osinfo.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/PowerShellScript/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/PowerShellScript/index.md
@@ -263,8 +263,8 @@ to the PowerShell scripts or when the input data is in an unexpected format.
 - [Microsoft.Windows.WindowsPowerShell][05]
 
 <!-- Link definitions -->
-[00]: ../../../../concepts/dsc/resource-capabilities.md
-[01]: ./examples/run-simple-powershell-script.md
+[00]: ../../../../../../concepts/resources/capabilities.md
+[01]: ./examples/run-a-simple-powershell-script.md
 [02]: ./examples/powershell-script-with-input-output.md
 [03]: ../RunCommandOnSet/index.md
 [04]: ../../PowerShell/index.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-a-simple-command.md
@@ -50,4 +50,4 @@ changedProperties: []
 > If you want to capture the output, you should redirect it to a file.
 
 <!-- Link reference definitions -->
-[00]: ../../../../../cli/resource/set.md
+[00]: ../../../../../../cli/resource/set.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/examples/run-powershell-command.md
@@ -74,4 +74,4 @@ winget list --id Microsoft.PowerShell.Preview
 ```
 
 <!-- Link reference definitions -->
-[00]: ../../../../../cli/config/set.md
+[00]: ../../../../../../cli/resource/set.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
@@ -175,6 +175,6 @@ The following snippet contains the JSON Schema that validates an instance of the
 - [Microsoft.DSC.PowerShell](../../PowerShell/index.md)
 - [Microsoft.Windows.WindowsPowerShell](../../../../Microsoft/Windows/WindowsPowerShell/index.md)
 
-[00]: ../../../../../../concepts/resources/capabilities.md#set
+[00]: ../../../../../../concepts/resources/capabilities.md
 [01]: ./examples/run-a-simple-command.md
 [02]: ./examples/run-powershell-command.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/RunCommandOnSet/index.md
@@ -175,6 +175,6 @@ The following snippet contains the JSON Schema that validates an instance of the
 - [Microsoft.DSC.PowerShell](../../PowerShell/index.md)
 - [Microsoft.Windows.WindowsPowerShell](../../../../Microsoft/Windows/WindowsPowerShell/index.md)
 
-[00]: ../../../../concepts/dsc/resource-capabilities.md
+[00]: ../../../../../../concepts/resources/capabilities.md#set
 [01]: ./examples/run-a-simple-command.md
 [02]: ./examples/run-powershell-command.md

--- a/docs/reference/resources/Microsoft/DSC/Transitional/WindowsPowerShellScript/index.md
+++ b/docs/reference/resources/Microsoft/DSC/Transitional/WindowsPowerShellScript/index.md
@@ -259,8 +259,8 @@ to the PowerShell scripts or when the input data is in an unexpected format.
 - [Microsoft.Windows.WindowsPowerShell][04]
 
 <!-- Link definitions -->
-[00]: ../../../../concepts/dsc/resource-capabilities.md
-[01]: ./examples/manage-windows-services-with-powershell.md
+[00]: ../../../../../../concepts/resources/capabilities.md
+[01]: ./examples/manage-windows-service-state-with-powershell.md
 [02]: ../PowerShellScript/index.md
 [03]: ../RunCommandOnSet/index.md
 [04]: ../../../../Microsoft/Windows/WindowsPowerShell/index.md

--- a/docs/reference/resources/Microsoft/Windows/RebootPending/examples/check-for-pending-reboot.md
+++ b/docs/reference/resources/Microsoft/Windows/RebootPending/examples/check-for-pending-reboot.md
@@ -41,7 +41,7 @@ The `rebootPending` property indicates whether the system requires a reboot (`tr
 > operation against the resource and use it in the `Microsoft.Dsc/Assertion` group resource. This
 > resource relies on the synthetic testing provided by DSC. For more information about synthetic
 > testing with DSC, see
-> [DSC resource capabiltiies](../../../../../concepts/resources/capabilities.md#test).
+> [DSC resource capabiltiies](../../../../../../concepts/resources/capabilities.md#test).
 >
 > For an example using this resource in an assertion, see
 > [Use the RebootPending resource in a configuration](./use-rebootpending-in-configuration.md).

--- a/docs/reference/resources/Microsoft/Windows/RebootPending/examples/check-for-pending-reboot.md
+++ b/docs/reference/resources/Microsoft/Windows/RebootPending/examples/check-for-pending-reboot.md
@@ -41,7 +41,7 @@ The `rebootPending` property indicates whether the system requires a reboot (`tr
 > operation against the resource and use it in the `Microsoft.Dsc/Assertion` group resource. This
 > resource relies on the synthetic testing provided by DSC. For more information about synthetic
 > testing with DSC, see
-> [DSC resource capabiltiies](../../../../../../concepts/resources/capabilities.md#test).
+> [DSC resource capabilities](../../../../../../concepts/resources/capabilities.md#test).
 >
 > For an example using this resource in an assertion, see
 > [Use the RebootPending resource in a configuration](./use-rebootpending-in-configuration.md).

--- a/docs/reference/resources/Microsoft/Windows/Registry/index.md
+++ b/docs/reference/resources/Microsoft/Windows/Registry/index.md
@@ -431,7 +431,7 @@ The resource returns the following exit codes from operations:
 - [1](#exit-code-1) - Invalid parameter
 - [2](#exit-code-2) - Invalid input
 - [3](#exit-code-3) - Registry error
-- [4](#exit-code-4) - Json serialization failed
+- [4](#exit-code-4) - JSON serialization failed
 
 ### Exit code 0
 

--- a/docs/reference/resources/Microsoft/Windows/Registry/index.md
+++ b/docs/reference/resources/Microsoft/Windows/Registry/index.md
@@ -471,6 +471,6 @@ Indicates the resource operation failed because the result couldn't be serialize
 [06]: ../../../../../concepts/resources/properties.md#required-resource-properties
 [07]: ../../../../../concepts/resources/properties.md#key-resource-properties
 [08]: ../../../../../concepts/resources/properties.md#read-only-resource-properties
-[09]: /en-us/windows/win32/sysinfo/registry-value-types
+[09]: /windows/win32/sysinfo/registry-value-types
 [10]: ../../osinfo/index.md
 [11]: /windows/win32/sysinfo/about-the-registry

--- a/docs/reference/resources/Microsoft/Windows/WMI/index.md
+++ b/docs/reference/resources/Microsoft/Windows/WMI/index.md
@@ -189,4 +189,4 @@ When the resource returns this exit code, it also emits an error message with de
 <!-- Link definitions -->
 [01]: ./examples/query-operating-system-info.md
 [02]: ./examples/query-filtered-disk-info.md
-[03]: ../../../../schemas/config/type.md
+[03]: ../../../../schemas/definitions/resourceType.md

--- a/docs/reference/resources/Microsoft/Windows/WindowsPowerShell/index.md
+++ b/docs/reference/resources/Microsoft/Windows/WindowsPowerShell/index.md
@@ -251,4 +251,4 @@ When the resource returns this exit code, it also emits an error message with de
 
 <!-- Link definitions -->
 [01]: ./examples/manage-a-windows-service.md
-[02]: ../../../../schemas/config/type.md
+[02]: ../../../../schemas/definitions/resourceType.md

--- a/docs/reference/resources/overview.md
+++ b/docs/reference/resources/overview.md
@@ -5,39 +5,39 @@ This document lists the available resources and links to the reference documenta
 
 ## All built-in resources
 
-- [Microsoft/OSInfo](./microsoft/osinfo/resource.md)
-- [Microsoft.DSC/Assertion](./microsoft/dsc/assertion/resource.md)
-- [Microsoft.DSC/Group](./microsoft/dsc/group/resource.md)
-- [Microsoft.DSC/Include](./microsoft/dsc/include/resource.md)
-- [Microsoft.Adapter/PowerShell](./microsoft/adapter/powershell/index.md)
-- [Microsoft.Adapter/WindowsPowerShell](./microsoft/adapter/windowspowershell/index.md)
-- [Microsoft.DSC/PowerShell](./microsoft/dsc/powershell/resource.md)
-- [Microsoft.DSC.Debug/Echo](./microsoft/dsc/debug/echo/resource.md)
-- [Microsoft.DSC.Transitional/RunCommandOnSet](./microsoft/dsc/transitional/runcomandonset/resource.md)
-- [Microsoft.Windows/RebootPending](./microsoft/windows/rebootpending/resource.md)
-- [Microsoft.Windows/Registry](./microsoft/windows/registry/resource.md)
-- [Microsoft.Windows/WindowsPowerShell](./microsoft/windows/windowspowershell/resource.md)
-- [Microsoft.Windows/WMI](./microsoft/windows/wmi/resource.md)
+- [Microsoft/OSInfo](./Microsoft/OSInfo/index.md)
+- [Microsoft.DSC/Assertion](./Microsoft/DSC/Assertion/index.md)
+- [Microsoft.DSC/Group](./Microsoft/DSC/Group/index.md)
+- [Microsoft.DSC/Include](./Microsoft/DSC/Include/index.md)
+- [Microsoft.Adapter/PowerShell](./Microsoft/Adapter/PowerShell/index.md)
+- [Microsoft.Adapter/WindowsPowerShell](./Microsoft/Adapter/WindowsPowerShell/index.md)
+- [Microsoft.DSC/PowerShell](./Microsoft/DSC/PowerShell/index.md)
+- [Microsoft.DSC.Debug/Echo](./Microsoft/DSC/Debug/echo/index.md)
+- [Microsoft.DSC.Transitional/RunCommandOnSet](./Microsoft/DSC/Transitional/RunCommandOnSet/index.md)
+- [Microsoft.Windows/RebootPending](./Microsoft/Windows/RebootPending/index.md)
+- [Microsoft.Windows/Registry](./Microsoft/Windows/Registry/index.md)
+- [Microsoft.Windows/WindowsPowerShell](./Microsoft/Windows/WindowsPowerShell/index.md)
+- [Microsoft.Windows/WMI](./Microsoft/Windows/WMI/index.md)
 
 ## Built-in assertion resources
 
 You can use the following built-in resources to query the current state of a machine but not to
 change the state of the machine directly:
 
-- [Microsoft/OSInfo](./microsoft/osinfo/resource.md)
-- [Microsoft.DSC/Assertion](./microsoft/dsc/assertion/resource.md)
-- [Microsoft.Windows/RebootPending](./microsoft/windows/rebootpending/resource.md)
+- [Microsoft/OSInfo](./Microsoft/OSInfo/index.md)
+- [Microsoft.DSC/Assertion](./Microsoft/DSC/Assertion/index.md)
+- [Microsoft.Windows/RebootPending](./Microsoft/Windows/RebootPending/index.md)
 
 ## Built-in adapter resources
 
 You can use the following built-in resources to leverage resources that don't define a DSC Resource
 Manifest:
 
-- [Microsoft.Adapter/PowerShell](./microsoft/adapter/powershell/index.md)
-- [Microsoft.Adapter/WindowsPowerShell](./microsoft/adapter/windowspowershell/index.md)
-- [Microsoft.DSC/PowerShell](./microsoft/dsc/powershell/index.md)
-- [Microsoft.Windows/WindowsPowerShell](./microsoft/windows/windowspowershell/index.md)
-- [Microsoft.Windows/WMI](./microsoft/windows/wmi/resource.md)
+- [Microsoft.Adapter/PowerShell](./Microsoft/Adapter/PowerShell/index.md)
+- [Microsoft.Adapter/WindowsPowerShell](./Microsoft/Adapter/WindowsPowerShell/index.md)
+- [Microsoft.DSC/PowerShell](./Microsoft/DSC/PowerShell/index.md)
+- [Microsoft.Windows/WindowsPowerShell](./Microsoft/windows/windowspowershell/index.md)
+- [Microsoft.Windows/WMI](./Microsoft/windows/wmi/index.md)
 
 > [!WARNING]
 > `Microsoft.DSC/PowerShell` and `Microsoft.Windows/WindowsPowerShell` will be deprecated in a
@@ -48,21 +48,21 @@ Manifest:
 
 The following built-in resources to change the state of a machine directly:
 
-- [Microsoft.DSC.Transitional/RunCommandOnSet](./microsoft/dsc/transitional/runcomandonset/resource.md)
-- [Microsoft.Windows/Registry](./microsoft/windows/registry/resource.md)
+- [Microsoft.DSC.Transitional/RunCommandOnSet](./Microsoft/DSC/Transitional/RunCommandOnSet/index.md)
+- [Microsoft.Windows/Registry](./Microsoft/Windows/Registry/index.md)
 
 ## Built-in debugging resources
 
 You can use the following built-in resources when debugging or exploring DSC. They don't affect
 the state of the machine.
 
-- [Microsoft.DSC.Debug/Echo](./microsoft/dsc/debug/echo/resource.md)
+- [Microsoft.DSC.Debug/Echo](./Microsoft/DSC/Debug/echo/index.md)
 
 ## Built-in group resources
 
 You can use the following built-in resources to change how DSC processes a group of nested resource
 instances:
 
-- [Microsoft.DSC/Assertion](./microsoft/dsc/assertion/resource.md)
-- [Microsoft.DSC/Group](./microsoft/dsc/group/resource.md)
-- [Microsoft.DSC/Include](./microsoft/dsc/include/resource.md)
+- [Microsoft.DSC/Assertion](./Microsoft/DSC/Assertion/index.md)
+- [Microsoft.DSC/Group](./Microsoft/DSC/Group/index.md)
+- [Microsoft.DSC/Include](./Microsoft/DSC/Include/index.md)

--- a/docs/reference/resources/overview.md
+++ b/docs/reference/resources/overview.md
@@ -36,8 +36,8 @@ Manifest:
 - [Microsoft.Adapter/PowerShell](./Microsoft/Adapter/PowerShell/index.md)
 - [Microsoft.Adapter/WindowsPowerShell](./Microsoft/Adapter/WindowsPowerShell/index.md)
 - [Microsoft.DSC/PowerShell](./Microsoft/DSC/PowerShell/index.md)
-- [Microsoft.Windows/WindowsPowerShell](./Microsoft/windows/windowspowershell/index.md)
-- [Microsoft.Windows/WMI](./Microsoft/windows/wmi/index.md)
+- [Microsoft.Windows/WindowsPowerShell](./Microsoft/Windows/WindowsPowerShell/index.md)
+- [Microsoft.Windows/WMI](./Microsoft/Windows/WMI/index.md)
 
 > [!WARNING]
 > `Microsoft.DSC/PowerShell` and `Microsoft.Windows/WindowsPowerShell` will be deprecated in a

--- a/docs/reference/schemas/config/document.md
+++ b/docs/reference/schemas/config/document.md
@@ -71,7 +71,7 @@ semantic version, the latest schema for a minor version, or the latest schema fo
 of DSC. For more information about schema URIs and versioning, see
 [DSC JSON Schema URIs](../schema-uris.md).
 
-For every version of the schema, there are three valid urls:
+For every version of the schema, there are three valid URLs:
 
 - `.../config/document.json`
 
@@ -93,7 +93,7 @@ For every version of the schema, there are three valid urls:
   it includes additional definitions that provide contextual help and snippets that the others
   don't include.
 
-  This schema uses keywords that are only recognized by VS Code. While DSC can still validate the
+  This schema uses keywords that are only recognized by Visual Studio Code. While DSC can still validate the
   document when it uses this schema, other tools may error or behave in unexpected ways.
 
 ```yaml
@@ -164,7 +164,7 @@ defined as key-value pair. The key for each pair defines the name of the paramet
 each pair must be an object that defines the `type` keyword to indicate how DSC should process the
 parameter.
 
-Parameters may be overridden at run-time, enabling re-use of the same configuration document for
+Parameters may be overridden at runtime, enabling re-use of the same configuration document for
 different contexts.
 
 For more information about defining parameters in a configuration, see
@@ -187,7 +187,7 @@ the variable by name can access the variable's value.
 
 This can help reduce the amount of copied values and options for resources in the configuration,
 which makes the document easier to read and maintain. Unlike parameters, variables can only be
-defined in the configuration and can't be overridden at run-time.
+defined in the configuration and can't be overridden at runtime.
 
 <!-- For more information about using variables in a configuration, see
 [DSC Configuration variables][04]. -->

--- a/docs/reference/schemas/config/functions/array.md
+++ b/docs/reference/schemas/config/functions/array.md
@@ -173,7 +173,7 @@ Type: array
 ## Related functions
 
 - [`createArray()`][00] - Creates a homogeneous array (all elements same type)
-- [`createObject()`][01] - Builds an object from key/value pairs
+- [`createObject()`][01] - Builds an object from key-value pairs
 - [`first()`][02] - Gets the first element from an array
 - [`indexOf()`][03] - Finds the index of an item in an array
 

--- a/docs/reference/schemas/config/functions/envvar.md
+++ b/docs/reference/schemas/config/functions/envvar.md
@@ -82,4 +82,4 @@ The `envvar()` function returns the value of the environment variable specified 
 Type: string
 ```
 
-[01]: ../../../cli/config/command.md#environment-variables
+[01]: ../../../cli/config/index.md#environment-variables

--- a/docs/reference/schemas/config/functions/items.md
+++ b/docs/reference/schemas/config/functions/items.md
@@ -23,8 +23,7 @@ The `items()` function converts a dictionary object to an array of key-value pai
   property name) and `value` (the property value).
 
 This function is useful for iterating over object properties in DSC configurations,
-especially when used with loops. It's the companion function to [`toObject()`][03],
-which converts an array back to an object.
+especially when used with loops.
 
 ## Examples
 
@@ -197,10 +196,8 @@ Type: array
 
 - [`createObject()`][00] - Creates an object from key-value pairs
 - [`length()`][01] - Returns the number of elements in an array or object
-- [`toObject()`][03] - Converts an array of key-value pairs to an object
 
 <!-- Link reference definitions -->
 [00]: ./createObject.md
 [01]: ./length.md
 [02]: ./copyIndex.md
-[03]: ./toObject.md

--- a/docs/reference/schemas/config/functions/join.md
+++ b/docs/reference/schemas/config/functions/join.md
@@ -28,7 +28,7 @@ The `delimiter` can be any value; it’s converted to a string.
 
 ### Example 1 - Produce a list of servers
 
-Create a comma-separated string from a list of host names to pass to tools or
+Create a comma-separated string from a list of hostnames to pass to tools or
 APIs that accept CSV input. This example uses [`createArray()`][02] to build
 the server list and joins with ", ".
 

--- a/docs/reference/schemas/config/functions/last.md
+++ b/docs/reference/schemas/config/functions/last.md
@@ -151,43 +151,6 @@ hadErrors: false
 The function returns `1704326400`, which represents the most recent backup in
 the chronologically sorted array.
 
-### Example 4 - Combine with other functions for complex logic
-
-Use `last()` together with [`split()`][02] to extract file extensions or path
-components. This example demonstrates parsing a filename to get its extension.
-
-```yaml
-# last.example.4.dsc.config.yaml
-$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
-resources:
-- name: File Extension Parser
-  type: Microsoft.DSC.Debug/Echo
-  properties:
-    output:
-      filename: config.production.yaml
-      extension: "[last(split('config.production.yaml', '.'))]"
-```
-
-```bash
-dsc config get --file last.example.4.dsc.config.yaml
-```
-
-```yaml
-results:
-- name: File Extension Parser
-  type: Microsoft.DSC.Debug/Echo
-  result:
-    actualState:
-      output:
-        filename: config.production.yaml
-        extension: yaml
-messages: []
-hadErrors: false
-```
-
-By combining `split()` and `last()`, you can extract the `yaml` extension from
-the full filename.
-
 ## Parameters
 
 ### arg
@@ -222,10 +185,8 @@ The function returns an error in the following cases:
 ## Related functions
 
 - [`first()`][00] - Returns the first element of an array or character of a string
-- [`split()`][02] - Splits a string into an array
 - [`createArray()`][01] - Creates an array from provided values
 
 <!-- Link reference definitions -->
 [00]: ./first.md
 [01]: ./createArray.md
-[02]: ./split.md

--- a/docs/reference/schemas/config/functions/objectKeys.md
+++ b/docs/reference/schemas/config/functions/objectKeys.md
@@ -296,5 +296,5 @@ The function will return an error in the following cases:
 [00]: ./items.md
 [01]: ./length.md
 [02]: ./contains.md
-[03]: ../document/copy.md
+[03]: ./copy.md
 [04]: ./createObject.md

--- a/docs/reference/schemas/config/functions/overview.md
+++ b/docs/reference/schemas/config/functions/overview.md
@@ -247,7 +247,7 @@ messages: []
 hadErrors: false
 ```
 
-### Example 4 - Access object properties and array items
+### Example 4 - Access object properties and array elements
 
 The following configuration documents show how you can access the properties of objects and items
 in arrays. The example uses a shared parameter definition file to make it easier to reference a

--- a/docs/reference/schemas/config/functions/overview.md
+++ b/docs/reference/schemas/config/functions/overview.md
@@ -247,7 +247,7 @@ messages: []
 hadErrors: false
 ```
 
-### Example 4 - Access object properties and array elements
+### Example 4 - Access object properties and array items
 
 The following configuration documents show how you can access the properties of objects and items
 in arrays. The example uses a shared parameter definition file to make it easier to reference a

--- a/docs/reference/schemas/config/functions/parameters.md
+++ b/docs/reference/schemas/config/functions/parameters.md
@@ -110,5 +110,5 @@ Type: [string, int, bool, object, array]
 
 <!-- Link reference definitions -->
 [01]: ../parameter.md
-[02]: ../../../cli/config/index.md#-p---parameters
-[03]: ../../../cli/config/index.md#-f---parameters_file
+[02]: ../../../cli/config/index.md#--parameters
+[03]: ../../../cli/config/index.md#--parameters-file

--- a/docs/reference/schemas/config/functions/parameters.md
+++ b/docs/reference/schemas/config/functions/parameters.md
@@ -110,5 +110,5 @@ Type: [string, int, bool, object, array]
 
 <!-- Link reference definitions -->
 [01]: ../parameter.md
-[02]: ../../../cli/config/command.md#-p---parameters
-[03]: ../../../cli/config/command.md#-f---parameters_file
+[02]: ../../../cli/config/index.md#-p---parameters
+[03]: ../../../cli/config/index.md#-f---parameters_file

--- a/docs/reference/schemas/config/functions/path.md
+++ b/docs/reference/schemas/config/functions/path.md
@@ -35,7 +35,7 @@ resources:
     - name: Simple Path Construct
       type: Microsoft.DSC.Debug/Echo
       properties:
-      output: "[path('C:\\Program Files', 'WindowsPowerShell')]"
+        output: "[path('C:\\Program Files', 'WindowsPowerShell')]"
 ```
 
 ```bash

--- a/docs/reference/schemas/config/functions/path.md
+++ b/docs/reference/schemas/config/functions/path.md
@@ -20,7 +20,7 @@ path(<path>, <child_path>, ...)
 ## Description
 
 The `path()` function takes a base path and any number of child items to combine
-into a single path, acounting for duplicate `/` characters. 
+into a single path, accounting for duplicate `/` characters. 
 
 ## Examples
 
@@ -33,9 +33,9 @@ This configuration constructs a simple absolute path of two elements.
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
     - name: Simple Path Construct
-        type: Microsoft.DSC.Debug/Echo
-        properties:
-        output: "[path('C:\\Program Files', 'WindowsPowerShell')]"
+      type: Microsoft.DSC.Debug/Echo
+      properties:
+      output: "[path('C:\\Program Files', 'WindowsPowerShell')]"
 ```
 
 ```bash
@@ -51,8 +51,6 @@ results:
       output: C:\Program Files\WindowsPowerShell
 messages: []
 hadErrors: false
-messages: []
-hadErrors: false
 ```
 
 ### Example 2 - Relative path with multiple elements
@@ -64,9 +62,9 @@ This configuration constructs a simple relative path of three elements.
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
     - name: Relative Path
-        type: Microsoft.DSC.Debug/Echo
-        properties:
-        output: "[path('.\\usr', 'bin', 'bash')]"
+      type: Microsoft.DSC.Debug/Echo
+      properties:
+      output: "[path('.\\usr', 'bin', 'bash')]"
 ```
 
 ```bash
@@ -82,8 +80,6 @@ results:
       output: .\usr\bin\bash
 messages: []
 hadErrors: false
-messages: []
-hadErrors: false
 ```
 
 ### Example 3 - Relative element in path
@@ -97,13 +93,13 @@ The path is returned as-is and is not resolved to an absolute path.
 $schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
 resources:
     - name: Double Dot Path
-        type: Microsoft.DSC.Debug/Echo
-        properties:
-        output: "[path('parent', '..', 'child')]"
+      type: Microsoft.DSC.Debug/Echo
+      properties:
+      output: "[path('parent', '..', 'child')]"
 ```
 
 ```bash
-dsc config get --file doubleDot.example.2.dsc.config.yaml
+dsc config get --file doubleDot.example.3.dsc.config.yaml
 ```
 
 ```yaml
@@ -115,8 +111,6 @@ results:
       output: parent\..\child
 messages: []
 hadErrors: false
-messages: []
-hadErrors: false
 ```
 
 ## Parameters
@@ -126,7 +120,8 @@ hadErrors: false
 The `path()` function expects at least two arguments, a base path and at 
 least one child. 
 
-The base path can be a absolute (e.g., `C:\Windows\Sytstem32`), relative (e.g., `./System32`) or Universal Naming Convention (UNC) (e.g., `\\server1\c$\Windows`).
+The base path can be an absolute (e.g., `C:\Windows\System32`, `\usr\bin`), relative (e.g., `./System32`) or 
+Universal Naming Convention (UNC) (e.g., `\\server1\c$\Windows`).
 
 ```yaml
 Type:         string
@@ -148,7 +143,7 @@ MaximumCount: 18446744073709551615
 
 Returns the concatenated path, made from the provided elements.
 
-There are slight differences in return value depending on the OS(e.g., path seperators, drive letters).
+There are slight differences in return value depending on the OS (e.g., path separators, drive letters).
 
 ```yaml
 Type: string

--- a/docs/reference/schemas/config/functions/path.md
+++ b/docs/reference/schemas/config/functions/path.md
@@ -1,0 +1,170 @@
+---
+description: Reference for the 'path' DSC configuration document function
+ms.date:     06/04/2025
+ms.topic:    reference
+title:       path
+---
+
+# path
+
+## Synopsis
+
+Construct a file system path from one or more path segments
+
+## Syntax
+
+```Syntax
+path(<path>, <child_path>, ...)
+```
+
+## Description
+
+The `path()` function takes a base path and any number of child items to combine
+into a single path, acounting for duplicate `/` characters. 
+
+## Examples
+
+### Example 1 - Construct with child path
+
+This configuration constructs a simple absolute path of two elements. 
+
+```yaml
+# parseChildPath.example.1.dsc.config.yaml
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+    - name: Simple Path Construct
+        type: Microsoft.DSC.Debug/Echo
+        properties:
+        output: "[path('C:\\Program Files', 'WindowsPowerShell')]"
+```
+
+```bash
+dsc config get --file parseChildPath.example.1.dsc.config.yaml
+```
+
+```yaml
+results:
+- name: Simple Path Construct
+  type: Microsoft.DSC.Debug/Echo
+  result:
+    actualState:
+      output: C:\Program Files\WindowsPowerShell
+messages: []
+hadErrors: false
+messages: []
+hadErrors: false
+```
+
+### Example 2 - Relative path with multiple elements
+
+This configuration constructs a simple relative path of three elements. 
+
+```yaml
+# relativePath.example.2.dsc.config.yaml
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+    - name: Relative Path
+        type: Microsoft.DSC.Debug/Echo
+        properties:
+        output: "[path('.\\usr', 'bin', 'bash')]"
+```
+
+```bash
+dsc config get --file relativePath.example.2.dsc.config.yaml
+```
+
+```yaml
+results:
+- name: Relative Path
+  type: Microsoft.DSC.Debug/Echo
+  result:
+    actualState:
+      output: .\usr\bin\bash
+messages: []
+hadErrors: false
+messages: []
+hadErrors: false
+```
+
+### Example 3 - Relative element in path
+
+This configuration constructs a path with a double dot in that path. 
+
+The path is returned as-is and is not resolved to an absolute path.
+
+```yaml
+# doubleDot.example.3.dsc.config.yaml
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+    - name: Double Dot Path
+        type: Microsoft.DSC.Debug/Echo
+        properties:
+        output: "[path('parent', '..', 'child')]"
+```
+
+```bash
+dsc config get --file doubleDot.example.2.dsc.config.yaml
+```
+
+```yaml
+results:
+- name: Double Dot Path
+  type: Microsoft.DSC.Debug/Echo
+  result:
+    actualState:
+      output: parent\..\child
+messages: []
+hadErrors: false
+messages: []
+hadErrors: false
+```
+
+## Parameters
+
+### path
+
+The `path()` function expects at least two arguments, a base path and at 
+least one child. 
+
+The base path can be a absolute (e.g., `C:\Windows\Sytstem32`), relative (e.g., `./System32`) or Universal Naming Convention (UNC) (e.g., `\\server1\c$\Windows`).
+
+```yaml
+Type:         string
+Required:     true
+Position:     1
+```
+### child
+
+The `path()` function expects at least one child path to be supplied.
+
+```yaml
+Type:         string
+Required:     true
+MinimumCount: 1
+MaximumCount: 18446744073709551615
+```
+
+## Output
+
+Returns the concatenated path, made from the provided elements.
+
+There are slight differences in return value depending on the OS(e.g., path seperators, drive letters).
+
+```yaml
+Type: string
+```
+
+## Errors
+
+The function returns an error in the following cases:
+
+- **Invalid type**: Any argument is not a string
+
+## Related functions
+
+- [`join()`][01] - Joins an array into a single string, separated using a delimiter.
+- [`uri()`][02] - Creates an absolute URI by combining the baseUri and the relativeUri string.
+
+<!-- Link reference definitions -->
+[01]: ./join.md
+[02]: ./uri.md

--- a/docs/reference/schemas/config/functions/path.md
+++ b/docs/reference/schemas/config/functions/path.md
@@ -64,7 +64,7 @@ resources:
     - name: Relative Path
       type: Microsoft.DSC.Debug/Echo
       properties:
-      output: "[path('.\\usr', 'bin', 'bash')]"
+        output: "[path('.\\usr', 'bin', 'bash')]"
 ```
 
 ```bash
@@ -95,7 +95,7 @@ resources:
     - name: Double Dot Path
       type: Microsoft.DSC.Debug/Echo
       properties:
-      output: "[path('parent', '..', 'child')]"
+        output: "[path('parent', '..', 'child')]"
 ```
 
 ```bash
@@ -117,11 +117,12 @@ hadErrors: false
 
 ### path
 
-The `path()` function expects at least two arguments, a base path and at 
-least one child. 
+Defines the base path that the function appends child path segments to. The base path must be a
+string value. It can be any of the following kinds of paths:
 
-The base path can be an absolute (e.g., `C:\Windows\System32`, `\usr\bin`), relative (e.g., `./System32`) or 
-Universal Naming Convention (UNC) (e.g., `\\server1\c$\Windows`).
+- Absolute, like `C:\Windows\System32` or `/usr/bin`
+- Relative, like `.\infrastructure` or `../compliance/pci`
+- Universal Naming Convention (UNC), such as `\\server1\c$\Windows`
 
 ```yaml
 Type:         string
@@ -130,7 +131,19 @@ Position:     1
 ```
 ### child
 
-The `path()` function expects at least one child path to be supplied.
+Defines the child path segments the function appends to the base path. The function expects at
+least one child path segment. Every child path segment must be a string value.
+
+The function appends each segment to the output path in the order that you specify them. The
+function inserts the operating system's path separator (`\` on Windows, `/` on Linux and macOS)
+between each defined segment unless the segment has a trailing forward slash (`/`).
+
+> [!NOTE]
+> On Windows systems, when you specify any absolute path as a child path segment, like `C:\dsc`,
+> the function _replaces_ the currently constructed path with that absolute path segment.
+>
+> For example, `[path('./a', 'b', 'C:\', 'd')]` resolves to `C:\d` on Windows and `./a/b/C:\/d`
+> on non-Windows systems.
 
 ```yaml
 Type:         string
@@ -143,7 +156,17 @@ MaximumCount: 18446744073709551615
 
 Returns the concatenated path, made from the provided elements.
 
-There are slight differences in return value depending on the OS (e.g., path separators, drive letters).
+The output path for the same input depends on the operating systems:
+
+- The function uses the operating system's defined path separator for appending child path segments
+  to the base path (`\` for Windows and `/` for Linux and macOS).
+  
+  For example, `[path('a', 'b', 'c')]` resolves to `a\b\c` on Windows and `a/b/c` on Linux and macOS.
+- On Windows, specifying a child path segment that begins with a drive letter _replaces_ the
+  constructed path instead of appending to it.
+  
+  For example, `[path('./a', 'b', 'C:\', 'd')]` resolves to `C:\d` on Windows and `./a/b/C:\/d`
+  on non-Windows systems.
 
 ```yaml
 Type: string

--- a/docs/reference/schemas/config/functions/resourceId.md
+++ b/docs/reference/schemas/config/functions/resourceId.md
@@ -105,7 +105,7 @@ Position: 0
 
 <!-- Link reference definitions -->
 [01]: ../resource.md#dependson
-[02]: /powershell/dsc/glossary#nested-resource-instance
+[02]: ../../../../glossary.md#nested-resource-instance
 [03]: ../resource.md#type
 [04]: ../../definitions/resourceType.md
 [05]: ../resource.md#name

--- a/docs/reference/schemas/config/functions/secret.md
+++ b/docs/reference/schemas/config/functions/secret.md
@@ -22,8 +22,8 @@ secret(<secretName>, [vaultName])
 The `secret()` function searches secret extensions for a secret with the provided name. You must
 pass a name of a valid secret that exists in at least one extension. 
 
-If more than one secret exists with the name and a different value, an error will be raised. If
-all the duplicate secrets share a value, it will return that value.
+If more than one secret exists with the same name and a different value, the function raises an
+error. If every duplicate secret has the same value, the function returns that value.
 
 ## Examples
 
@@ -71,8 +71,10 @@ Position: 1
 
 ### vaultName
 
-The name of the vault to retrieve the secret from. The implementation of the is dependent on the
-secret extension and may not be required.
+The name of the vault to retrieve the secret from. When you don't specify a value for this
+parameter DSC requests the secret by name from every vault registered with every secret extension.
+When you specify this parameter DSC requests the secret from the given vault by name for every
+secret extension.
 
 ```yaml
 Type:     string
@@ -83,6 +85,14 @@ Position: 2
 ## Output
 
 The `secret()` function returns the value of the secret as a string.
+
+> [!IMPORTANT]
+> DSC returns the value as a `string` (`"<secret>"`) rather than wrapping the value as a
+> `secureString` (`{"secureString": "<secret>"}`) to simplify passing the value to resources.
+>
+> DSC doesn't emit this value into its trace messaging but cannot guarantee that the resource won't
+> emit a secret in messages or output. Always review resource behavior that relies on secret
+> values.
 
 ```yaml
 Type: string

--- a/docs/reference/schemas/config/functions/secret.md
+++ b/docs/reference/schemas/config/functions/secret.md
@@ -1,4 +1,4 @@
---
+---
 description: Reference for the 'secret' DSC configuration document function
 ms.date:     06/04/2025
 ms.topic:    reference

--- a/docs/reference/schemas/config/functions/secret.md
+++ b/docs/reference/schemas/config/functions/secret.md
@@ -1,0 +1,102 @@
+--
+description: Reference for the 'secret' DSC configuration document function
+ms.date:     06/04/2025
+ms.topic:    reference
+title:       secret
+---
+
+# secret
+
+## Synopsis
+
+Retrieves a secret from a vault.
+
+## Syntax
+
+```Syntax
+secret(<secretName>, [vaultName])
+```
+
+## Description
+
+The `secret()` function searches secret extensions for a secret with the provided name. You must
+pass a name of a valid secret that exists in at least one extension. 
+
+If more than one secret exists with the name and a different value, an error will be raised. If
+all the duplicate secrets share a value, it will return that value.
+
+## Examples
+
+### Example 1 - Echo a secret's value
+
+The configuration uses the `secret()` function to query from secret extensions and echo the value
+of the secret.
+
+```yaml
+# secret.example.1.dsc.config.yaml
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Echo secret value
+    type: Microsoft.DSC.Debug/Echo
+    properties:
+      output: "[secret('mySecretName')]"
+```
+
+```bash
+dsc config get --file secret.example.1.dsc.config.yaml
+```
+
+```yaml
+results:
+- name: Echo secret value
+  type: Microsoft.DSC.Debug/Echo
+  result:
+    actualState:
+      output: Password123!
+messages: []
+hadErrors: false
+```
+
+## Parameters
+
+### secretName
+
+The name of the secret to retrieve.
+
+```yaml
+Type:     string
+Required: true
+Position: 1
+```
+
+### vaultName
+
+The name of the vault to retrieve the secret from. The implementation of the is dependent on the
+secret extension and may not be required.
+
+```yaml
+Type:     string
+Required: false
+Position: 2
+```
+
+## Output
+
+The `secret()` function returns the value of the secret as a string.
+
+```yaml
+Type: string
+```
+
+## Errors
+
+The function returns an error in the following cases:
+
+- **Invalid type**: Any argument is not a string
+- **No extensions**: There are no secret extensions available
+- **Multiple secrets**: Multiple secrets with the same name but different values were returned
+- **Extension returned error**: A secret extension returned an error during the query
+- **Secret not found**: No secret was found 
+
+<!-- Link reference definitions -->
+[01]: ../../../schemas/extension/manifest/discover.md

--- a/docs/reference/schemas/config/functions/string.md
+++ b/docs/reference/schemas/config/functions/string.md
@@ -246,7 +246,7 @@ Type: string
 - [`concat()`][00] - Concatenates strings together
 - [`int()`][01] - Converts a string to an integer
 - [`bool()`][02] - Converts a string to a boolean
-- [`base64()`][03] - Encodes a string to Base64 format
+- [`base64()`][03] - Encodes a string to base64 format
 - [`length()`][04] - Returns the length of a string
 
 <!-- Link reference definitions -->

--- a/docs/reference/schemas/config/functions/systemRoot.md
+++ b/docs/reference/schemas/config/functions/systemRoot.md
@@ -1,0 +1,98 @@
+--
+description: Reference for the 'systemRoot' DSC configuration document function
+ms.date:     06/04/2025
+ms.topic:    reference
+title:       systemRoot
+---
+
+# systemRoot
+
+## Synopsis
+
+Returns the system root path.
+
+## Syntax
+
+```Syntax
+systemRoot()
+```
+
+## Description
+
+The `systemRoot()` function returns the value of the system root path[01].
+
+## Examples
+
+### Example 1 - Get the current system root
+
+The configuration uses the `systemRoot()` function to echo the current system root.
+
+```yaml
+# systemRoot.example.1.dsc.config.yaml
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Echo system root
+    type: Microsoft.DSC.Debug/Echo
+    properties:
+      output: "[systemRoot()]"
+```
+
+```bash
+dsc config get --file systemRoot.example.1.dsc.config.yaml
+```
+
+```yaml
+results:
+- name: Echo system root
+  type: Microsoft.DSC.Debug/Echo
+  result:
+    actualState:
+      output: C:\
+messages: []
+hadErrors: false
+```
+
+### Example 2 - Construct and override the system root path
+
+The configuration uses the `path()`[02] function to construct a path pf the `systemRoot()`, which 
+is overriden using in the command line.
+
+```yaml
+# joinSystemRoot.example.2.dsc.config.yaml
+$schema: https://aka.ms/dsc/schemas/v3/bundled/config/document.json
+resources:
+  - name: Echo system home
+    type: Microsoft.DSC.Debug/Echo
+    properties:
+      output: "[path(systemRoot(), 'home')]"
+```
+
+```bash
+dsc config ---system-root / get --file joinSystemRoot.example.2.dsc.config.yaml
+```
+
+```yaml
+results:
+- name: Echo system home
+  type: Microsoft.DSC.Debug/Echo
+  result:
+    actualState:
+      output: /home
+messages: []
+hadErrors: false
+```
+
+## Output
+
+The `systemRoot()` function returns the system root of the current host, or the value overriden
+using the `--system-root` command line flag[01].
+
+This is usually `C:\` on Windows system and `/` on Unix systems.
+
+```yaml
+Type: [string, int, bool, object, array]
+```
+
+<!-- Link reference definitions -->
+[01]: ../../../cli/config/index.md#-r---system-root
+[02]: ./path.md

--- a/docs/reference/schemas/config/functions/systemRoot.md
+++ b/docs/reference/schemas/config/functions/systemRoot.md
@@ -1,4 +1,4 @@
---
+---
 description: Reference for the 'systemRoot' DSC configuration document function
 ms.date:     06/04/2025
 ms.topic:    reference
@@ -90,7 +90,7 @@ using the `--system-root` command line flag[01].
 This is usually `C:\` on Windows system and `/` on Unix systems.
 
 ```yaml
-Type: [string, int, bool, object, array]
+Type: string
 ```
 
 <!-- Link reference definitions -->

--- a/docs/reference/schemas/config/functions/systemRoot.md
+++ b/docs/reference/schemas/config/functions/systemRoot.md
@@ -19,7 +19,7 @@ systemRoot()
 
 ## Description
 
-The `systemRoot()` function returns the value of the system root path[01].
+The `systemRoot()` function returns the value of the [system root path][01].
 
 ## Examples
 
@@ -54,8 +54,8 @@ hadErrors: false
 
 ### Example 2 - Construct and override the system root path
 
-The configuration uses the `path()`[02] function to construct a path from the `systemRoot()`, which 
-is overridden using in the command line.
+The configuration uses the [`path()`][02] function to construct a path from the `systemRoot()`,
+which is overridden using in the command line.
 
 ```yaml
 # joinSystemRoot.example.2.dsc.config.yaml
@@ -85,7 +85,7 @@ hadErrors: false
 ## Output
 
 The `systemRoot()` function returns the system root of the current host, or the value overriden
-using the `--system-root` command line flag[01].
+using the [`--system-root` command line flag][01].
 
 This is usually `C:\` on Windows system and `/` on Unix systems.
 
@@ -94,5 +94,5 @@ Type: string
 ```
 
 <!-- Link reference definitions -->
-[01]: ../../../cli/config/index.md#-r---system-root
+[01]: ../../../cli/config/index.md#--system-root
 [02]: ./path.md

--- a/docs/reference/schemas/config/functions/systemRoot.md
+++ b/docs/reference/schemas/config/functions/systemRoot.md
@@ -54,8 +54,8 @@ hadErrors: false
 
 ### Example 2 - Construct and override the system root path
 
-The configuration uses the `path()`[02] function to construct a path pf the `systemRoot()`, which 
-is overriden using in the command line.
+The configuration uses the `path()`[02] function to construct a path from the `systemRoot()`, which 
+is overridden using in the command line.
 
 ```yaml
 # joinSystemRoot.example.2.dsc.config.yaml
@@ -68,7 +68,7 @@ resources:
 ```
 
 ```bash
-dsc config ---system-root / get --file joinSystemRoot.example.2.dsc.config.yaml
+dsc config --system-root / get --file joinSystemRoot.example.2.dsc.config.yaml
 ```
 
 ```yaml

--- a/docs/reference/schemas/config/functions/trim.md
+++ b/docs/reference/schemas/config/functions/trim.md
@@ -20,7 +20,7 @@ trim(<stringToTrim>)
 ## Description
 
 The `trim()` function removes all leading and trailing whitespace characters from
-the input string. whitespace characters include spaces, tabs, newlines, carriage
+the input string. Whitespace characters include spaces, tabs, newlines, carriage
 returns, and other Unicode whitespace characters. The function preserves internal
 whitespace within the string. Use it for cleaning user input, normalizing
 configuration values, or preparing strings for comparison.

--- a/docs/reference/schemas/config/functions/trim.md
+++ b/docs/reference/schemas/config/functions/trim.md
@@ -245,8 +245,7 @@ Type: string
 - [`startsWith()`][03] - Checks if a string starts with a value
 - [`endsWith()`][04] - Checks if a string ends with a value
 - [`substring()`][05] - Extracts a portion of a string
-- [`replace()`][06] - Replaces text in a string
-- [`parameters()`][07] - Retrieves parameter values
+- [`parameters()`][06] - Retrieves parameter values
 
 <!-- Link reference definitions -->
 [00]: ./toLower.md
@@ -255,5 +254,4 @@ Type: string
 [03]: ./startsWith.md
 [04]: ./endsWith.md
 [05]: ./substring.md
-[06]: ./replace.md
-[07]: ./parameters.md
+[06]: ./parameters.md

--- a/docs/reference/schemas/config/functions/trim.md
+++ b/docs/reference/schemas/config/functions/trim.md
@@ -9,7 +9,7 @@ title:       trim
 
 ## Synopsis
 
-Removes all leading and trailing white-space characters from the specified string.
+Removes all leading and trailing whitespace characters from the specified string.
 
 ## Syntax
 
@@ -19,8 +19,8 @@ trim(<stringToTrim>)
 
 ## Description
 
-The `trim()` function removes all leading and trailing white-space characters from
-the input string. White-space characters include spaces, tabs, newlines, carriage
+The `trim()` function removes all leading and trailing whitespace characters from
+the input string. whitespace characters include spaces, tabs, newlines, carriage
 returns, and other Unicode whitespace characters. The function preserves internal
 whitespace within the string. Use it for cleaning user input, normalizing
 configuration values, or preparing strings for comparison.
@@ -231,7 +231,7 @@ Position: 1
 ## Output
 
 The `trim()` function returns the input string with all leading and trailing
-white-space characters removed. Internal whitespace is preserved.
+whitespace characters removed. Internal whitespace is preserved.
 
 ```yaml
 Type: string

--- a/docs/reference/schemas/config/functions/uri.md
+++ b/docs/reference/schemas/config/functions/uri.md
@@ -334,14 +334,10 @@ Type: string
 - [`concat()`][01] - Concatenates multiple strings together
 - [`format()`][02] - Creates a formatted string from a template
 - [`substring()`][03] - Extracts a portion of a string
-- [`replace()`][04] - Replaces text in a string
-- [`split()`][05] - Splits a string into an array
-- [`parameters()`][06] - Retrieves parameter values
+- [`parameters()`][04] - Retrieves parameter values
 
 <!-- Link reference definitions -->
 [01]: ./concat.md
 [02]: ./format.md
 [03]: ./substring.md
-[04]: ./replace.md
-[05]: ./split.md
-[06]: ./parameters.md
+[04]: ./parameters.md

--- a/docs/reference/schemas/config/resource.md
+++ b/docs/reference/schemas/config/resource.md
@@ -145,7 +145,7 @@ ItemsPattern:      ^\[resourceId\(\s*'\w+(\.\w+){0,2}\/\w+'\s*,\s*'[a-zA-Z0-9 ]+
 
 [01]: ../definitions/resourceType.md
 [02]: functions/resourceId.md
-[03]: /powershell/dsc/glossary#nested-resource-instance
+[03]: ../../../glossary.md#nested-resource-instance
 [04]: functions/overview.md
 <!-- [aa]: ../../../resources/concepts/schemas.md -->
 <!-- [ab]: ../../../configurations/concepts/dependencies.md -->

--- a/docs/reference/schemas/extension/manifest/root.md
+++ b/docs/reference/schemas/extension/manifest/root.md
@@ -55,7 +55,7 @@ semantic version, the latest schema for a minor version, or the latest schema fo
 of DSC. For more information about schema URIs and versioning, see
 [DSC JSON Schema URIs](../../schema-uris.md).
 
-For every version of the schema, there are three valid urls:
+For every version of the schema, there are three valid URLs:
 
 - `.../extension/manifest.json`
 
@@ -77,8 +77,9 @@ For every version of the schema, there are three valid urls:
   it includes additional definitions that provide contextual help and snippets that the others
   don't include.
 
-  This schema uses keywords that are only recognized by VS Code. While DSC can still validate the
-  document when it uses this schema, other tools may error or behave in unexpected ways.
+  This schema uses keywords that are only recognized by Visual Studio Code. While DSC can still 
+  validate the document when it uses this schema, other tools may error or behave in unexpected 
+  ways.
 
 ```yaml
 Type:        string
@@ -120,7 +121,7 @@ Pattern:  ^\w+(\.\w+){0,3}\/\w+$
 ### version
 
 The `version` property must be the current version of the extension as a valid semantic version
-(semver) string.
+(SemVer) string.
 
 ```yaml
 Type:     string

--- a/docs/reference/schemas/outputs/extension/list.md
+++ b/docs/reference/schemas/outputs/extension/list.md
@@ -51,7 +51,7 @@ Pattern:  ^\w+(\.\w+){0,2}\/\w+$
 
 ### version
 
-Represents the current version of the extension as a valid semantic version (semver) string.
+Represents the current version of the extension as a valid semantic version (SemVer) string.
 
 ```yaml
 Type:     string

--- a/docs/reference/schemas/outputs/resource/list.md
+++ b/docs/reference/schemas/outputs/resource/list.md
@@ -68,7 +68,7 @@ ValidValues:  [Resource, Adapter, Group]
 
 ### version
 
-Represents the current version of the resource as a valid semantic version (semver) string. The
+Represents the current version of the resource as a valid semantic version (SemVer) string. The
 version applies to the resource, not the software it manages.
 
 ```yaml

--- a/docs/reference/schemas/resource/manifest/root.md
+++ b/docs/reference/schemas/resource/manifest/root.md
@@ -298,7 +298,7 @@ Required: false
 When specified, the `adapter` property defines the resource as a DSC Resource Adapter.
 
 The value of this property must be an object. The object's `list` and `config` properties are
-mandatory. The `list` property defines how to call the provider to return the resources that the
+mandatory. The `list` property defines how to call the adapter to return the resources that the
 adapter can manage. The `config` property defines how the adapter expects input. For more
 information, see the [DSC Resource manifest adapter property schema reference][13].
 

--- a/docs/reference/schemas/resource/manifest/root.md
+++ b/docs/reference/schemas/resource/manifest/root.md
@@ -292,14 +292,14 @@ Type:     object
 Required: false
 ```
 
-### provider
+### adapter
 
-When specified, the `provider` property defines the resource as a DSC Resource Provider.
+When specified, the `adapter` property defines the resource as a DSC Resource Adapter.
 
 The value of this property must be an object. The object's `list` and `config` properties are
 mandatory. The `list` property defines how to call the provider to return the resources that the
-provider can manage. The `config` property defines how the provider expects input. For more
-information, see the [DSC Resource manifest provider property schema reference][13].
+adapter can manage. The `config` property defines how the adapter expects input. For more
+information, see the [DSC Resource manifest adapter property schema reference][13].
 
 ### exitCodes
 
@@ -363,5 +363,5 @@ Required: true
 [10]: whatif.md
 [11]: test.md
 [12]: validate.md
-[13]: provider.md
+[13]: adapter.md
 [14]: schema/property.md

--- a/docs/reference/schemas/resource/manifest/root.md
+++ b/docs/reference/schemas/resource/manifest/root.md
@@ -55,7 +55,7 @@ semantic version, the latest schema for a minor version, or the latest schema fo
 of DSC. For more information about schema URIs and versioning, see
 [DSC JSON Schema URIs](../../schema-uris.md).
 
-For every version of the schema, there are three valid urls:
+For every version of the schema, there are three valid URLs:
 
 - `.../resource/manifest.json`
 
@@ -77,8 +77,9 @@ For every version of the schema, there are three valid urls:
   it includes additional definitions that provide contextual help and snippets that the others
   don't include.
 
-  This schema uses keywords that are only recognized by VS Code. While DSC can still validate the
-  document when it uses this schema, other tools may error or behave in unexpected ways.
+  This schema uses keywords that are only recognized by Visual Studio Code. While DSC can still 
+  validate the document when it uses this schema, other tools may error or behave in unexpected
+  ways.
 
 ```yaml
 Type:        string
@@ -146,7 +147,7 @@ Pattern:  ^\w+(\.\w+){0,2}\/\w+$
 ### version
 
 The `version` property must be the current version of the resource as a valid semantic version
-(semver) string. The version applies to the resource, not the software it manages.
+(SemVer) string. The version applies to the resource, not the software it manages.
 
 ```yaml
 Type:     string

--- a/docs/reference/schemas/resource/manifest/schema/embedded.md
+++ b/docs/reference/schemas/resource/manifest/schema/embedded.md
@@ -25,8 +25,8 @@ The `embedded` subproperty defines a full JSON schema for a DSC Resource's insta
 JSON schema to validate every instance of the resource before calling the resource's commands and
 after receiving an instance as output from the resource.
 
-Embedded JSON schemas are also used by integrating and authoring tools like VS Code to validate
-resource instances and provide IntelliSense.
+Embedded JSON schemas are also used by integrating and authoring tools like Visual Studio Code to 
+validate resource instances and provide IntelliSense.
 
 ## Required keywordds
 

--- a/docs/reference/schemas/resource/manifest/schema/embedded.md
+++ b/docs/reference/schemas/resource/manifest/schema/embedded.md
@@ -28,7 +28,7 @@ after receiving an instance as output from the resource.
 Embedded JSON schemas are also used by integrating and authoring tools like Visual Studio Code to 
 validate resource instances and provide IntelliSense.
 
-## Required keywordds
+## Required keywords
 
 The `embedded` definition must include these keywords:
 

--- a/docs/reference/schemas/resource/stdout/list.md
+++ b/docs/reference/schemas/resource/stdout/list.md
@@ -80,7 +80,7 @@ ValidValues: [resource, adapter, group, importer, exporter]
 ### version
 
 The `version` property represents the current version of the adapted resource as a valid semantic
-version (semver) string. The version applies to the adapted resource, not the software it manages.
+version (SemVer) string. The version applies to the adapted resource, not the software it manages.
 
 ```yaml
 Type:     string

--- a/docs/reference/schemas/schema-uris.md
+++ b/docs/reference/schemas/schema-uris.md
@@ -155,18 +155,18 @@ the `$schema` keyword.
 ### Enhanced authoring schemas
 
 Every DSC Schema published in the canonically bundled form is also published in the enhanced
-authoring form. These schemas use the extended vocabulary that VS Code recognizes for JSON Schemas
-to provide improved IntelliSense, hover documentation, error messaging, and default snippets. These
-schemas make it easier to author, edit, and review your configuration documents, resource
-manifests, and DSC's output in VS Code.
+authoring form. These schemas use the extended vocabulary that Visual Studio Code recognizes for 
+JSON Schemas to provide improved IntelliSense, hover documentation, error messaging, and default
+snippets. These schemas make it easier to author, edit, and review your configuration documents,
+resource manifests, and DSC's output in Visual Studio Code.
 
 These schemas validate the data with the same vocabulary as the canonical forms of the schema. They
-only affect the experience for authoring, editing, and reviewing the data in VS Code.
+only affect the experience for authoring, editing, and reviewing the data in Visual Studio Code.
 
 These JSON Schemas are _not_ canonical. They use a vocabulary that most JSON Schema libraries and
 tools don't understand. In most cases, using these schemas with those tools shouldn't raise any
-errors. However, when you want to use the DSC schemas with tools other than VS Code, you should
-consider using the canonically bundled form of the schema instead.
+errors. However, when you want to use the DSC schemas with tools other than Visual Studio Code, 
+you should consider using the canonically bundled form of the schema instead.
 
 ## Bundled schema URIs list
 

--- a/docs/reference/tools/builtin.md
+++ b/docs/reference/tools/builtin.md
@@ -9,7 +9,7 @@ title:       osinfo
 
 # DSC tools overview
 
-Microsoft's Desired State Configuration (DSC) platform includes commandline tools for early
+Microsoft's Desired State Configuration (DSC) platform includes command-line tools for early
 feedback and functionality.
 
 The following table describes the tools included in current releases of DSC and the platforms those

--- a/docs/reference/tools/registry/schema/index.md
+++ b/docs/reference/tools/registry/schema/index.md
@@ -49,7 +49,7 @@ registry schema
 <a id="example-2"></a>
 
 With the `--pretty` flag, the output includes whitespace between key-value pairs, newlines after
-each key-value pair and array item, and indentation to make the schema easier to read.
+each key-value pair and array element, and indentation to make the schema easier to read.
 
 ```powershell
 registry schema --pretty
@@ -62,7 +62,7 @@ registry schema --pretty
 <a id="-p"></a>
 <a id="--pretty"></a>
 
-Returns the schema with indentation and newlines between key-value pairs and array items. By
+Returns the schema with indentation and newlines between key-value pairs and array elements. By
 default, the command returns the schema compressed on a single line without any unquoted
 whitespace.
 

--- a/docs/reference/tools/registry/schema/index.md
+++ b/docs/reference/tools/registry/schema/index.md
@@ -49,7 +49,7 @@ registry schema
 <a id="example-2"></a>
 
 With the `--pretty` flag, the output includes whitespace between key-value pairs, newlines after
-each key-value pair and array element, and indentation to make the schema easier to read.
+each key-value pair and array items, and indentation to make the schema easier to read.
 
 ```powershell
 registry schema --pretty
@@ -62,7 +62,7 @@ registry schema --pretty
 <a id="-p"></a>
 <a id="--pretty"></a>
 
-Returns the schema with indentation and newlines between key-value pairs and array elements. By
+Returns the schema with indentation and newlines between key-value pairs and array items. By
 default, the command returns the schema compressed on a single line without any unquoted
 whitespace.
 


### PR DESCRIPTION
Fix broken docs links using markdown-link-check.
Fix linting issues using textlint and fixed issues.
Add documentation for:
- secret function
- path function
- systemRoot function