### PR TITLE
Fix CI so that build failure stops workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -54,7 +54,7 @@ jobs:
         run: ./build.ps1 -SkipBuild -Clippy  -Verbose
       - name: Build and test with code coverage
         id: rust-tests
-        continue-on-error: true
+        continue-on-error: false
         run: ./build.ps1 -Clippy -Test -CodeCoverage -ExcludePesterTests -Verbose
       - name: Upload coverage data
         if: always()
@@ -146,7 +146,7 @@ jobs:
         run: ./build.ps1 -SkipBuild -Clippy  -Verbose
       - name: Build and test with code coverage
         id: rust-tests
-        continue-on-error: true
+        continue-on-error: false
         run: ./build.ps1 -Clippy -Test -CodeCoverage -ExcludePesterTests -Verbose
       - name: Upload coverage data
         if: always()
@@ -242,7 +242,7 @@ jobs:
         run: ./build.ps1 -SkipBuild -Clippy  -Verbose
       - name: Build and test with code coverage
         id: rust-tests
-        continue-on-error: true
+        continue-on-error: false
         run: ./build.ps1 -Clippy -Test -CodeCoverage -ExcludePesterTests -Verbose
       - name: Upload coverage data
         if: always()


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

CI was incorrectly reporting when it failed.  When the build isn't successful, it continues to try to package up the built binaries for CC, but the binaries aren't there since the build failed.  Fix is to not have it continue with CC if the build has a failure.
