### PR TITLE
refactoring Jason/Mikey RFC

### DIFF
--- a/docs/concepts/resources/class-based-psdsc-v3.md
+++ b/docs/concepts/resources/class-based-psdsc-v3.md
@@ -1,0 +1,209 @@
+---
+description: >-
+  Explains how class-based PSDSC resources can participate in DSC v3 through the
+  PowerShell adapter.
+ms.date:     06/15/2026
+ms.topic:    conceptual
+title:       Author class-based PSDSC resources for DSC v3
+---
+
+# Author class-based PSDSC resources for DSC v3
+
+This article collects the background and examples for RFC 0001, which defines the contract for
+PowerShell **class-based** PSDSC resources that participate in DSC v3 through the PowerShell
+adapter.
+
+## Related DSC concepts
+
+This article assumes you're already familiar with the shared DSC concepts and data models described
+in the following docs:
+
+- [DSC Resources](./overview.md)
+- [DSC resource operations](./operations.md)
+- [DSC resource capabilities](./capabilities.md)
+- [DSC resource properties](./properties.md)
+- [DSC resource test operation stdout schema reference](../../reference/schemas/resource/stdout/test.md)
+- [DSC resource set operation stdout schema reference](../../reference/schemas/resource/stdout/set.md)
+- [DSC Resource _inDesiredState property schema](../../reference/schemas/resource/properties/inDesiredState.md)
+
+## Relationship between PSDSC and DSC operations
+
+Class-based PSDSC resources always expose the instance methods `Get()`, `Test()`, and `Set()`.
+Through the adapter, the same class can also expose optional static methods that line up with DSC v3
+operations.
+
+| Operation | PSDSC class contract | DSC v3 adapter contract |
+| --- | --- | --- |
+| Get | `[<ResourceClass>] Get()` | `static [<ResourceClass>] Get([<ResourceClass>]$instance)` |
+| Test | `[bool] Test()` | `static [System.Tuple[bool, <ResourceClass>]] Test(...)` or `static [System.Tuple[bool, <ResourceClass>, String[]]] Test(...)` |
+| Set | `[void] Set()` | `static [void] Set(...)`, `static [<ResourceClass>] Set(...)`, or `static [System.Tuple[<ResourceClass>, String[]]] Set(...)` |
+| Delete | not available | `static [void] Delete([<ResourceClass>]$instance)` |
+| Export | not available | `static [<ResourceClass>[]] Export()` and/or `static [<ResourceClass>[]] Export([<ResourceClass>]$filteringInstance)` |
+| Schema | MOF or class properties | `static [string] InstanceJsonSchema()` |
+
+The biggest semantic differences are:
+
+- DSC **Test** returns actual state and can also return differing properties.
+- DSC **Set** returns richer change information and may support explicit `whatIf`.
+- DSC adds **Delete** and **Export**, which have no PSDSC instance-method equivalent.
+
+## The PSDSC `Reasons` pattern
+
+Many PSDSC resources adopted a `Reasons` property to surface why an instance wasn't in the desired
+state.
+
+This pattern was especially important for Azure Machine Configuration and typically required:
+
+1. A resource-specific reason type with only `Code` and `Phrase` string properties.
+1. A non-configurable `Reasons` property on the resource that returned an array of those reason
+   objects.
+
+For example:
+
+```powershell
+class MyModuleReasons {
+    [DscProperty()] [string] $Code
+    [DscProperty()] [string] $Phrase
+}
+
+[DscResource()]
+class Package {
+    [DscProperty(NotConfigurable)] [MyModuleReasons[]] $Reasons
+}
+```
+
+The pattern existed because PSDSC `Test()` only returned a boolean and PSDSC `Set()` returned no
+data. As a result, authors often had to push compliance detail into `Get()`.
+
+In DSC v3, richer `Test` and `Set` results reduce the need for a dedicated `Reasons` property:
+
+- `Test` can return whether the instance is in the desired state, the actual state, and optionally
+  the differing properties.
+- `Set` can return the final state and optionally the changed properties.
+- Resources can also emit structured messages during operations.
+
+## Authoring a class-based resource that works for PSDSC v1/v2 and DSC v3
+
+The following example uses a hypothetical resource named `SoftwarePackage`.
+
+- `Name` is the package name.
+- `Version` is the package version.
+- `_exist` indicates whether the package should exist.
+
+The example keeps the PSDSC instance methods and adds optional static methods for DSC v3:
+
+```powershell
+[DscResource()]
+class SoftwarePackage {
+    [DscProperty(Key)]
+    [string] $Name
+
+    [DscProperty()]
+    [string] $Version
+
+    [DscProperty()]
+    [bool] $_exist = $true
+
+    static [string] InstanceJsonSchema() {
+        return (
+            @{
+                '$schema'   = 'https://json-schema.org/draft/2020-12/schema'
+                type        = 'object'
+                required    = @('name')
+                properties  = @{
+                    name    = @{ type = 'string' }
+                    version = @{ type = 'string' }
+                    _exist  = @{
+                        '$ref' = 'https://aka.ms/dsc/schemas/v3/resource/properties/exist.json'
+                    }
+                }
+            } | ConvertTo-Json -Depth 10 -Compress
+        )
+    }
+
+    static [System.Tuple[bool, SoftwarePackage, string[]]] Test(
+        [SoftwarePackage] $instance
+    ) {
+        return Test-SoftwarePackageResource -Instance $instance
+    }
+
+    static [System.Tuple[SoftwarePackage, string[]]] Set(
+        [SoftwarePackage] $instance
+    ) {
+        return Set-SoftwarePackageResource -Instance $instance
+    }
+
+    static [SoftwarePackage] Get(
+        [SoftwarePackage] $instance
+    ) {
+        return Get-SoftwarePackageResource -Instance $instance
+    }
+
+    static [void] Delete(
+        [SoftwarePackage] $instance
+    ) {
+        Remove-SoftwarePackageResource -Instance $instance
+    }
+
+    static [SoftwarePackage[]] Export() {
+        return Export-SoftwarePackageResource
+    }
+
+    static [SoftwarePackage[]] Export(
+        [SoftwarePackage] $filteringInstance
+    ) {
+        if ($null -eq $filteringInstance) {
+            throw 'Invalid operation'
+        }
+
+        return Export-SoftwarePackageResource -FilteringInstance $filteringInstance
+    }
+
+    [SoftwarePackage] Get() {
+        return Get-SoftwarePackageResource -Instance $this
+    }
+
+    [bool] Test() {
+        return Test-SoftwarePackageResource -Instance $this |
+            Select-Object -ExpandProperty Item1
+    }
+
+    [void] Set() {
+        Set-SoftwarePackageResource -Instance $this
+    }
+}
+```
+
+Key points in this pattern:
+
+- The class remains a valid PSDSC resource.
+- DSC-specific methods are static and optional.
+- The static methods can delegate to internal helper functions.
+- The adapter can translate tuple returns into the JSON Lines DSC expects.
+
+## Using the resource in DSC v3
+
+After the adapter exposes the resource to DSC, you can use it like any other DSC v3 resource.
+
+For example:
+
+```yaml
+resources:
+  - type: Contoso.DSC/SoftwarePackage
+    name: InstallGit
+    properties:
+      Name: git
+```
+
+When the class implements the optional static methods, DSC can:
+
+- Validate input with the schema returned by `InstanceJsonSchema()`.
+- Call richer `Test`, `Set`, `Delete`, and `Export` operations through the adapter.
+- Surface structured state and diff information instead of only PSDSC-compatible results.
+
+## See also
+
+- [RFC 0001 - Class-based PSDSC resource contract for DSC v3](../../../rfc/draft/rfc0001.md)
+- [DSC resource operations](./operations.md)
+- [DSC resource capabilities](./capabilities.md)
+- [DSC resource properties](./properties.md)

--- a/docs/concepts/resources/overview.md
+++ b/docs/concepts/resources/overview.md
@@ -306,6 +306,8 @@ resources:
 
 - [Anatomy of a DSC command resource][05] to learn about authoring resources in your language
   of choice.
+- [Author class-based PSDSC resources for DSC v3][08] to learn about adapting PowerShell
+  class-based resources to the DSC v3 contract.
 - [DSC configuration documents][06] to learn about using resources in a configuration document.
 - [Command line reference for the 'dsc resource' command][07]
 
@@ -316,3 +318,4 @@ resources:
 [05]: ./anatomy.md
 [06]: ../configuration-documents/overview.md
 [07]: ../../reference/cli/resource/index.md
+[08]: ./class-based-psdsc-v3.md

--- a/rfc/draft/rfc0001.md
+++ b/rfc/draft/rfc0001.md
@@ -1,0 +1,456 @@
+---
+RFC:          RFC0001 # WG will set the number after submission
+Author:       jahelmic # <@GitHubUserName>
+Sponsor:      michaeltlombardi    # <@GitHubUserName>
+Status:       Draft   # <Draft | Experimental | Accepted | Final>
+SupercededBy: null    # <Superceding RFC Number>
+Version:      1.0     # <Major>.<Minor>
+Area:         DSC     # <Area within the DSC project>
+CommentsDue:  null    # <Date for submitting comments to current draft (minimum 1 month)>
+---
+
+# Class-based PSDSC resource contract for DSC v3
+
+This RFC defines a contract for PowerShell **class-based** PSDSC resources so that a single
+implementation can:
+
+- Continue to work with **PSDSC v1/v2**, and
+- Participate fully in **DSC v3 semantics** via the PSDSC adapter,
+
+without requiring a hard dependency on a Microsoft-shipped "DSC types" or RDK module.
+
+The RFC focuses on:
+
+- The **method signatures** DSC v3 cares about for PowerShell class-based resources.
+- The **structured return shapes** the adapter must translate to DSC.
+- The **adapter behavior** needed to project those class methods into DSC v3.
+
+## Table of Contents
+
+- [1. Summary](#1-summary)
+- [2. Motivation](#2-motivation)
+- [3. Background and related documentation](#3-background-and-related-documentation)
+- [4. Proposed experience](#4-proposed-experience)
+  - [4.1. Explicitly out of scope](#41-explicitly-out-of-scope)
+- [5. Specification](#5-specification)
+  - [5.1. Resource class shape](#51-resource-class-shape)
+  - [5.2. DSC operation method selection](#52-dsc-operation-method-selection)
+  - [5.3. Method signatures](#53-method-signatures)
+    - [5.3.1. Get operation method](#531-get-operation-method)
+    - [5.3.2. Set operation method](#532-set-operation-method)
+    - [5.3.3. Test operation method](#533-test-operation-method)
+    - [5.3.4. Export operation method](#534-export-operation-method)
+    - [5.3.5. Delete operation method](#535-delete-operation-method)
+    - [5.3.6. InstanceJsonSchema method](#536-instancejsonschema-method)
+  - [5.4. Adapter considerations](#54-adapter-considerations)
+- [6. Alternate Proposals and Considerations](#6-alternate-proposals-and-considerations)
+  - [6.1. Functions as the primary contract](#61-functions-as-the-primary-contract)
+  - [6.2. Mandatory shared types module](#62-mandatory-shared-types-module)
+  - [6.3. Resource metadata and manifest equivalence](#63-resource-metadata-and-manifest-equivalence)
+  - [6.4. RDK on the critical path](#64-rdk-on-the-critical-path)
+- [7. Related work items](#7-related-work-items)
+
+## 1. Summary
+
+This RFC proposes a lightweight contract for PowerShell class-based DSC resources that lets
+existing PSDSC v1/v2 resources adopt DSC v3 behavior incrementally. It defines the resource
+class shape, operation method signatures, and return data needed for the PSDSC adapter and
+tooling to support richer DSC v3 semantics without forcing authors onto a separate codebase or
+new mandatory dependency.
+
+## 2. Motivation
+
+> As a DSC resource author with existing PSDSC class-based resources, I want to augment those
+> resources to participate in DSC v3 semantics, so that I can support both PSDSC v1/v2 and DSC v3
+> without maintaining separate codebases.
+
+Additional motivations:
+
+- Many resources already implemented as **class-based PSDSC resources** have active users and are
+  expensive to rewrite.
+- DSC v3 introduces richer semantics and tooling:
+  - Structured results from `Test`, `Set`, and `Get`.
+  - Better diff semantics.
+  - JSON-schema-based validation and manifest-driven discovery.
+- Resource authors should be able to:
+  - Incrementally add **v3-only capabilities** to existing class-based resources.
+  - Avoid taking a **mandatory dependency** on a Microsoft-shipped types or RDK module.
+- The DSC community needs a **clear, documented contract** so that:
+  - Static analysis is feasible.
+  - Schema and manifest generation is consistent.
+  - ScriptAnalyzer rules can be updated coherently for v1/v2/v3 resources.
+
+## 3. Background and related documentation
+
+This RFC intentionally does **not** restate general DSC semantics. The following docs define the
+shared DSC concepts this contract builds on:
+
+- [DSC resource overview](../../docs/concepts/resources/overview.md)
+- [DSC Get operation semantics](../../docs/concepts/resources/operations.md#get-operation)
+- [DSC Test operation semantics](../../docs/concepts/resources/operations.md#test-operation)
+- [DSC Set operation semantics](../../docs/concepts/resources/operations.md#set-operation)
+- [DSC Delete operation semantics](../../docs/concepts/resources/operations.md#delete-operation)
+- [DSC Export operation semantics](../../docs/concepts/resources/operations.md#export-operation)
+- [DSC set capability semantics](../../docs/concepts/resources/capabilities.md#set)
+- [DSC setHandlesExist capability semantics](../../docs/concepts/resources/capabilities.md#sethandlesexist)
+- [DSC whatIf capability semantics](../../docs/concepts/resources/capabilities.md#whatif)
+- [DSC test capability semantics](../../docs/concepts/resources/capabilities.md#test)
+- [DSC delete capability semantics](../../docs/concepts/resources/capabilities.md#delete)
+- [DSC export capability semantics](../../docs/concepts/resources/capabilities.md#export)
+- [DSC set manifest `return` semantics](../../docs/reference/schemas/resource/manifest/set.md#return)
+- [DSC set manifest `handlesExist` semantics](../../docs/reference/schemas/resource/manifest/set.md#handlesexist)
+- [DSC test manifest `return` semantics](../../docs/reference/schemas/resource/manifest/test.md#return)
+- [DSC whatIf manifest `return` semantics](../../docs/reference/schemas/resource/manifest/whatif.md#return)
+- [DSC Test stdout state output](../../docs/reference/schemas/resource/stdout/test.md#state-output)
+- [DSC Test stdout diff output](../../docs/reference/schemas/resource/stdout/test.md#diff-output)
+- [DSC Set stdout null output](../../docs/reference/schemas/resource/stdout/set.md#null-output)
+- [DSC Set stdout state output](../../docs/reference/schemas/resource/stdout/set.md#state-output)
+- [DSC Set stdout diff output](../../docs/reference/schemas/resource/stdout/set.md#diff-output)
+- [DSC `_inDesiredState` property semantics](../../docs/reference/schemas/resource/properties/inDesiredState.md#description)
+- [DSC embedded instance schema `properties` semantics](../../docs/reference/schemas/resource/manifest/schema/embedded.md#properties)
+
+Supporting material moved out of this RFC is documented in:
+
+- [Author class-based PSDSC resources for DSC v3](../../docs/concepts/resources/class-based-psdsc-v3.md)
+
+## 4. Proposed experience
+
+Resource authors keep a single PowerShell class that remains a valid PSDSC resource and may add
+optional static methods for DSC v3.
+
+Key experience changes:
+
+- All DSC v3-relevant methods are **static** and optional.
+- The class continues to expose the PSDSC **instance methods** `Get()`, `Test()`, and `Set()`.
+- Authors may return richer structured data for DSC v3 without introducing new required types.
+- The adapter projects those static methods into DSC capabilities and JSON Line output.
+
+For a full authoring walkthrough, migration notes for the PSDSC `Reasons` pattern, and end-to-end
+examples, see [Author class-based PSDSC resources for DSC v3](../../docs/concepts/resources/class-based-psdsc-v3.md).
+
+### 4.1. Explicitly out of scope
+
+The following related concerns remain out of scope for this RFC and should be handled separately:
+
+- Discovering DSC classes that do **not** use the `[DscResource()]` attribute.
+- Defining or translating canonical resource properties beyond the specific adapter behavior this
+  RFC requires.
+- Emitting structured messages to `stderr` from class-based resources.
+- Static analysis that generates a JSON schema from the PowerShell class AST.
+- Reference documentation generation from the PowerShell class AST.
+- Enhanced authoring abstractions, such as base classes, reusable attributes, and generic return
+  types.
+
+## 5. Specification
+
+### 5.1. Resource class shape
+
+A PowerShell class-based resource compatible with this contract must define a PowerShell class that
+is also a valid PSDSC resource. This requires the class to:
+
+- Have the `[DscResource()]` attribute.
+- Define at least one property with the `[DscProperty(Key)]` attribute.
+- Define the PSDSC instance methods `Get`, `Set`, and `Test` with the correct signatures.
+
+To participate in DSC v3 through this contract, the author may also implement static methods on the
+class that adhere to the signatures defined in this RFC.
+
+Class skeleton (methods only):
+
+```powershell
+[DscResource()]
+class <ResourceClass> {
+    # PSDSC (instance) methods
+    [<ResourceClass>] Get() {}
+    [bool]            Test() {}
+    [void]            Set() {}
+
+    # DSC (static) methods
+    static [<ResourceClass>]   Get([<ResourceClass>]$instance) {}
+    static [<SetReturn>]       Set([<ResourceClass>]$instance) {}
+    static [<TestReturn>]      Test([<ResourceClass>]$instance) {}
+    static [<ResourceClass>[]] Export() {}
+    static [<ResourceClass>[]] Export([<ResourceClass>]$filteringInstance) {}
+    static [void]              Delete([<ResourceClass>]$instance) {}
+    static [string]            InstanceJsonSchema() {}
+}
+```
+
+> [!NOTE]
+> With the exception of `<ResourceClass>`, the wrapped types such as `[<SetReturn>]` are placeholders
+> defined later in this RFC.
+
+> [!IMPORTANT]
+> Every static method signature is optional. When the class doesn't define a given static method, the
+> PowerShell adapter for DSC handles the resource like a classic PSDSC resource.
+
+### 5.2. DSC operation method selection
+
+If a class has the `[DscResource()]` attribute, DSC and the adapter know that the resource class
+implements the traditional PSDSC resource methods `Get()`, `Set()`, and `Test()`.
+
+When selecting the method to use for an operation, the adapter:
+
+1. Checks for a DSC static method for that operation.
+1. If the resource class implements a matching static method, DSC invokes that method.
+1. If the class doesn't implement a static method for `Get`, `Set`, or `Test`, DSC uses the
+   corresponding PSDSC instance method.
+1. If the class doesn't implement a static or instance method for the operation, DSC raises an
+   error.
+
+Supporting classes that don't have the `[DscResource()]` attribute is out of scope for this RFC.
+
+### 5.3. Method signatures
+
+This RFC proposes the following method signatures. In this proposal, `Tuple` is used for structured
+return data so the contract can be implemented and statically analyzed without any new required
+types.
+
+Future RFCs may introduce strongly-typed result classes or an optional shared types module that map
+to the same shapes.
+
+#### 5.3.1. Get operation method
+
+Signature:
+
+```pwsh
+static [<ResourceClass>] Get([<ResourceClass>]$instance)
+```
+
+The `Get` operation must always return the actual state of the instance with all discoverable
+properties populated.
+
+#### 5.3.2. Set operation method
+
+The general DSC semantics for `Set`, `set.return`, `set.handlesExist`, and `whatIf` are defined in:
+
+- [DSC Set operation semantics](../../docs/concepts/resources/operations.md#set-operation)
+- [DSC set capability semantics](../../docs/concepts/resources/capabilities.md#set)
+- [DSC setHandlesExist capability semantics](../../docs/concepts/resources/capabilities.md#sethandlesexist)
+- [DSC whatIf capability semantics](../../docs/concepts/resources/capabilities.md#whatif)
+- [DSC set manifest `return` semantics](../../docs/reference/schemas/resource/manifest/set.md#return)
+- [DSC set manifest `handlesExist` semantics](../../docs/reference/schemas/resource/manifest/set.md#handlesexist)
+- [DSC whatIf manifest `return` semantics](../../docs/reference/schemas/resource/manifest/whatif.md#return)
+- [DSC Set stdout null output](../../docs/reference/schemas/resource/stdout/set.md#null-output)
+- [DSC Set stdout state output](../../docs/reference/schemas/resource/stdout/set.md#state-output)
+- [DSC Set stdout diff output](../../docs/reference/schemas/resource/stdout/set.md#diff-output)
+
+For this contract:
+
+- The static `Set` method is optional.
+- The adapter infers the effective `set.return` behavior from the method's return type.
+- The adapter behaves as though `implementsPretest` is `false` for this contract and always invokes
+  `Test` before invoking `Set`.
+- For resources that define `_exist`, the adapter behaves as though `setHandlesExist` is `true`.
+- State data returned from `Set` is validated against the instance JSON schema before being emitted
+  to DSC.
+
+Supported signatures:
+
+- No return data:
+
+  ```pwsh
+  static [void] Set([<ResourceClass>]$instance)
+  ```
+
+- Return final state only:
+
+  ```pwsh
+  static [<ResourceClass>] Set([<ResourceClass>]$instance)
+  ```
+
+- Return final state and changed properties:
+
+  ```pwsh
+  static [System.Tuple[<ResourceClass>, String[]]] Set([<ResourceClass>]$instance)
+  ```
+
+- To indicate explicit `whatIf` support, define the same return form with a trailing boolean:
+
+  ```pwsh
+  static [void] Set([<ResourceClass>]$instance, [bool]$whatIf)
+  static [<ResourceClass>] Set([<ResourceClass>]$instance, [bool]$whatIf)
+  static [System.Tuple[<ResourceClass>, String[]]] Set([<ResourceClass>]$instance, [bool]$whatIf)
+  ```
+
+If a class defines both `Set([<ResourceClass>]$instance)` and `Set([<ResourceClass>]$instance, [bool]$whatIf)`,
+the two overloads must use the same return kind.
+
+#### 5.3.3. Test operation method
+
+The general DSC semantics for `Test`, synthetic testing, `test.return`, and `_inDesiredState` are
+defined in:
+
+- [DSC Test operation semantics](../../docs/concepts/resources/operations.md#test-operation)
+- [DSC test capability semantics](../../docs/concepts/resources/capabilities.md#test)
+- [DSC test manifest `return` semantics](../../docs/reference/schemas/resource/manifest/test.md#return)
+- [DSC Test stdout state output](../../docs/reference/schemas/resource/stdout/test.md#state-output)
+- [DSC Test stdout diff output](../../docs/reference/schemas/resource/stdout/test.md#diff-output)
+- [DSC `_inDesiredState` property semantics](../../docs/reference/schemas/resource/properties/inDesiredState.md#description)
+
+For this contract:
+
+1. The PSDSC instance `Test()` method remains mandatory because the class is still a PSDSC resource.
+1. The static `Test` method is optional.
+1. When a static `Test` method is present, the contract returns the in-desired-state boolean
+  separately from the resource instance so the adapter can project `_inDesiredState` for DSC
+  without requiring a corresponding PowerShell class property.
+
+Supported signatures:
+
+- Return in-desired-state and actual state:
+
+  ```pwsh
+  static [System.Tuple[bool, <ResourceClass>]] Test([<ResourceClass>] $instance)
+  ```
+
+- Return in-desired-state, actual state, and differing properties:
+
+  ```pwsh
+  static [System.Tuple[bool, <ResourceClass>, String[]]] Test([<ResourceClass>] $instance)
+  ```
+
+#### 5.3.4. Export operation method
+
+The general DSC semantics for `Export` are defined in:
+
+- [DSC Export operation semantics](../../docs/concepts/resources/operations.md#export-operation)
+- [DSC export capability semantics](../../docs/concepts/resources/capabilities.md#export)
+- [DSC synthetic export semantics](../../docs/concepts/resources/capabilities.md#synthetic-export)
+
+Supported signatures:
+
+- Unfiltered export:
+
+  ```pwsh
+  static [<ResourceClass>[]] Export()
+  ```
+
+- Filtered export:
+
+  ```pwsh
+  static [<ResourceClass>[]] Export([<ResourceClass>]$filteringInstance)
+  ```
+
+The return type for the `Export` operation is always an array of instances of the resource class.
+
+#### 5.3.5. Delete operation method
+
+The general DSC semantics for `Delete` are defined in:
+
+- [DSC Delete operation semantics](../../docs/concepts/resources/operations.md#delete-operation)
+- [DSC delete capability semantics](../../docs/concepts/resources/capabilities.md#delete)
+
+Supported signature:
+
+```pwsh
+static [void] Delete([<ResourceClass>]$instance)
+```
+
+In the current DSC data model, `Delete` returns no data.
+
+#### 5.3.6. InstanceJsonSchema method
+
+The general DSC guidance for resource properties and embedded instance schemas is defined in:
+
+- [DSC resource property semantics](../../docs/concepts/resources/properties.md)
+- [DSC embedded instance schema `properties` semantics](../../docs/reference/schemas/resource/manifest/schema/embedded.md#properties)
+
+Signature:
+
+```pwsh
+static [string] InstanceJsonSchema()
+```
+
+The method must return a string representation of the resource instance JSON schema. The returned
+schema must validate against:
+
+```text
+https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/manifest.schema.json#/properties/embedded
+```
+
+If the class implements this method, DSC and the adapter validate user-supplied data against the
+emitted JSON schema.
+
+### 5.4. Adapter considerations
+
+This RFC assumes a PSDSC-aware adapter for DSC that:
+
+- Can load class-based PSDSC resources and recognize the proposed contract.
+- Converts the return data for resource operations into the JSON Lines DSC expects.
+- Inserts the `_inDesiredState` canonical property into projected `Test` output and the emitted JSON
+  schema shape used for validation.
+- Indicates resource capabilities to DSC based on static analysis of the class.
+- Captures PowerShell stream messages from a resource and emits the correctly structured JSON Line
+  to `stderr`.
+
+> OPEN:
+>
+> - Final shipping model (in-module vs separate module) and versioning strategy.
+> - How to clearly communicate to users what changed when PSDSC or the adapter is updated.
+
+## 6. Alternate Proposals and Considerations
+
+### 6.1. Functions as the primary contract
+
+An alternative approach was to make top-level functions the DSC v3 contract surface, using the
+class only for schema.
+
+- Pros:
+  - Familiar for PowerShell users who prefer functions over classes.
+- Cons:
+  - Requires DSC to reason about a more complex combination of functions and classes.
+  - Static analysis and manifest generation are simpler with everything on the class.
+  - Harder to express the contract as a single analyzable unit.
+
+This RFC proposes **static class methods** as the primary contract, with authors free to delegate
+to functions internally.
+
+### 6.2. Mandatory shared types module
+
+Another alternative was to require all resources to depend on a shared types module for result
+types, attributes, and related helpers.
+
+- Pros:
+  - Strong typing and IntelliSense for result objects and attributes.
+  - Clear place to evolve shared patterns.
+- Cons:
+  - Introduces dependency hell for resource authors and consumers.
+  - Complicates versioning and servicing.
+  - Isn't necessary for basic functionality.
+
+This RFC opts for generic structured forms such as tuples to represent resource output.
+
+### 6.3. Resource metadata and manifest equivalence
+
+The current iteration of this proposal intentionally does not define PowerShell-class equivalents
+for all DSC manifest metadata and switches.
+
+- The contract doesn't expose additional class surface for choosing alternatives to fields such as
+  `set.handlesExist` or `set.implementsPretest`.
+- The contract doesn't define how to represent static resource metadata such as `description`,
+  `author`, or `tags`.
+
+These concerns can be revisited in future RFCs once the core contract for method signatures is
+settled.
+
+### 6.4. RDK on the critical path
+
+The working group explicitly does **not** want the Resource Development Kit (RDK) on the critical
+path:
+
+- RDK should be able to build on this contract once defined.
+- The contract and adapter behavior must stand on their own.
+- Community and Sampler-based tooling can implement schema and manifest generation independently.
+
+## 7. Related work items
+
+- Issue: "Define method signatures for PSDSC resource classes" (link TBD)
+
+  Describes the need to clarify what methods and signatures DSC v3 should look for on class-based
+  resources.
+
+- Future (potential separate RFCs):
+  - PSDSC v2 adapter for DSC v3 (shipping model and behavior).
+  - JSON schema and manifest specification for DSC v3 resources.
+  - ScriptAnalyzer rule set for v1/v2/v3 DSC resources, including class-based patterns.


### PR DESCRIPTION
For @theJasonHelmick and @michaeltlombardi, I've tried to refactor the RFC into something lighter, easier to chew, by moving (maybe aggressively) all related explanations to `docs/` in order to keep the RFC concise on the proposal.

All parts link back to those docs.
Let me know how that look.