### PR TITLE
Add `invoke_dsc_function()` and `invoke_dsc_expression()` tools to Server mode

### DIFF
--- a/dsc/locales/en-us.toml
+++ b/dsc/locales/en-us.toml
@@ -101,12 +101,10 @@ failedSetParameters = "Failed to set parameters"
 [server.invoke_dsc_expression]
 parserInitializationFailed = "Failed to initialize parser: %{error}"
 expressionEvaluationFailed = "Failed to evaluate expression '%{expression}': %{error}"
-failedConvertResult = "Failed to convert expression result to string: %{error}"
 
 [server.invoke_dsc_function]
 parametersNotArray = "Parameters must be an array"
 functionInvocationFailed = "Function '%{function}' invocation failed: %{error}"
-failedConvertResult = "Failed to convert function result to string: %{error}"
 
 [server.invoke_dsc_resource]
 resourceNotFound = "Resource type '%{resource}' does not exist"

--- a/dsc/locales/en-us.toml
+++ b/dsc/locales/en-us.toml
@@ -58,34 +58,6 @@ Visit https://aka.ms/dscv3-docs for more information on how to use DSC.exe.
 Press any key to close this window"""
 failedToStartServer = "Failed to start server: %{error}"
 
-[mcp.mod]
-failedToInitialize = "Failed to initialize MCP server: %{error}"
-failedToStart = "Failed to start MCP server: %{error}"
-instructions = "This server provides tools that work with DSC (DesiredStateConfiguration) which enables users to manage and configure their systems declaratively."
-serverStopped = "MCP server stopped"
-failedToCreateRuntime = "Failed to create async runtime: %{error}"
-serverWaitFailed = "Failed to wait for MCP server: %{error}"
-
-[mcp.invoke_dsc_config]
-invalidConfiguration = "Invalid configuration document"
-invalidParameters = "Invalid parameters"
-failedConvertJson = "Failed to convert to JSON"
-failedSerialize = "Failed to serialize configuration"
-failedSetParameters = "Failed to set parameters"
-
-[mcp.invoke_dsc_resource]
-resourceNotFound = "Resource type '%{resource}' does not exist"
-
-[mcp.list_dsc_functions]
-invalidNamePattern = "Invalid function name pattern '%{pattern}'"
-
-[mcp.list_dsc_resources]
-resourceNotAdapter = "The resource '%{adapter}' is not a valid adapter"
-adapterNotFound = "Adapter '%{adapter}' does not exist"
-
-[mcp.show_dsc_resource]
-resourceNotFound = "Resource type '%{type_name}' does not exist"
-
 [resolve]
 processingInclude = "Processing Include input"
 invalidInclude = "Failed to deserialize Include input"
@@ -110,6 +82,44 @@ testInputEmpty = "Expected input is required"
 jsonError = "JSON: %{err}"
 routingToDelete = "Routing to delete operation because _exist is false"
 syntheticWhatIf = "Resource does not natively support what-if, engine will generate synthetic what-if"
+
+[server.mod]
+failedToInitialize = "Failed to initialize MCP server: %{error}"
+failedToStart = "Failed to start MCP server: %{error}"
+instructions = "This server provides tools that work with DSC (DesiredStateConfiguration) which enables users to manage and configure their systems declaratively."
+serverStopped = "MCP server stopped"
+failedToCreateRuntime = "Failed to create async runtime: %{error}"
+serverWaitFailed = "Failed to wait for MCP server: %{error}"
+
+[server.invoke_dsc_config]
+invalidConfiguration = "Invalid configuration document"
+invalidParameters = "Invalid parameters"
+failedConvertJson = "Failed to convert to JSON"
+failedSerialize = "Failed to serialize configuration"
+failedSetParameters = "Failed to set parameters"
+
+[server.invoke_dsc_expression]
+parserInitializationFailed = "Failed to initialize parser: %{error}"
+expressionEvaluationFailed = "Failed to evaluate expression '%{expression}': %{error}"
+failedConvertResult = "Failed to convert expression result to string: %{error}"
+
+[server.invoke_dsc_function]
+parametersNotArray = "Parameters must be an array"
+functionInvocationFailed = "Function '%{function}' invocation failed: %{error}"
+failedConvertResult = "Failed to convert function result to string: %{error}"
+
+[server.invoke_dsc_resource]
+resourceNotFound = "Resource type '%{resource}' does not exist"
+
+[server.list_dsc_functions]
+invalidNamePattern = "Invalid function name pattern '%{pattern}'"
+
+[server.list_dsc_resources]
+resourceNotAdapter = "The resource '%{adapter}' is not a valid adapter"
+adapterNotFound = "Adapter '%{adapter}' does not exist"
+
+[server.show_dsc_resource]
+resourceNotFound = "Resource type '%{type_name}' does not exist"
 
 [subcommand]
 actualStateNotObject = "actual_state is not an object"

--- a/dsc/src/server/invoke_dsc_config.rs
+++ b/dsc/src/server/invoke_dsc_config.rs
@@ -83,7 +83,7 @@ impl McpServer {
                             return Err(McpError::invalid_request(
                                 format!(
                                     "{}: {e}",
-                                    t!("mcp.invoke_dsc_config.invalidConfiguration")
+                                    t!("server.invoke_dsc_config.invalidConfiguration")
                                 ),
                                 None,
                             ))
@@ -93,7 +93,7 @@ impl McpServer {
                         return Err(McpError::invalid_request(
                             format!(
                                 "{}: {e}",
-                                t!("mcp.invoke_dsc_config.failedConvertJson")
+                                t!("server.invoke_dsc_config.failedConvertJson")
                             ),
                             None,
                         ))
@@ -103,7 +103,7 @@ impl McpServer {
                     return Err(McpError::invalid_request(
                         format!(
                             "{}: {e}",
-                            t!("mcp.invoke_dsc_config.invalidConfiguration")
+                            t!("server.invoke_dsc_config.invalidConfiguration")
                         ),
                         None,
                     ))
@@ -114,7 +114,7 @@ impl McpServer {
                 Ok(json) => json,
                 Err(e) => {
                     return Err(McpError::internal_error(
-                        format!("{}: {e}", t!("mcp.invoke_dsc_config.failedSerialize")),
+                        format!("{}: {e}", t!("server.invoke_dsc_config.failedSerialize")),
                         None,
                     ))
                 }
@@ -135,7 +135,7 @@ impl McpServer {
                             return Err(McpError::invalid_request(
                                 format!(
                                     "{}: {e}",
-                                    t!("mcp.invoke_dsc_config.failedConvertJson")
+                                    t!("server.invoke_dsc_config.failedConvertJson")
                                 ),
                                 None,
                             ))
@@ -145,7 +145,7 @@ impl McpServer {
                         return Err(McpError::invalid_request(
                             format!(
                                 "{}: {e}",
-                                t!("mcp.invoke_dsc_config.invalidParameters")
+                                t!("server.invoke_dsc_config.invalidParameters")
                             ),
                             None,
                         ))
@@ -162,7 +162,7 @@ impl McpServer {
 
             if let Err(e) = configurator.set_context(parameters_value.as_ref()) {
                 return Err(McpError::invalid_request(
-                    format!("{}: {e}", t!("mcp.invoke_dsc_config.failedSetParameters")),
+                    format!("{}: {e}", t!("server.invoke_dsc_config.failedSetParameters")),
                     None,
                 ));
             }

--- a/dsc/src/server/invoke_dsc_expression.rs
+++ b/dsc/src/server/invoke_dsc_expression.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::server::mcp_server::McpServer;
+use dsc_lib::{configure::context::Context, parser::Statement};
+use rmcp::{ErrorData as McpError, Json, tool, tool_router, handler::server::wrapper::Parameters};
+use rust_i18n::t;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::task;
+
+// This wrapper is needed as rmcp does not support directly returning a `Value` type
+#[derive(Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum ExpressionResult {
+    Value(Value),
+}
+
+#[derive(Serialize, JsonSchema)]
+pub struct ExpressionResponse {
+    pub result: ExpressionResult,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct ExpressionRequest {
+    #[schemars(description = "The DSC expression to invoke")]
+    pub expression: String,
+}
+
+#[tool_router(router = invoke_dsc_expression_router, vis = "pub")]
+impl McpServer {
+    #[tool(
+        description = "Invoke a DSC expression.",
+        annotations(
+            title = "Invoke a DSC expression",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true,
+        )
+    )]
+    pub async fn invoke_dsc_expression(&self, Parameters(ExpressionRequest { expression }): Parameters<ExpressionRequest>) -> Result<Json<ExpressionResponse>, McpError> {
+        let result = task::spawn_blocking(move || {
+            let mut statement = Statement::new().map_err(|e| McpError::internal_error(t!("server.invoke_dsc_expression.parserInitializationFailed", error = e), None))?;
+            let result = statement.parse_and_execute(&expression, &Context::new())
+                .map_err(|e| McpError::invalid_request(t!("server.invoke_dsc_expression.expressionEvaluationFailed", expression = expression, error = e), None))?;
+            Ok(ExpressionResponse { result: ExpressionResult::Value(result) })
+        }).await.map_err(|e| McpError::internal_error(e.to_string(), None))??;
+
+        Ok(Json(result))
+    }
+}

--- a/dsc/src/server/invoke_dsc_function.rs
+++ b/dsc/src/server/invoke_dsc_function.rs
@@ -1,0 +1,61 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+use crate::server::mcp_server::McpServer;
+use dsc_lib::{configure::context::Context, functions::FunctionDispatcher};
+use rmcp::{ErrorData as McpError, Json, tool, tool_router, handler::server::wrapper::Parameters};
+use rust_i18n::t;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tokio::task;
+
+// This wrapper is needed as rmcp does not support directly returning a `Value` type
+#[derive(Deserialize, Serialize, JsonSchema)]
+#[serde(untagged)]
+pub enum FunctionValue {
+    Value(Value),
+}
+
+
+#[derive(Serialize, JsonSchema)]
+pub struct FunctionResponse {
+    pub result: FunctionValue,
+}
+
+#[derive(Deserialize, JsonSchema)]
+pub struct FunctionRequest {
+    #[schemars(description = "The name of the DSC function to invoke")]
+    pub function: String,
+    #[schemars(description = "The parameters to pass to the DSC function as JSON array.  Must match the function JSON schema from `list_dsc_function` tool.")]
+    pub parameters: FunctionValue,
+}
+
+#[tool_router(router = invoke_dsc_function_router, vis = "pub")]
+impl McpServer {
+    #[tool(
+        description = "Invoke a DSC function with specified parameters as a JSON Array.",
+        annotations(
+            title = "Invoke a DSC function with specified parameters as a JSON Array",
+            read_only_hint = false,
+            destructive_hint = false,
+            idempotent_hint = true,
+            open_world_hint = true,
+        )
+    )]
+    pub async fn invoke_dsc_function(&self, Parameters(FunctionRequest { function, parameters }): Parameters<FunctionRequest>) -> Result<Json<FunctionResponse>, McpError> {
+        let result = task::spawn_blocking(move || {
+            // if parameters is not JSON array, return error
+            let parameters_array: Vec<Value> = match parameters {
+                FunctionValue::Value(Value::Array(arr)) => arr,
+                _ => return Err(McpError::invalid_request(t!("server.invoke_dsc_function.parametersNotArray"), None)),
+            };
+            let function_dispatcher = FunctionDispatcher::new();
+            let result = function_dispatcher.invoke(&function, &parameters_array, &Context::new())
+                .map_err(|e| McpError::invalid_request(t!("server.invoke_dsc_function.functionInvocationFailed", function = function, error = e), None))?;
+            Ok(FunctionResponse { result: FunctionValue::Value(result) })
+        }).await.map_err(|e| McpError::internal_error(e.to_string(), None))??;
+
+        Ok(Json(result))
+    }
+}

--- a/dsc/src/server/invoke_dsc_function.rs
+++ b/dsc/src/server/invoke_dsc_function.rs
@@ -27,8 +27,8 @@ pub struct FunctionResponse {
 pub struct FunctionRequest {
     #[schemars(description = "The name of the DSC function to invoke")]
     pub function: String,
-    #[schemars(description = "The parameters to pass to the DSC function as JSON array.  Must match the function JSON schema from `list_dsc_function` tool.")]
-    pub parameters: FunctionValue,
+    #[schemars(description = "The parameters to pass to the DSC function as JSON array.  Must match the function JSON schema from `list_dsc_functions` tool.")]
+    pub parameters: Vec<Value>,
 }
 
 #[tool_router(router = invoke_dsc_function_router, vis = "pub")]
@@ -46,12 +46,8 @@ impl McpServer {
     pub async fn invoke_dsc_function(&self, Parameters(FunctionRequest { function, parameters }): Parameters<FunctionRequest>) -> Result<Json<FunctionResponse>, McpError> {
         let result = task::spawn_blocking(move || {
             // if parameters is not JSON array, return error
-            let parameters_array: Vec<Value> = match parameters {
-                FunctionValue::Value(Value::Array(arr)) => arr,
-                _ => return Err(McpError::invalid_request(t!("server.invoke_dsc_function.parametersNotArray"), None)),
-            };
             let function_dispatcher = FunctionDispatcher::new();
-            let result = function_dispatcher.invoke(&function, &parameters_array, &Context::new())
+            let result = function_dispatcher.invoke(&function, &parameters, &Context::new())
                 .map_err(|e| McpError::invalid_request(t!("server.invoke_dsc_function.functionInvocationFailed", function = function, error = e), None))?;
             Ok(FunctionResponse { result: FunctionValue::Value(result) })
         }).await.map_err(|e| McpError::internal_error(e.to_string(), None))??;

--- a/dsc/src/server/invoke_dsc_resource.rs
+++ b/dsc/src/server/invoke_dsc_resource.rs
@@ -72,7 +72,7 @@ impl McpServer {
         let result = task::spawn_blocking(move || {
             let mut dsc = DscManager::new();
             let Some(resource) = dsc.find_resource(&DiscoveryFilter::new(&resource_type, None, None)).unwrap_or(None) else {
-                return Err(McpError::invalid_request(t!("mcp.invoke_dsc_resource.resourceNotFound", resource = resource_type), None));
+                return Err(McpError::invalid_request(t!("server.invoke_dsc_resource.resourceNotFound", resource = resource_type), None));
             };
             match operation {
                 DscOperation::Get => {

--- a/dsc/src/server/list_dsc_functions.rs
+++ b/dsc/src/server/list_dsc_functions.rs
@@ -47,7 +47,7 @@ impl McpServer {
 
                 let regex = regex_builder.build()
                     .map_err(|_| McpError::invalid_params(
-                        t!("mcp.list_dsc_functions.invalidNamePattern", pattern = name_pattern),
+                        t!("server.list_dsc_functions.invalidNamePattern", pattern = name_pattern),
                         None
                     ))?;
 

--- a/dsc/src/server/list_dsc_resources.rs
+++ b/dsc/src/server/list_dsc_resources.rs
@@ -53,11 +53,11 @@ impl McpServer {
                 Some(adapter) => {
                     if let Some(resource) = dsc.find_resource(&DiscoveryFilter::new(&adapter, None, None)).unwrap_or(None) {
                         if resource.kind != Kind::Adapter {
-                            return Err(McpError::invalid_params(t!("mcp.list_dsc_resources.resourceNotAdapter", adapter = adapter), None));
+                            return Err(McpError::invalid_params(t!("server.list_dsc_resources.resourceNotAdapter", adapter = adapter), None));
                         }
                         Some(&TypeNameFilter::Literal(resource.type_name.clone()))
                     } else {
-                        return Err(McpError::invalid_params(t!("mcp.list_dsc_resources.adapterNotFound", adapter = adapter), None));
+                        return Err(McpError::invalid_params(t!("server.list_dsc_resources.adapterNotFound", adapter = adapter), None));
                     }
                 },
                 None => None,

--- a/dsc/src/server/mcp_server.rs
+++ b/dsc/src/server/mcp_server.rs
@@ -22,6 +22,8 @@ impl McpServer {
         Self {
             tool_router:
                 Self::invoke_dsc_config_router()
+                + Self::invoke_dsc_expression_router()
+                + Self::invoke_dsc_function_router()
                 + Self::invoke_dsc_resource_router()
                 + Self::list_dsc_functions_router()
                 + Self::list_dsc_resources_router()
@@ -45,7 +47,7 @@ impl ServerHandler for McpServer {
                 .enable_tools()
                 .build()
         );
-        info.instructions = Some(t!("mcp.mod.instructions").to_string());
+        info.instructions = Some(t!("server.mod.instructions").to_string());
         info
     }
 

--- a/dsc/src/server/mod.rs
+++ b/dsc/src/server/mod.rs
@@ -10,6 +10,8 @@ use rmcp::{
 use rust_i18n::t;
 
 pub mod invoke_dsc_config;
+pub mod invoke_dsc_expression;
+pub mod invoke_dsc_function;
 pub mod invoke_dsc_resource;
 pub mod list_dsc_functions;
 pub mod list_dsc_resources;
@@ -28,13 +30,13 @@ pub async fn start_server_async() -> Result<(), McpError> {
 
     // Try to create the service with proper error handling
     let service = server.serve(stdio()).await
-        .map_err(|err|  McpError::internal_error(t!("mcp.mod.failedToInitialize", error = err.to_string()), None))?;
+        .map_err(|err|  McpError::internal_error(t!("server.mod.failedToInitialize", error = err.to_string()), None))?;
 
     // Wait for the service to complete with proper error handling
     service.waiting().await
-        .map_err(|err| McpError::internal_error(t!("mcp.mod.serverWaitFailed", error = err.to_string()), None))?;
+        .map_err(|err| McpError::internal_error(t!("server.mod.serverWaitFailed", error = err.to_string()), None))?;
 
-    tracing::info!("{}", t!("mcp.mod.serverStopped"));
+    tracing::info!("{}", t!("server.mod.serverStopped"));
     Ok(())
 }
 
@@ -45,9 +47,9 @@ pub async fn start_server_async() -> Result<(), McpError> {
 /// This function will return an error if the MCP server fails to start or if the tokio runtime cannot be created.
 pub fn start_server() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     let rt = tokio::runtime::Runtime::new()
-        .map_err(|e| McpError::internal_error(t!("mcp.mod.failedToCreateRuntime", error = e.to_string()), None))?;
+        .map_err(|e| McpError::internal_error(t!("server.mod.failedToCreateRuntime", error = e.to_string()), None))?;
 
     rt.block_on(start_server_async())
-        .map_err(|e| McpError::internal_error(t!("mcp.mod.failedToStart", error = e.to_string()), None))?;
+        .map_err(|e| McpError::internal_error(t!("server.mod.failedToStart", error = e.to_string()), None))?;
     Ok(())
 }

--- a/dsc/src/server/show_dsc_resource.rs
+++ b/dsc/src/server/show_dsc_resource.rs
@@ -65,7 +65,7 @@ impl McpServer {
         let result = task::spawn_blocking(move || {
             let mut dsc = DscManager::new();
             let Some(resource) = dsc.find_resource(&DiscoveryFilter::new(&r#type, None, None)).unwrap_or(None) else {
-                return Err(McpError::invalid_params(t!("mcp.show_dsc_resource.resourceNotFound", type_name = r#type), None))
+                return Err(McpError::invalid_params(t!("server.show_dsc_resource.resourceNotFound", type_name = r#type), None))
             };
             let schema = match resource.schema() {
                 Ok(schema_str) => serde_json::from_str(&schema_str).ok(),

--- a/dsc/tests/dsc_server.tests.ps1
+++ b/dsc/tests/dsc_server.tests.ps1
@@ -645,6 +645,7 @@ greeting: Hello from YAML parameters
         @{ expression = "[createObject('key1', 'value1', 'key2', 2)]"; expected = [pscustomobject]@{ key1 = 'value1'; key2 = 2 } }
         @{ expression = "[createArray('hello', 'world')]"; expected = @('hello', 'world') }
         @{ expression = "[tryWhich('nonexistent')]"; expected = $null }
+        @{ expression = "bareWord"; expected = "bareWord" }
     ) {
         param($expression, $expected)
 
@@ -671,6 +672,25 @@ greeting: Hello from YAML parameters
         }
     }
 
+    It 'Calling invoke_dsc_expression with invalid expression returns error' {
+        $mcpRequest = @{
+            jsonrpc = "2.0"
+            id      = 21
+            method  = "tools/call"
+            params  = @{
+                name      = "invoke_dsc_expression"
+                arguments = @{
+                    expression = "[invalid expression]"
+                }
+            }
+        }
+
+        $response = Send-McpRequest -request $mcpRequest
+        $response.id | Should -Be 21
+        $response.error.code | Should -Be -32600
+        $response.error.message | Should -BeExactly "Failed to evaluate expression '[invalid expression]': Parser: Unable to parse statement root: [invalid expression]"
+    }
+
     It 'Calling invoke_dsc_function works: <function>' -TestCases @(
         @{ function = "concat"; parameters = @("Hello", " ", "World"); expected = "Hello World" }
         @{ function = "add"; parameters = @(2, 4); expected = 6 }
@@ -682,7 +702,7 @@ greeting: Hello from YAML parameters
         param($function, $parameters, $expected)
         $mcpRequest = @{
             jsonrpc = "2.0"
-            id      = 21
+            id      = 22
             method  = "tools/call"
             params  = @{
                 name      = "invoke_dsc_function"
@@ -694,7 +714,7 @@ greeting: Hello from YAML parameters
         }
 
         $response = Send-McpRequest -request $mcpRequest
-        $response.id | Should -Be 21
+        $response.id | Should -Be 22
         if ($expected -is [pscustomobject] -or $expected -is [array]) {
             $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
             $expectedJson = $expected | ConvertTo-Json -Depth 10
@@ -702,5 +722,45 @@ greeting: Hello from YAML parameters
         } else {
             $response.result.structuredContent.result | Should -Be $expected -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
         }
+    }
+
+    It 'Calling invoke_dsc_function with invalid function returns error' {
+        $mcpRequest = @{
+            jsonrpc = "2.0"
+            id      = 23
+            method  = "tools/call"
+            params  = @{
+                name      = "invoke_dsc_function"
+                arguments = @{
+                    function   = "nonexistentFunction"
+                    parameters = @()
+                }
+            }
+        }
+
+        $response = Send-McpRequest -request $mcpRequest
+        $response.id | Should -Be 23
+        $response.error.code | Should -Be -32600
+        $response.error.message | Should -BeExactly "Function 'nonexistentFunction' invocation failed: Parser: Unknown function 'nonexistentFunction'"
+    }
+
+    It 'Calling invoke_dsc_function with invalid function parameters returns error' {
+        $mcpRequest = @{
+            jsonrpc = "2.0"
+            id      = 24
+            method  = "tools/call"
+            params  = @{
+                name      = "invoke_dsc_function"
+                arguments = @{
+                    function   = "add"
+                    parameters = @("not a number", 4)
+                }
+            }
+        }
+
+        $response = Send-McpRequest -request $mcpRequest
+        $response.id | Should -Be 24
+        $response.error.code | Should -Be -32600
+        $response.error.message | Should -BeExactly "Function 'add' invocation failed: Parser: Function 'add' does not accept string arguments, accepted types are: Number"
     }
 }

--- a/dsc/tests/dsc_server.tests.ps1
+++ b/dsc/tests/dsc_server.tests.ps1
@@ -642,7 +642,7 @@ greeting: Hello from YAML parameters
         @{ expression = "[add(2, 4)]"; expected = 6 }
         @{ expression = "[empty(createArray(1,2))]"; expected = $false }
         @{ expression = "[createArray(1,2,3)]"; expected = @(1,2,3) }
-        @{ expression = "[createObject('key1', 'value1', 'key2', 2)]"; expected = @{ key1 = 'value1'; key2 = 2 } }
+        @{ expression = "[createObject('key1', 'value1', 'key2', 2)]"; expected = [pscustomobject]@{ key1 = 'value1'; key2 = 2 } }
         @{ expression = "[createArray('hello', 'world')]"; expected = @('hello', 'world') }
         @{ expression = "[tryWhich('nonexistent')]"; expected = $null }
     ) {
@@ -662,7 +662,7 @@ greeting: Hello from YAML parameters
 
         $response = Send-McpRequest -request $mcpRequest
         $response.id | Should -Be 20
-        if ($expected -is [hashtable] -or $expected -is [array]) {
+        if ($expected -is [pscustomobject] -or $expected -is [array]) {
             $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
             $expectedJson = $expected | ConvertTo-Json -Depth 10
             $result | Should -Be $expectedJson -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
@@ -676,7 +676,7 @@ greeting: Hello from YAML parameters
         @{ function = "add"; parameters = @(2, 4); expected = 6 }
         @{ function = "empty"; parameters = @( "hello" ); expected = $false }
         @{ function = "createArray"; parameters = @(1,2,3); expected = @(1,2,3) }
-        @{ function = "createObject"; parameters = @('key1', 'value1', 'key2', 2); expected = @{ key1 = 'value1'; key2 = 2 } }
+        @{ function = "createObject"; parameters = @('key1', 'value1', 'key2', 2); expected = [pscustomobject]@{ key1 = 'value1'; key2 = 2 } }
         @{ function = "tryWhich"; parameters = @('nonexistent'); expected = $null }
     ) {
         param($function, $parameters, $expected)
@@ -695,7 +695,7 @@ greeting: Hello from YAML parameters
 
         $response = Send-McpRequest -request $mcpRequest
         $response.id | Should -Be 21
-        if ($expected -is [hashtable] -or $expected -is [array]) {
+        if ($expected -is [pscustomobject] -or $expected -is [array]) {
             $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
             $expectedJson = $expected | ConvertTo-Json -Depth 10
             $result | Should -Be $expectedJson -Because ($response | ConvertTo-Json -Depth 20 | Out-String)

--- a/dsc/tests/dsc_server.tests.ps1
+++ b/dsc/tests/dsc_server.tests.ps1
@@ -71,12 +71,14 @@ Describe 'Tests for DSC server' {
         }
 
         $tools = @{
-            'invoke_dsc_config'   = $false
-            'invoke_dsc_resource' = $false
-            'list_dsc_functions'  = $false
-            'list_dsc_resources'  = $false
-            'show_dsc_resource'   = $false
-            'show_dsc_schema'     = $false
+            'invoke_dsc_config'     = $false
+            'invoke_dsc_expression' = $false
+            'invoke_dsc_function'   = $false
+            'invoke_dsc_resource'   = $false
+            'list_dsc_functions'    = $false
+            'list_dsc_resources'    = $false
+            'show_dsc_resource'     = $false
+            'show_dsc_schema'       = $false
         }
 
         $response = Send-McpRequest -request $mcpRequest
@@ -633,5 +635,72 @@ greeting: Hello from YAML parameters
         $schema = dsc schema --type adapted-dsc-resource-manifest | ConvertFrom-Json -Depth 20
         $response.result.structuredContent.schema.'$schema' | Should -Be $schema.'$schema' -Because ($response.result.structuredContent | ConvertTo-Json -Depth 20 | Out-String)
         $response.result.structuredContent.schema.title | Should -BeExactly $schema.title -Because ($response.result.structuredContent | ConvertTo-Json -Depth 20 | Out-String)
+    }
+
+    It 'Calling invoke_dsc_expression works: <expression>' -TestCases @(
+        @{ expression = "[concat('Hello', ' ', 'World')]"; expected = "Hello World" }
+        @{ expression = "[add(2, 4)]"; expected = 6 }
+        @{ expression = "[empty(createArray(1,2))]"; expected = $false }
+        @{ expression = "[createArray(1,2,3)]"; expected = @(1,2,3) }
+        @{ expression = "[createObject('key1', 'value1', 'key2', 2)]"; expected = @{ key1 = 'value1'; key2 = 2 } }
+        @{ expression = "[createArray('hello', 'world')]"; expected = @('hello', 'world') }
+        @{ expression = "[tryWhich('nonexistent')]"; expected = $null }
+    ) {
+        param($expression, $expected)
+
+        $mcpRequest = @{
+            jsonrpc = "2.0"
+            id      = 20
+            method  = "tools/call"
+            params  = @{
+                name      = "invoke_dsc_expression"
+                arguments = @{
+                    expression = $expression
+                }
+            }
+        }
+
+        $response = Send-McpRequest -request $mcpRequest
+        $response.id | Should -Be 20
+        if ($expected -is [hashtable]) {
+            $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
+            $expectedJson = $expected | ConvertTo-Json -Depth 10
+            $result | Should -Be $expectedJson -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
+        } else {
+            $response.result.structuredContent.result | Should -Be $expected -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
+        }
+    }
+
+    It 'Calling invoke_dsc_function works: <function>' -TestCases @(
+        @{ function = "concat"; parameters = @("Hello", " ", "World"); expected = "Hello World" }
+        @{ function = "add"; parameters = @(2, 4); expected = 6 }
+        @{ function = "empty"; parameters = @( "hello" ); expected = $false }
+        @{ function = "createArray"; parameters = @(1,2,3); expected = @(1,2,3) }
+        @{ function = "createObject"; parameters = @('key1', 'value1', 'key2', 2); expected = @{ key1 = 'value1'; key2 = 2 } }
+        @{ function = "tryWhich"; parameters = @('nonexistent'); expected = $null }
+    ) {
+        param($function, $parameters, $expected)
+        $mcpRequest = @{
+            jsonrpc = "2.0"
+            id      = 21
+            method  = "tools/call"
+            params  = @{
+                name      = "invoke_dsc_function"
+                arguments = @{
+                    function   = $function
+                    parameters = $parameters
+                }
+            }
+        }
+
+        $response = Send-McpRequest -request $mcpRequest
+        $response.id | Should -Be 21
+        if ($expected -is [hashtable]) {
+            $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
+            $expectedJson = $expected | ConvertTo-Json -Depth 10
+            $result | Should -Be $expectedJson -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
+        } else {
+            $response.result.structuredContent.result | Should -Be $expected -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
+        }
     }
 }

--- a/dsc/tests/dsc_server.tests.ps1
+++ b/dsc/tests/dsc_server.tests.ps1
@@ -662,7 +662,7 @@ greeting: Hello from YAML parameters
 
         $response = Send-McpRequest -request $mcpRequest
         $response.id | Should -Be 20
-        if ($expected -is [hashtable]) {
+        if ($expected -is [hashtable] -or $expected -is [array]) {
             $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
             $expectedJson = $expected | ConvertTo-Json -Depth 10
             $result | Should -Be $expectedJson -Because ($response | ConvertTo-Json -Depth 20 | Out-String)
@@ -695,7 +695,7 @@ greeting: Hello from YAML parameters
 
         $response = Send-McpRequest -request $mcpRequest
         $response.id | Should -Be 21
-        if ($expected -is [hashtable]) {
+        if ($expected -is [hashtable] -or $expected -is [array]) {
             $result = $response.result.structuredContent.result | ConvertTo-Json -Depth 10
             $expectedJson = $expected | ConvertTo-Json -Depth 10
             $result | Should -Be $expectedJson -Because ($response | ConvertTo-Json -Depth 20 | Out-String)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Complete renaming of loc string tags to `server` instead of `mcp`
- Add `invoke_dsc_function()` and `invoke_dsc_expression()` tools

`rmcp` crate doesn't allow direct use of `serde_json::Value` type, so need a wrapper enum to make it work.

## PR Context

For you @ThomasNieto :)