### PR TITLE
(GH-1580) Fix table output for no-truncate option

### DIFF
--- a/dsc/src/subcommand.rs
+++ b/dsc/src/subcommand.rs
@@ -615,18 +615,27 @@ pub fn resource(subcommand: &ResourceSubCommand, progress_format: ProgressFormat
     }
 }
 
+/// Indicates whether to emit a table based on the output format and whether stdout is a terminal.
+fn should_write_table(format: Option<&ListOutputFormat>) -> bool {
+    if matches!(format, Some(ListOutputFormat::TableNoTruncate)) {
+        // write as table if user specified the table format
+        true
+    } else {
+        // write as table if format is not specified and interactive
+        format.is_none() && io::stdout().is_terminal()
+    }
+}
+
 fn list_extensions(dsc: &mut DscManager, extension_name: &TypeNameFilter, format: Option<&ListOutputFormat>, progress_format: ProgressFormat) {
-    let mut write_table = false;
+    let write_table = should_write_table(format);
+
     let mut table = Table::new(&[
         t!("subcommand.tableHeader_type").to_string().as_ref(),
         t!("subcommand.tableHeader_version").to_string().as_ref(),
         t!("subcommand.tableHeader_capabilities").to_string().as_ref(),
         t!("subcommand.tableHeader_description").to_string().as_ref(),
     ]);
-    if format.is_none() && io::stdout().is_terminal() {
-        // write as table if format is not specified and interactive
-        write_table = true;
-    }
+
     let mut include_separator = false;
 
     for manifest_resource in dsc.list_available(&DiscoveryKind::Extension, extension_name, None, progress_format) {
@@ -682,7 +691,7 @@ fn list_extensions(dsc: &mut DscManager, extension_name: &TypeNameFilter, format
 }
 
 fn list_functions(functions: &FunctionDispatcher, function_name: Option<&String>, output_format: Option<&ListOutputFormat>) {
-    let mut write_table = false;
+    let write_table = should_write_table(output_format);
     let mut table = Table::new(&[
         t!("subcommand.tableHeader_functionCategory").to_string().as_ref(),
         t!("subcommand.tableHeader_functionName").to_string().as_ref(),
@@ -691,10 +700,7 @@ fn list_functions(functions: &FunctionDispatcher, function_name: Option<&String>
         t!("subcommand.tableHeader_argTypes").to_string().as_ref(),
         t!("subcommand.tableHeader_description").to_string().as_ref(),
     ]);
-    if output_format.is_none() && io::stdout().is_terminal() {
-        // write as table if format is not specified and interactive
-        write_table = true;
-    }
+
     let mut include_separator = false;
     let returned_types= [
         (FunctionArgKind::Array, "a"),

--- a/dsc/tests/dsc_function_list.tests.ps1
+++ b/dsc/tests/dsc_function_list.tests.ps1
@@ -1,6 +1,14 @@
 # Copyright (c) Microsoft Corporation.
 # Licensed under the MIT License.
 
+BeforeDiscovery {
+    try {
+        $windowWidth = [Console]::WindowWidth
+    } catch {
+        $consoleUnavailable = $true
+    }
+}
+
 Describe 'Tests for function list subcommand' {
     It 'Should list all available functions' {
         $out = dsc function list | ConvertFrom-Json
@@ -21,5 +29,17 @@ Describe 'Tests for function list subcommand' {
         $out.maxArgs | Should -Be 2
         $out.returnTypes | Should -Be @('String')
         $out.description | Should -Not -BeNullOrEmpty
+    }
+
+    It 'Table can be not truncated' -Skip:($consoleUnavailable) {
+        $output = dsc function list --output-format table-no-truncate
+        $LASTEXITCODE | Should -Be 0
+        $foundWideLine = $false
+        foreach ($line in $output) {
+            if ($line.Length -gt $windowWidth) {
+                $foundWideLine = $true
+            }
+        }
+        $foundWideLine | Should -BeTrue
     }
 }


### PR DESCRIPTION
# PR Summary

This change:

- Updates the logic for determining whether to write a table for both commands to correctly emit a table when the `table-no-truncate` output format is specified _or_ when no output format is specified and the output isn't being redirected, assigned, or piped to another command.
- Fixes #1580

## PR Context

Prior to this change, the implementation for the `dsc function list` and `dsc extension list` commands supported the `table-no-truncate` output format, but the output wasn't emitted correctly. Instead, the command emitted the output as a series of YAML documents with the `---` separator.