### PR TITLE
Increase default stack size on Windows

### DIFF
--- a/dsc/locales/en-us.toml
+++ b/dsc/locales/en-us.toml
@@ -39,6 +39,8 @@ serverAbout = "Use DSC as a server over JSON-RPC (useful as MCP server)"
 bicepAbout = "Use DSC as a Bicep server over gRPC"
 
 [main]
+failedToSpawnMain = "Failed to spawn dsc main thread: %{error}"
+failedToJoinMain = "Failed to join dsc main thread: %{error}"
 ctrlCReceived = "Ctrl-C received"
 failedCtrlCHandler = "Failed to set Ctrl-C handler"
 generatingCompleter = "Generating completion script for"

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -29,6 +29,21 @@ pub mod util;
 i18n!("locales", fallback = "en-us");
 
 fn main() {
+    #[cfg(windows)]
+    {
+        let mut builder = std::thread::Builder::new();
+        builder = builder.stack_size(2 * 1024 * 1024); // Default stack is too small on Windows causing overflow
+        builder.spawn(|| {
+            dsc_main();
+        }).unwrap().join().unwrap();
+    }
+    #[cfg(not(windows))]
+    {
+        dsc_main();
+    }
+}
+
+fn dsc_main() {
     #[cfg(debug_assertions)]
     check_debug();
 

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -31,11 +31,22 @@ i18n!("locales", fallback = "en-us");
 fn main() {
     #[cfg(windows)]
     {
-        let mut builder = std::thread::Builder::new();
-        builder = builder.stack_size(2 * 1024 * 1024); // Default stack is too small on Windows causing overflow
-        builder.spawn(|| {
-            dsc_main();
-        }).unwrap().join().unwrap();
+        let handle = match std::thread::Builder::new()
+            .name("dsc-main".to_string())
+            .stack_size(2 * 1024 * 1024) // Default stack is too small on Windows causing overflow
+            .spawn(dsc_main)
+        {
+            Ok(handle) => handle,
+            Err(err) => {
+                error!("Failed to spawn dsc main thread: {err}");
+                exit(util::EXIT_DSC_ERROR);
+            }
+        };
+
+        if let Err(err) = handle.join() {
+            error!("dsc main thread panicked: {err:?}");
+            exit(util::EXIT_DSC_ERROR);
+        }
     }
     #[cfg(not(windows))]
     {

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -38,13 +38,13 @@ fn main() {
         {
             Ok(handle) => handle,
             Err(err) => {
-                error!("Failed to spawn dsc main thread: {err}");
+                error!("{}", t!("main.failedToSpawnMain", error = err));
                 exit(util::EXIT_DSC_ERROR);
             }
         };
 
         if let Err(err) = handle.join() {
-            error!("dsc main thread panicked: {err:?}");
+            error!("{}", t!("main.failedToJoinMain", error = err : {:?}));
             exit(util::EXIT_DSC_ERROR);
         }
     }


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Debug builds on Windows are hitting the limits of the default stack size and `clap` creating the arg structures.  Fix is on Windows, increase the stack size to 2MB (I believe default is 1MB).
