### PR TITLE
win_psDscAdapter.psm1: Retry to import module again if CommandNotFoundException is thrown

### DIFF
--- a/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
@@ -631,7 +631,7 @@ function GetTypeInstanceFromModule {
     try {
         $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
     } catch {
-        if ($error.FullyQualifiedErrorId -eq "CommandNotFoundException") {
+        if ($_.FullyQualifiedErrorId -eq "CommandNotFoundException") {
             $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
         }
     }

--- a/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
@@ -632,7 +632,7 @@ function GetTypeInstanceFromModule {
         $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
     } catch {
         if ($_.FullyQualifiedErrorId -eq "CommandNotFoundException") {
-            $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
+            $instance = & (Import-Module $modulename -PassThru -Force) ([scriptblock]::Create("'$classname' -as 'type'"))
         }
     }
     return $instance

--- a/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
@@ -628,7 +628,13 @@ function GetTypeInstanceFromModule {
         [Parameter(Mandatory = $true)]
         [string] $classname
     )
-    $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
+    try {
+        $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
+    } catch {
+        if ($error.FullyQualifiedErrorId -eq "CommandNotFoundException") {
+            $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
+        }
+    }
     return $instance
 }
 


### PR DESCRIPTION
# PR Summary

This PR fixes an issue if trying to import a module and it throws a `CommandNotFoundException`, e.g. when the module contains a `ScriptsToProcess` directive.

## PR Context

When trying to enumerate the resources from module `Microsoft365Dsc`, which uses the adapter `Microsoft.Windows/WindowsPowerShell`, it throws an error because this module contains a `ScriptsToProcess` directive and the function `GetTypeInstanceFromModule`, from `win_psDscAdapter.psm1`, cannot cope with it because a `CommandNotFoundException` will be thrown . This PR fixes this by retrying to import the module once again a second time, only if the exception thrown is `CommandNotFoundException`, which will work as advised by @Gijsreyn.

This should fix the issue #1574 I raised earlier.
