### PR TITLE
Fix PSAdapter to work with modules that have ScriptsToProcess

### DIFF
--- a/adapters/powershell/Tests/TestClassResource/0.0.1/TestClassResource.psd1
+++ b/adapters/powershell/Tests/TestClassResource/0.0.1/TestClassResource.psd1
@@ -36,6 +36,8 @@ AliasesToExport = @()
 # DSC resources to export from this module
 DscResourcesToExport = @('TestClassResource', 'NoExport', 'FilteredExport', 'StreamResource')
 
+ScriptsToProcess = @('TestScript.ps1')
+
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{
     PSData = @{

--- a/adapters/powershell/Tests/TestClassResource/0.0.1/TestScript.ps1
+++ b/adapters/powershell/Tests/TestClassResource/0.0.1/TestScript.ps1
@@ -1,1 +1,1 @@
-# does thing
+# does nothing

--- a/adapters/powershell/Tests/TestClassResource/0.0.1/TestScript.ps1
+++ b/adapters/powershell/Tests/TestClassResource/0.0.1/TestScript.ps1
@@ -1,0 +1,1 @@
+# does thing

--- a/adapters/powershell/psDscAdapter/psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/psDscAdapter.psm1
@@ -637,11 +637,13 @@ function GetTypeInstanceFromModule {
         [Parameter(Mandatory = $true)]
         [string] $classname
     )
-    $module = Get-Module -Name $modulename -ErrorAction Ignore
+    $module = Get-Module -Name $modulename
     if ($null -eq $module) {
-        $module = Import-Module -Name $modulename -ErrorAction Stop -PassThru
+        # `Import-Module -Passthru` will return multiple objects if there are ScriptsToProcess, so we use `Get-Module` separately
+        Import-Module -Name $modulename -Force -ErrorAction Stop
+        $module = Get-Module -Name $modulename
     }
-    $instance = & ($module) ([scriptblock]::Create("'$classname' -as 'type'"))
+    $instance = $module.Invoke([scriptblock]::Create("'$classname' -as 'type'"))
     return $instance
 }
 

--- a/adapters/powershell/psDscAdapter/psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/psDscAdapter.psm1
@@ -642,6 +642,9 @@ function GetTypeInstanceFromModule {
         # `Import-Module -Passthru` will return multiple objects if there are ScriptsToProcess, so we use `Get-Module` separately
         Import-Module -Name $modulename -Force -ErrorAction Stop
         $module = Get-Module -Name $modulename
+        if ($module.Count -gt 1) {
+            throw "Multiple modules imported for $modulename"
+        }
     }
     $instance = $module.Invoke([scriptblock]::Create("'$classname' -as 'type'"))
     return $instance

--- a/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
@@ -235,7 +235,7 @@ function Invoke-DscCacheRefresh {
             }
 
             # workaround: Use GetTypeInstanceFromModule to get the type instance from the module and validate if it is a class-based resource
-            $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name -ErrorAction SilentlyContinue
+            $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name
             if ($classBased -and ($classBased.CustomAttributes.AttributeType.Name -eq 'DscResourceAttribute')) {
                 Write-Debug -Debug ("Detected class-based resource: $($dscResource.Name) => Type: $($classBased.BaseType.FullName)")
                 $dscResourceInfo.ImplementationDetail = 'ClassBased'
@@ -623,7 +623,13 @@ function GetTypeInstanceFromModule {
         [Parameter(Mandatory = $true)]
         [string] $classname
     )
-    $instance = & (Import-Module $modulename -PassThru) ([scriptblock]::Create("'$classname' -as 'type'"))
+    $module = Get-Module -Name $modulename
+    if ($null -eq $module) {
+        # `Import-Module -Passthru` will return multiple objects if there are ScriptsToProcess, so we use `Get-Module` separately
+        Import-Module -Name $modulename -Force -ErrorAction Stop
+        $module = Get-Module -Name $modulename
+    }
+    $instance = $module.Invoke([scriptblock]::Create("'$classname' -as 'type'"))
     return $instance
 }
 

--- a/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
@@ -235,7 +235,12 @@ function Invoke-DscCacheRefresh {
             }
 
             # workaround: Use GetTypeInstanceFromModule to get the type instance from the module and validate if it is a class-based resource
-            $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name
+            try {
+                $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name
+            }
+            catch {
+                Write-Warning "Failed to get type instance from module '$moduleName': $_"
+            }
             if ($classBased -and ($classBased.CustomAttributes.AttributeType.Name -eq 'DscResourceAttribute')) {
                 Write-Debug -Debug ("Detected class-based resource: $($dscResource.Name) => Type: $($classBased.BaseType.FullName)")
                 $dscResourceInfo.ImplementationDetail = 'ClassBased'
@@ -628,6 +633,9 @@ function GetTypeInstanceFromModule {
         # `Import-Module -Passthru` will return multiple objects if there are ScriptsToProcess, so we use `Get-Module` separately
         Import-Module -Name $modulename -Force -ErrorAction Stop
         $module = Get-Module -Name $modulename
+        if ($module.Count -gt 1) {
+            throw "Multiple modules imported for $modulename"
+        }
     }
     $instance = $module.Invoke([scriptblock]::Create("'$classname' -as 'type'"))
     return $instance

--- a/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
+++ b/adapters/powershell/psDscAdapter/win_psDscAdapter.psm1
@@ -235,7 +235,7 @@ function Invoke-DscCacheRefresh {
             }
 
             # workaround: Use GetTypeInstanceFromModule to get the type instance from the module and validate if it is a class-based resource
-            $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name -ErrorAction Ignore
+            $classBased = GetTypeInstanceFromModule -modulename $moduleName -classname $dscResource.Name -ErrorAction SilentlyContinue
             if ($classBased -and ($classBased.CustomAttributes.AttributeType.Name -eq 'DscResourceAttribute')) {
                 Write-Debug -Debug ("Detected class-based resource: $($dscResource.Name) => Type: $($classBased.BaseType.FullName)")
                 $dscResourceInfo.ImplementationDetail = 'ClassBased'
@@ -476,14 +476,11 @@ function Invoke-DscOperation {
                                     $_.Value.Password
 
                                 if (-not $hasSecureCred -and -not $hasTextCred) {
-                                Write-Debug -Debug "Invalid credential object for property '$($_.Name)'"
                                     Write-Error ("Credential object '$($_.Name)' requires both 'username' and 'password' properties")
                                     exit 1
                                 }
 
                                 if ($hasSecureCred) {
-                                Write-Debug -Debug "Credential object '$($_.Name)' - SecureObject"
-
                                     $username = $_.Value.secureObject.Username
                                     $password = $_.Value.secureObject.Password |
                                         ConvertTo-SecureString -AsPlainText -Force
@@ -492,8 +489,6 @@ function Invoke-DscOperation {
                                         [System.Management.Automation.PSCredential]::new($username, $password)
                                 }
                                 elseif ($hasTextCred) {
-                                    Write-Debug -Debug "Credential object '$($_.Name)' - Text"
-
                                     $username = $_.Value.Username
                                     $password = $_.Value.Password |
                                         ConvertTo-SecureString -AsPlainText -Force


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

The PSAdapter uses module scope to instantiate a class based resource.  The problem is if the module has `ScriptsToProcess`, then `Import-Module -Passthru` actually returns each script as an object when the PSAdapter was expecting just a single `PSModuleInfo`.  The fix is to not `Import-Module` if the module is already loaded, but also if there is a need to import the module, use a separate call to `Get-Module` which should return a single object.  If multiple modules (like different versions) are returned, that's an error.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1574
