### PR TITLE
Enable `export` operation to have own schema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,6 +979,7 @@ name = "dsctest"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "regex",
  "registry",
  "schemars",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,9 +2625,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2648,9 +2648,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "registry"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,7 +197,7 @@ quote = { version = "1.0" }
 # used by other crates
 rand = { version = "0.10.1" }
 # dsc, dsc-lib
-regex = { version = "1.12.3" }
+regex = { version = "1.12.4" }
 # registry, dsc-lib, dsc-lib-registry, dsctest
 registry = { version = "1.3" }
 # dsc

--- a/dsc/tests/dsc_resource_export.tests.ps1
+++ b/dsc/tests/dsc_resource_export.tests.ps1
@@ -3,11 +3,10 @@
 
 Describe 'Resource export tests' {
     It "Export with <resource> accepts input '<json>' and returns filtered results" -TestCases @(
-        @{ resource = 'Test/ExportSchemaCommand'; json = '{ "name": "Gijs" }'; expected = @('Gijs') },
-        @{ resource = 'Test/ExportSchemaCommand'; json = '{ "name": "*e*" }'; expected = @('Steve', 'Tess') },
-        @{ resource = 'Test/ExportSchemaEmbedded'; json = '{ "name": "Gijs" }'; expected = @('Gijs') },
-        @{ resource = 'Test/ExportSchemaEmbedded'; json = '{ "name": "*e*" }'; expected = @('Steve', 'Tess') },
-        @{ resource = 'Test/ExportSchemaNoFiltering'; json = '{ "name": "Gijs" }'; expected = @('Steve', 'Tess', 'Gijs') }
+        @{ resource = 'Test/ExportSchemaCommand'; json = '{ "name": "Gijs" }'; expected = @('Gijs') }
+        @{ resource = 'Test/ExportSchemaCommand'; json = '{ "name": "*e*" }'; expected = @('Steve', 'Tess') }
+        @{ resource = 'Test/ExportSchemaEmbedded'; json = '{ "name": "Gijs" }'; expected = @('Gijs') }
+        @{ resource = 'Test/ExportSchemaEmbedded'; json = '{ "name": "*e*" }'; expected = @('Steve', 'Tess') }
     ){
         param($resource, $json, $expected)
 
@@ -16,5 +15,15 @@ Describe 'Resource export tests' {
         $LASTEXITCODE | Should -Be 0 -Because $errorlog
         $output.resources.count | Should -Be $expected.Count -Because ($output | ConvertTo-Json -Depth 4)
         $output.resources.properties.name | Should -Be $expected -Because ($output | ConvertTo-Json -Depth 4)
+    }
+
+    It 'Resource not support export filtering will return error' {
+        $resource = 'Test/ExportSchemaNoFiltering'
+        $json = '{ "name": "Gijs" }'
+
+        $output = dsc resource export -r $resource -i $json  2>$TESTDRIVE/error.log | ConvertFrom-Json
+        $errorlog = Get-Content "$TESTDRIVE/error.log" -Raw
+        $LASTEXITCODE | Should -Be 2 -Because $errorlog
+        $errorlog | Should -Match "Resource '$resource' does not support export filtering"
     }
 }

--- a/dsc/tests/dsc_resource_export.tests.ps1
+++ b/dsc/tests/dsc_resource_export.tests.ps1
@@ -1,0 +1,20 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'Resource export tests' {
+    It "Export with <resource> accepts input '<json>' and returns filtered results" -TestCases @(
+        @{ resource = 'Test/ExportSchemaCommand'; json = '{ "name": "Gijs" }'; expected = @('Gijs') },
+        @{ resource = 'Test/ExportSchemaCommand'; json = '{ "name": "*e*" }'; expected = @('Steve', 'Tess') },
+        @{ resource = 'Test/ExportSchemaEmbedded'; json = '{ "name": "Gijs" }'; expected = @('Gijs') },
+        @{ resource = 'Test/ExportSchemaEmbedded'; json = '{ "name": "*e*" }'; expected = @('Steve', 'Tess') },
+        @{ resource = 'Test/ExportSchemaNoFiltering'; json = '{ "name": "Gijs" }'; expected = @('Steve', 'Tess', 'Gijs') }
+    ){
+        param($resource, $json, $expected)
+
+        $output = dsc resource export -r $resource -i $json  2>$TESTDRIVE/error.log | ConvertFrom-Json
+        $errorlog = Get-Content "$TESTDRIVE/error.log" -Raw
+        $LASTEXITCODE | Should -Be 0 -Because $errorlog
+        $output.resources.count | Should -Be $expected.Count -Because ($output | ConvertTo-Json -Depth 4)
+        $output.resources.properties.name | Should -Be $expected -Because ($output | ConvertTo-Json -Depth 4)
+    }
+}

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -195,6 +195,7 @@ whatIfWarning = "Resource '%{resource}' uses deprecated 'whatIf' operation. See 
 securityContextRequired = "Operation '%{operation}' for resource '%{resource}' requires security context '%{context}'"
 noAdaptedContent = "No adapted content available for resource '%{resource}'"
 invalidAdaptedContent = "Invalid adapted content for resource '%{resource}': %{error}"
+exportFilteringNotSupported = "Resource '%{resource}' does not support export filtering"
 
 [dscresources.dscresource]
 invokeGet = "Invoking get for '%{resource}'"

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -195,7 +195,6 @@ whatIfWarning = "Resource '%{resource}' uses deprecated 'whatIf' operation. See 
 securityContextRequired = "Operation '%{operation}' for resource '%{resource}' requires security context '%{context}'"
 noAdaptedContent = "No adapted content available for resource '%{resource}'"
 invalidAdaptedContent = "Invalid adapted content for resource '%{resource}': %{error}"
-exportNoFilteringWithInput = "Resource '%{resource}' does not support filtering export results and input was provided"
 
 [dscresources.dscresource]
 invokeGet = "Invoking get for '%{resource}'"

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -195,6 +195,7 @@ whatIfWarning = "Resource '%{resource}' uses deprecated 'whatIf' operation. See 
 securityContextRequired = "Operation '%{operation}' for resource '%{resource}' requires security context '%{context}'"
 noAdaptedContent = "No adapted content available for resource '%{resource}'"
 invalidAdaptedContent = "Invalid adapted content for resource '%{resource}': %{error}"
+exportNoFilteringWithInput = "Resource '%{resource}' does not support filtering export results and input was provided"
 
 [dscresources.dscresource]
 invokeGet = "Invoking get for '%{resource}'"

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -7,8 +7,8 @@ use jsonschema::Validator;
 use rust_i18n::t;
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use std::{collections::HashMap, env, path::Path, process::Stdio};
-use crate::{configure::{config_doc::{ExecutionKind, SecurityContextKind}, config_result::{ResourceGetResult, ResourceTestResult}}, dscresources::{resource_manifest::SchemaArgKind}, types::ExitCodesMap, util::canonicalize_which};
+use std::{collections::HashMap, env, path::{Path, PathBuf}, process::Stdio};
+use crate::{configure::{config_doc::{ExecutionKind, SecurityContextKind}, config_result::{ResourceGetResult, ResourceTestResult}}, dscresources::resource_manifest::{ExportSchemaKind, SchemaArgKind}, types::{ExitCodesMap, FullyQualifiedTypeName}, util::canonicalize_which};
 use crate::dscerror::DscError;
 use super::{
     dscresource::{get_diff, redact, DscResource},
@@ -586,6 +586,34 @@ pub fn get_schema(resource: &DscResource, target_resource: Option<&DscResource>)
     }
 }
 
+pub fn get_export_schema(resource: &DscResource, target_resource: Option<&DscResource>) -> Result<String, DscError> {
+    let Some(manifest) = &resource.manifest else {
+        return Err(DscError::MissingManifest(resource.type_name.to_string()));
+    };
+    let Some(export) = manifest.export.as_ref() else {
+        return Err(DscError::SchemaNotAvailable(resource.type_name.to_string()));
+    };
+
+    match export.schema {
+        Some(ExportSchemaKind::Command(ref command)) => {
+            let resource_type = match target_resource {
+                Some(r) => r.type_name.clone(),
+                None => resource.type_name.clone(),
+            };
+            let args = process_schema_args(command.args.as_ref(), &CommandResourceInfo { type_name: resource_type, path: None });
+            let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, args, None, Some(&resource.directory), None, manifest.exit_codes.as_ref())?;
+            Ok(stdout)
+        },
+        Some(ExportSchemaKind::Embedded(ref schema)) => {
+            let json = serde_json::to_string(schema)?;
+            Ok(json)
+        },
+        _ => {
+            get_schema(resource, target_resource)
+        }
+    }
+}
+
 /// Invoke the export operation on a resource
 ///
 /// # Arguments
@@ -636,9 +664,26 @@ pub fn invoke_export(resource: &DscResource, input: Option<&str>, target_resourc
         None => resource,
     };
     validate_security_context(&export.require_security_context, &command_resource.type_name, "export")?;
+
     if let Some(input) = input {
+        let input = if export.schema == Some(ExportSchemaKind::NoFiltering) {
+            ""
+        } else {
+            input
+        };
         if !input.is_empty() {
-            verify_json_from_manifest(resource, input, target_resource)?;
+            let schema = serde_json::from_str(&get_export_schema(resource, target_resource)?)?;
+            let compiled_schema = match Validator::new(&schema) {
+                Ok(schema) => schema,
+                Err(e) => {
+                    return Err(DscError::Schema(e.to_string()));
+                },
+            };
+            let json: Value = serde_json::from_str(input)?;
+            if let Err(err) = compiled_schema.validate(&json) {
+                return Err(DscError::Schema(err.to_string()));
+            }
+
 
             command_input = get_command_input(export.input.as_ref(), input)?;
         }

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -7,8 +7,8 @@ use jsonschema::Validator;
 use rust_i18n::t;
 use serde::Deserialize;
 use serde_json::{Map, Value};
-use std::{collections::HashMap, env, path::{Path, PathBuf}, process::Stdio};
-use crate::{configure::{config_doc::{ExecutionKind, SecurityContextKind}, config_result::{ResourceGetResult, ResourceTestResult}}, dscresources::resource_manifest::{ExportSchemaKind, SchemaArgKind}, types::{ExitCodesMap, FullyQualifiedTypeName}, util::canonicalize_which};
+use std::{collections::HashMap, env, path::Path, process::Stdio};
+use crate::{configure::{config_doc::{ExecutionKind, SecurityContextKind}, config_result::{ResourceGetResult, ResourceTestResult}}, dscresources::resource_manifest::{ExportSchemaKind, SchemaArgKind}, types::{ExitCodesMap}, util::canonicalize_which};
 use crate::dscerror::DscError;
 use super::{
     dscresource::{get_diff, redact, DscResource},
@@ -595,34 +595,38 @@ fn verify_with_export_schema(input: &str, resource: &DscResource, target_resourc
         return Err(DscError::SchemaNotAvailable(resource.type_name.to_string()));
     };
 
-    if export.schema.is_none() && manifest.validate.is_some() {
-        let result = invoke_validate(resource, input, target_resource)?;
-        if result.valid {
-            return Ok(());
-        }
-
-        let reason = result
-            .reason
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .unwrap_or_else(|| t!("dscresources.commandResource.resourceInvalidJson").to_string());
-        return Err(DscError::Validation(reason));
-    }
+    let command_resource = match target_resource {
+        Some(r) => r,
+        None => resource,
+    };
 
     let schema = match export.schema {
         Some(ExportSchemaKind::Command(ref command)) => {
-            let resource_type = match target_resource {
-                Some(r) => r.type_name.clone(),
-                None => resource.type_name.clone(),
-            };
-            let args = process_schema_args(command.args.as_ref(), &CommandResourceInfo { type_name: resource_type, path: None });
+            let args = process_schema_args(command.args.as_ref(), command_resource);
             let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, args, None, Some(&resource.directory), None, manifest.exit_codes.as_ref())?;
             stdout
         },
         Some(ExportSchemaKind::Embedded(ref schema)) => {
             serde_json::to_string(schema)?
         },
-        _ => {
+        Some(ExportSchemaKind::NoFiltering) => {
+            return Ok(());
+        },
+        None => {
+            if manifest.validate.is_some() {
+                let result = invoke_validate(resource, input, target_resource)?;
+                if result.valid {
+                    return Ok(());
+                }
+
+                let reason = result
+                    .reason
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .unwrap_or_else(|| t!("dscresources.commandResource.resourceInvalidJson").to_string());
+                return Err(DscError::Validation(reason));
+            }
+
             get_schema(resource, target_resource)?
         }
     };

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -8,7 +8,7 @@ use rust_i18n::t;
 use serde::Deserialize;
 use serde_json::{Map, Value};
 use std::{collections::HashMap, env, path::Path, process::Stdio};
-use crate::{configure::{config_doc::{ExecutionKind, SecurityContextKind}, config_result::{ResourceGetResult, ResourceTestResult}}, dscresources::resource_manifest::{ExportSchemaKind, SchemaArgKind}, types::{ExitCodesMap}, util::canonicalize_which};
+use crate::{configure::{config_doc::{ExecutionKind, SecurityContextKind}, config_result::{ResourceGetResult, ResourceTestResult}}, dscresources::resource_manifest::{ExportSchemaKind, ExportSchemaOrFiltering, SchemaArgKind}, types::{ExitCodesMap}, util::canonicalize_which};
 use crate::dscerror::DscError;
 use super::{
     dscresource::{get_diff, redact, DscResource},
@@ -600,19 +600,19 @@ fn verify_with_export_schema(input: &str, resource: &DscResource, target_resourc
         None => resource,
     };
 
-    let schema = match export.schema {
-        Some(ExportSchemaKind::Command(ref command)) => {
+    let schema = match export.schema_or_filtering {
+        Some(ExportSchemaOrFiltering::Schema(ExportSchemaKind::Command(ref command))) => {
             let args = process_schema_args(command.args.as_ref(), command_resource);
             let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, args, None, Some(&resource.directory), None, manifest.exit_codes.as_ref())?;
             stdout
         },
-        Some(ExportSchemaKind::Embedded(ref schema)) => {
+        Some(ExportSchemaOrFiltering::Schema(ExportSchemaKind::Embedded(ref schema))) => {
             serde_json::to_string(schema)?
         },
-        Some(ExportSchemaKind::NoFiltering) => {
-            return Ok(());
+        Some(ExportSchemaOrFiltering::SupportsFiltering(false)) => {
+            return Err(DscError::Operation(t!("dscresources.commandResource.exportFilteringNotSupported", resource = &resource.type_name).to_string()));
         },
-        None => {
+        Some(ExportSchemaOrFiltering::SupportsFiltering(true)) | None => {
             if manifest.validate.is_some() {
                 let result = invoke_validate(resource, input, target_resource)?;
                 if result.valid {
@@ -696,11 +696,10 @@ pub fn invoke_export(resource: &DscResource, input: Option<&str>, target_resourc
     validate_security_context(&export.require_security_context, &command_resource.type_name, "export")?;
 
     if let Some(input) = input {
-        let input = if export.schema == Some(ExportSchemaKind::NoFiltering) {
-            ""
-        } else {
-            input
-        };
+        if matches!(export.schema_or_filtering, Some(ExportSchemaOrFiltering::SupportsFiltering(false))) {
+            return Err(DscError::Operation(t!("dscresources.commandResource.exportFilteringNotSupported", resource = &resource.type_name).to_string()));
+        }
+
         if !input.is_empty() {
             verify_with_export_schema(input, resource, target_resource)?;
 

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -591,7 +591,11 @@ fn verify_with_export_schema(input: &str, resource: &DscResource, target_resourc
         return Err(DscError::MissingManifest(resource.type_name.to_string()));
     };
 
-    if manifest.validate.is_some() {
+    let Some(export) = manifest.export.as_ref() else {
+        return Err(DscError::SchemaNotAvailable(resource.type_name.to_string()));
+    };
+
+    if export.schema.is_none() && manifest.validate.is_some() {
         let result = invoke_validate(resource, input, target_resource)?;
         if result.valid {
             return Ok(());
@@ -604,10 +608,6 @@ fn verify_with_export_schema(input: &str, resource: &DscResource, target_resourc
             .unwrap_or_else(|| t!("dscresources.commandResource.resourceInvalidJson").to_string());
         return Err(DscError::Validation(reason));
     }
-
-    let Some(export) = manifest.export.as_ref() else {
-        return Err(DscError::SchemaNotAvailable(resource.type_name.to_string()));
-    };
 
     let schema = match export.schema {
         Some(ExportSchemaKind::Command(ref command)) => {

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -586,15 +586,30 @@ pub fn get_schema(resource: &DscResource, target_resource: Option<&DscResource>)
     }
 }
 
-fn get_export_schema(resource: &DscResource, target_resource: Option<&DscResource>) -> Result<String, DscError> {
+fn verify_with_export_schema(input: &str, resource: &DscResource, target_resource: Option<&DscResource>) -> Result<(), DscError> {
     let Some(manifest) = &resource.manifest else {
         return Err(DscError::MissingManifest(resource.type_name.to_string()));
     };
+
+    if manifest.validate.is_some() {
+        let result = invoke_validate(resource, input, target_resource)?;
+        if result.valid {
+            return Ok(());
+        }
+
+        let reason = result
+            .reason
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .unwrap_or_else(|| t!("dscresources.commandResource.resourceInvalidJson").to_string());
+        return Err(DscError::Validation(reason));
+    }
+
     let Some(export) = manifest.export.as_ref() else {
         return Err(DscError::SchemaNotAvailable(resource.type_name.to_string()));
     };
 
-    match export.schema {
+    let schema = match export.schema {
         Some(ExportSchemaKind::Command(ref command)) => {
             let resource_type = match target_resource {
                 Some(r) => r.type_name.clone(),
@@ -602,16 +617,27 @@ fn get_export_schema(resource: &DscResource, target_resource: Option<&DscResourc
             };
             let args = process_schema_args(command.args.as_ref(), &CommandResourceInfo { type_name: resource_type, path: None });
             let (_exit_code, stdout, _stderr) = invoke_command(&command.executable, args, None, Some(&resource.directory), None, manifest.exit_codes.as_ref())?;
-            Ok(stdout)
+            stdout
         },
         Some(ExportSchemaKind::Embedded(ref schema)) => {
-            let json = serde_json::to_string(schema)?;
-            Ok(json)
+            serde_json::to_string(schema)?
         },
         _ => {
-            get_schema(resource, target_resource)
+            get_schema(resource, target_resource)?
         }
+    };
+    let schema = serde_json::from_str(&schema)?;
+    let compiled_schema = match Validator::new(&schema) {
+        Ok(schema) => schema,
+        Err(e) => {
+            return Err(DscError::Schema(e.to_string()));
+        },
+    };
+    let json: Value = serde_json::from_str(input)?;
+    if let Err(err) = compiled_schema.validate(&json) {
+        return Err(DscError::Schema(err.to_string()));
     }
+    Ok(())
 }
 
 /// Invoke the export operation on a resource
@@ -672,18 +698,7 @@ pub fn invoke_export(resource: &DscResource, input: Option<&str>, target_resourc
             input
         };
         if !input.is_empty() {
-            let schema = serde_json::from_str(&get_export_schema(resource, target_resource)?)?;
-            let compiled_schema = match Validator::new(&schema) {
-                Ok(schema) => schema,
-                Err(e) => {
-                    return Err(DscError::Schema(e.to_string()));
-                },
-            };
-            let json: Value = serde_json::from_str(input)?;
-            if let Err(err) = compiled_schema.validate(&json) {
-                return Err(DscError::Schema(err.to_string()));
-            }
-
+            verify_with_export_schema(input, resource, target_resource)?;
 
             command_input = get_command_input(export.input.as_ref(), input)?;
         }

--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -586,7 +586,7 @@ pub fn get_schema(resource: &DscResource, target_resource: Option<&DscResource>)
     }
 }
 
-pub fn get_export_schema(resource: &DscResource, target_resource: Option<&DscResource>) -> Result<String, DscError> {
+fn get_export_schema(resource: &DscResource, target_resource: Option<&DscResource>) -> Result<String, DscError> {
     let Some(manifest) = &resource.manifest else {
         return Err(DscError::MissingManifest(resource.type_name.to_string()));
     };

--- a/lib/dsc-lib/src/dscresources/resource_manifest.rs
+++ b/lib/dsc-lib/src/dscresources/resource_manifest.rs
@@ -206,6 +206,18 @@ pub enum SchemaKind {
     Embedded(Value),
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]
+#[dsc_repo_schema(base_name = "manifest.exportSchema", folder_path = "definitions")]
+#[serde(rename_all = "camelCase")]
+pub enum ExportSchemaKind {
+    /// The export schema is returned by running a command.
+    Command(SchemaCommand),
+    /// The export schema is embedded in the manifest.
+    Embedded(Value),
+    /// The export operation does not support filtering.
+    NoFiltering,
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
 pub struct SchemaCommand {
     /// The command to run to get the schema.
@@ -321,6 +333,7 @@ pub struct ExportMethod {
     /// The security context required to run the Export method.  Default if not specified is `current`.
     #[serde(rename = "requireSecurityContext", skip_serializing_if = "Option::is_none")]
     pub require_security_context: Option<SecurityContextKind>,
+    pub schema: Option<ExportSchemaKind>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]

--- a/lib/dsc-lib/src/dscresources/resource_manifest.rs
+++ b/lib/dsc-lib/src/dscresources/resource_manifest.rs
@@ -214,8 +214,6 @@ pub enum ExportSchemaKind {
     Command(SchemaCommand),
     /// The export schema is embedded in the manifest.
     Embedded(Value),
-    /// The export operation does not support filtering.
-    NoFiltering,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
@@ -321,6 +319,13 @@ pub struct ValidateMethod { // TODO: enable validation via schema or command
     pub input: Option<InputKind>,
 }
 
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum ExportSchemaOrFiltering {
+    Schema(ExportSchemaKind),
+    SupportsFiltering(bool),
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]
 #[dsc_repo_schema(base_name = "manifest.export", folder_path = "resource")]
 pub struct ExportMethod {
@@ -333,7 +338,8 @@ pub struct ExportMethod {
     /// The security context required to run the Export method.  Default if not specified is `current`.
     #[serde(rename = "requireSecurityContext", skip_serializing_if = "Option::is_none")]
     pub require_security_context: Option<SecurityContextKind>,
-    pub schema: Option<ExportSchemaKind>,
+    #[serde(flatten, skip_serializing_if = "Option::is_none")]
+    pub schema_or_filtering: Option<ExportSchemaOrFiltering>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, DscRepoSchema)]

--- a/tools/dsctest/Cargo.toml
+++ b/tools/dsctest/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2024"
 
 [dependencies]
 clap = { workspace = true }
+regex = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/tools/dsctest/dsctest.dsc.manifests.json
+++ b/tools/dsctest/dsctest.dsc.manifests.json
@@ -1405,6 +1405,110 @@
           ]
         }
       }
+    },
+    {
+      "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+      "type": "Test/ExportSchemaCommand",
+      "version": "0.1.0",
+      "description": "Test resource for export specific schema",
+      "export": {
+        "executable": "dsctest",
+        "args": [
+          "export-schema",
+          {
+            "jsonInputArg": "--input",
+            "mandatory": true
+          }
+        ],
+        "schema": {
+          "command":{
+            "executable": "dsctest",
+            "args": [
+              "schema",
+              "-s",
+              "export-schema"
+            ]
+          }
+        }
+      },
+      "schema": {
+        "command": {
+          "executable": "dsctest",
+          "args": [
+            "schema",
+            "-s",
+            "export-get-schema"
+          ]
+        }
+      }
+    },
+    {
+      "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+      "type": "Test/ExportSchemaEmbedded",
+      "version": "0.1.0",
+      "description": "Test resource for export specific schema",
+      "export": {
+        "executable": "dsctest",
+        "args": [
+          "export-schema",
+          {
+            "jsonInputArg": "--input",
+            "mandatory": true
+          }
+        ],
+        "schema": {
+          "embedded": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "$id": "http://example.com/export-schema",
+            "title": "Export Schema",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Export Property",
+                "description": "Can contain wildcards for export filtering."
+              }
+            }
+          }
+        }
+      },
+      "schema": {
+        "command": {
+          "executable": "dsctest",
+          "args": [
+            "schema",
+            "-s",
+            "export-get-schema"
+          ]
+        }
+      }
+    },
+    {
+      "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
+      "type": "Test/ExportSchemaNoFiltering",
+      "version": "0.1.0",
+      "description": "Test resource for export specific schema",
+      "export": {
+        "executable": "dsctest",
+        "args": [
+          "export-schema",
+          {
+            "jsonInputArg": "--input",
+            "mandatory": true
+          }
+        ],
+        "schema": "noFiltering"
+      },
+      "schema": {
+        "command": {
+          "executable": "dsctest",
+          "args": [
+            "schema",
+            "-s",
+            "export-get-schema"
+          ]
+        }
+      }
     }
   ]
 }

--- a/tools/dsctest/dsctest.dsc.manifests.json
+++ b/tools/dsctest/dsctest.dsc.manifests.json
@@ -1501,7 +1501,7 @@
             "mandatory": true
           }
         ],
-        "schema": "noFiltering"
+        "supportsFiltering": false
       },
       "schema": {
         "command": {

--- a/tools/dsctest/dsctest.dsc.manifests.json
+++ b/tools/dsctest/dsctest.dsc.manifests.json
@@ -1462,13 +1462,17 @@
             "$id": "http://example.com/export-schema",
             "title": "Export Schema",
             "type": "object",
+            "additionalProperties": false,
             "properties": {
               "name": {
                 "type": "string",
                 "title": "Export Property",
                 "description": "Can contain wildcards for export filtering."
               }
-            }
+            },
+            "required": [
+              "name"
+            ]
           }
         }
       },

--- a/tools/dsctest/src/args.rs
+++ b/tools/dsctest/src/args.rs
@@ -11,6 +11,8 @@ pub enum Schemas {
     Exist,
     ExitCode,
     Export,
+    ExportGetSchema,
+    ExportSchema,
     Exporter,
     Get,
     InDesiredState,
@@ -92,6 +94,12 @@ pub enum SubCommand {
     #[clap(name = "export", about = "Export instances")]
     Export {
         #[clap(name = "input", short, long, help = "The input to the export command as JSON")]
+        input: String,
+    },
+
+    #[clap(name = "export-schema", about = "Test export specific schema")]
+    ExportSchema {
+        #[clap(name = "input", short, long, help = "The input to the export schema command as JSON")]
         input: String,
     },
 

--- a/tools/dsctest/src/export_schema.rs
+++ b/tools/dsctest/src/export_schema.rs
@@ -1,0 +1,86 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use std::fmt::Display;
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+pub enum Names {
+    Gijs,
+    Steve,
+    Tess,
+}
+
+impl Display for Names {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Names::Gijs => write!(f, "Gijs"),
+            Names::Steve => write!(f, "Steve"),
+            Names::Tess => write!(f, "Tess"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct Schema {
+    pub name: Names,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ExportSchema {
+    pub name: String,
+}
+
+pub fn invoke_export_schema(input: &str) -> String {
+    let instances = vec![
+        Schema {
+            name: Names::Steve,
+        },
+        Schema {
+            name: Names::Tess,
+        },
+        Schema {
+            name: Names::Gijs,
+        },
+    ];
+    let filter: ExportSchema = if !input.is_empty() {
+        match serde_json::from_str(input) {
+            Ok(filter) => filter,
+            Err(err) => {
+                eprintln!("Error JSON does not match schema: {err}");
+                std::process::exit(1);
+            }
+        }
+    } else {
+        ExportSchema {
+            name: "*".to_string(),
+        }
+    };
+    let filtered_instances: Vec<Schema> = if filter.name.contains("*") {
+        // convert the wildcard to a regex
+        let regex = filter.name.replace("*", ".*");
+        let regex = regex::Regex::new(&regex).unwrap();
+        instances
+            .into_iter()
+            .filter(|instance| regex.is_match(&instance.name.to_string()))
+            .collect()
+    } else {
+        instances
+            .into_iter()
+            .filter(|instance| instance.name.to_string() == filter.name)
+            .collect()
+    };
+    let mut output = String::new();
+    let mut count = filtered_instances.len();
+    for instance in &filtered_instances {
+        output.push_str(serde_json::to_string(instance).unwrap().as_str());
+        if count > 1 {
+            output.push('\n');
+        }
+        count -= 1;
+    }
+    output
+}

--- a/tools/dsctest/src/main.rs
+++ b/tools/dsctest/src/main.rs
@@ -7,6 +7,7 @@ mod delete;
 mod exist;
 mod exit_code;
 mod export;
+mod export_schema;
 mod exporter;
 mod get;
 mod in_desired_state;
@@ -31,6 +32,7 @@ use crate::delete::Delete;
 use crate::exist::{Exist, State};
 use crate::exit_code::ExitCode;
 use crate::export::Export;
+use crate::export_schema::{ExportSchema, invoke_export_schema};
 use crate::exporter::{Exporter, Resource};
 use crate::get::Get;
 use crate::in_desired_state::InDesiredState;
@@ -131,6 +133,9 @@ fn main() {
                 println!("{}", serde_json::to_string(&instance).unwrap());
             }
             String::new()
+        },
+        SubCommand::ExportSchema { input } => {
+            invoke_export_schema(&input)
         },
         SubCommand::Exporter { input } => {
             let exporter = match serde_json::from_str::<Exporter>(&input) {
@@ -299,6 +304,12 @@ fn main() {
                 },
                 Schemas::Export => {
                     schema_for!(Export)
+                },
+                Schemas::ExportGetSchema => {
+                    schema_for!(export_schema::Schema)
+                },
+                Schemas::ExportSchema => {
+                    schema_for!(ExportSchema)
                 },
                 Schemas::Exporter => {
                     schema_for!(Exporter)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Enables resources supporting `export` to optionally have separate schema from `get`, `set`, and `test`.

In the resource manifest under the `export` operation, there is now an optional `schema` property that can be:

`command` - same as normal schema which runs a command that returns JSON schema
`embedded` - same as normal schema which has embedded JSON schema

Alternatively, a resource manifest can have a `supportsFiltering` property that is a boolean.  `schema` and `supportsFiltering` are mutually exclusive.  If this is set to `true` and any input is provided by the user, then this returns an error without calling the resource.

New test resource added to validate these scenarios particularly where the `name` property is an enum, but the `export` allows `name` to be an arbitrary string to allow passing in wildcards.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1232