### PR TITLE
Remove temporary base64 function used for coverage validation

### DIFF
--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -55,9 +55,6 @@ fn main() {
 }
 
 fn dsc_main() {
-    // Temporary: validate code coverage instrumentation
-    let _encoded = base64_encode("coverage-test");
-
     #[cfg(debug_assertions)]
     check_debug();
 
@@ -225,62 +222,3 @@ fn check_store() {
     }
 }
 
-/// Temporary function for validating code coverage instrumentation.
-/// Encodes a string as base64 without external crates.
-fn base64_encode(input: &str) -> String {
-    const ALPHABET: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
-    let bytes = input.as_bytes();
-    let mut output = String::with_capacity(bytes.len().div_ceil(3) * 4);
-
-    for chunk in bytes.chunks(3) {
-        let b0 = chunk[0] as u32;
-        let b1 = if chunk.len() > 1 { chunk[1] as u32 } else { 0 };
-        let b2 = if chunk.len() > 2 { chunk[2] as u32 } else { 0 };
-
-        let triple = (b0 << 16) | (b1 << 8) | b2;
-
-        output.push(ALPHABET[((triple >> 18) & 0x3F) as usize] as char);
-        output.push(ALPHABET[((triple >> 12) & 0x3F) as usize] as char);
-
-        if chunk.len() > 1 {
-            output.push(ALPHABET[((triple >> 6) & 0x3F) as usize] as char);
-        } else {
-            output.push('=');
-        }
-
-        if chunk.len() > 2 {
-            output.push(ALPHABET[(triple & 0x3F) as usize] as char);
-        } else {
-            output.push('=');
-        }
-    }
-
-    output
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_base64_encode_empty() {
-        assert_eq!(base64_encode(""), "");
-    }
-
-    #[test]
-    fn test_base64_encode_basic() {
-        assert_eq!(base64_encode("Hello"), "SGVsbG8=");
-    }
-
-    #[test]
-    fn test_base64_encode_padding() {
-        assert_eq!(base64_encode("Hi"), "SGk=");
-        assert_eq!(base64_encode("Hey"), "SGV5");
-    }
-
-    #[test]
-    fn test_base64_encode_coverage_string() {
-        assert_eq!(base64_encode("coverage-test"), "Y292ZXJhZ2UtdGVzdA==");
-    }
-}

--- a/helpers.build.psm1
+++ b/helpers.build.psm1
@@ -1961,11 +1961,15 @@ function Show-CodeCoverageReport {
     #>
     [CmdletBinding()]
     param(
-        [Parameter(Mandatory)]
-        [PSCustomObject[]]$FileDetails
+        [Parameter()]
+        [AllowEmptyCollection()]
+        [PSCustomObject[]]$FileDetails = @()
     )
 
     process {
+        if ($FileDetails.Count -eq 0) {
+            return
+        }
         foreach ($detail in $FileDetails) {
             $filePath = $detail.File
             $lineCoverageMap = $detail.LineCoverageMap


### PR DESCRIPTION
## Summary

Removes the temporary `base64_encode` function and its unit tests from `dsc/src/main.rs`. This code was added solely to validate that the code coverage instrumentation was working correctly (confirmed at 97% in PR #1600).

## Changes

- Removed `base64_encode()` function
- Removed 4 unit tests (`test_base64_encode_empty`, `test_base64_encode_basic`, `test_base64_encode_padding`, `test_base64_encode_coverage_string`)
- Removed the call site in `dsc_main()`