### PR TITLE
Fix extension discover test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4240,15 +4240,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_feature"
-version = "0.1.0"
-dependencies = [
- "rust-i18n",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "windows_firewall"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ default-members = [
     "lib/dsc-lib-registry",
     "resources/runcommandonset",
     "lib/dsc-lib-security_context",
+    "resources/dism_dsc",
     "resources/sshdconfig",
     "resources/WindowsUpdate",
     "resources/windows_service",
@@ -57,8 +58,7 @@ default-members = [
     "grammars/tree-sitter-dscexpression",
     "grammars/tree-sitter-ssh-server-config",
     "y2j",
-    "xtask",
-    "resources/dism_dsc"
+    "xtask"
 ]
 
 [workspace.metadata.groups]

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -109,7 +109,6 @@ Describe 'Discover extension tests' {
             $out.type | Should -Be 'Test/DiscoverRelative'
             $out = dsc resource list 2> $TestDrive/error.log
             $LASTEXITCODE | Should -Be 0
-            $out | Should -BeNullOrEmpty
             $errorMessage = Get-Content -Path "$TestDrive/error.log" -Raw
             $errorMessage | Should -BeLike '*is not an absolute path*'
         } finally {

--- a/dsc/tests/dsc_extension_discover.tests.ps1
+++ b/dsc/tests/dsc_extension_discover.tests.ps1
@@ -107,7 +107,7 @@ Describe 'Discover extension tests' {
             $out = dsc extension list | ConvertFrom-Json
             $out.Count | Should -Be 1 -Because ($out | Out-String)
             $out.type | Should -Be 'Test/DiscoverRelative'
-            $out = dsc resource list 2> $TestDrive/error.log
+            $null = dsc resource list 2> $TestDrive/error.log
             $LASTEXITCODE | Should -Be 0
             $errorMessage = Get-Content -Path "$TestDrive/error.log" -Raw
             $errorMessage | Should -BeLike '*is not an absolute path*'

--- a/lib/dsc-lib-jsonschema/.versions.json
+++ b/lib/dsc-lib-jsonschema/.versions.json
@@ -1,10 +1,11 @@
 {
   "latestMajor": "V3",
   "latestMinor": "V3_2",
-  "latestPatch": "V3_2_1",
+  "latestPatch": "V3_2_2",
   "all": [
     "V3",
     "V3_2",
+    "V3_2_2",
     "V3_2_1",
     "V3_2_0",
     "V3_1",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Now that PS7 ships w/ a DSCv3 resource, it invalidates one of the expectations of the discover extension test.  Fix is to remove that check since it's not really needed for the purpose of the test anyways.

Also updated .versions.json since the build detects a new version.
Cargo.toml reorganization