### PR TITLE
Verify write permissions on settings policy folder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -810,6 +810,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "which",
+ "windows 0.62.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -786,6 +786,7 @@ dependencies = [
  "linked-hash-map",
  "miette",
  "murmurhash64",
+ "nix",
  "num-traits",
  "path-absolutize",
  "pretty_assertions",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -266,11 +266,14 @@ urlencoding = { version = "2.1" }
 which = { version = "8.0.4" }
 # dsc-lib
 ipnetwork = { version = "0.21" }
-# WindowsUpdate, windows_service
+# WindowsUpdate, windows_service, dsc-lib (ACL checks)
 windows = { version = "0.62", features = [
     "Win32_Foundation",
     "Win32_NetworkManagement_WindowsFirewall",
+    "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_System_Com",
+    "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_Services",
     "Win32_System_Variant",

--- a/dsc/tests/dsc_settings.tests.ps1
+++ b/dsc/tests/dsc_settings.tests.ps1
@@ -17,6 +17,20 @@ Describe 'tests for dsc settings' {
         if ($IsWindows) { #"Setting policy on Linux requires sudo"
             $script:policyDirPath = $script:policyFilePath | Split-Path
             New-Item -ItemType Directory -Path $script:policyDirPath | Out-Null
+            # Set secure ACLs: only SYSTEM and Administrators have write access
+            $acl = Get-Acl -Path $script:policyDirPath
+            $acl.SetAccessRuleProtection($true, $false)
+            $acl.Access | ForEach-Object { $acl.RemoveAccessRule($_) } | Out-Null
+            $systemRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                "NT AUTHORITY\SYSTEM", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
+            $adminsRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                "BUILTIN\Administrators", "FullControl", "ContainerInherit,ObjectInherit", "None", "Allow")
+            $usersReadRule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+                "BUILTIN\Users", "ReadAndExecute", "ContainerInherit,ObjectInherit", "None", "Allow")
+            $acl.AddAccessRule($systemRule)
+            $acl.AddAccessRule($adminsRule)
+            $acl.AddAccessRule($usersReadRule)
+            Set-Acl -Path $script:policyDirPath -AclObject $acl
         }
 
         #create backups of settings files

--- a/dsc/tests/dsc_settings_policy_security.tests.ps1
+++ b/dsc/tests/dsc_settings_policy_security.tests.ps1
@@ -27,7 +27,7 @@ Describe 'tests for policy folder security validation' {
             @{ tracing = @{ level = "TRACE" } } | ConvertTo-Json -Depth 5 | Set-Content -Path $script:policyFilePath
 
             # Grant Everyone write access to make the folder insecure
-            icacls $script:policyDirPath /grant "Everyone:(OI)(CI)(W)" /T | Out-Null
+            icacls $script:policyDirPath /grant "Everyone:(OI)(CI)(W)" | Out-Null
         }
 
         AfterAll {
@@ -51,7 +51,7 @@ Describe 'tests for policy folder security validation' {
         }
     }
 
-    Context 'Linux policy folder with insecure permissions emits warning' -Skip:($IsWindows -or !$isElevated) {
+    Context 'Linux policy folder with insecure permissions emits warning' -Skip:(!$IsLinux -or !$isElevated) {
         BeforeAll {
             $script:policyDirPath = "/etc/dsc"
             $script:policyFilePath = Join-Path $script:policyDirPath "dsc.settings.json"

--- a/dsc/tests/dsc_settings_policy_security.tests.ps1
+++ b/dsc/tests/dsc_settings_policy_security.tests.ps1
@@ -1,0 +1,88 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT License.
+
+Describe 'tests for policy folder security validation' {
+    BeforeDiscovery {
+        $isElevated = if ($IsWindows) {
+            ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole(
+                [Security.Principal.WindowsBuiltInRole]::Administrator)
+        } else {
+            (id -u) -eq 0
+        }
+    }
+
+    Context 'Windows policy folder with insecure ACL emits warning' -Skip:(!$IsWindows -or !$isElevated) {
+        BeforeAll {
+            $script:policyDirPath = Join-Path $env:ProgramData "dsc"
+            $script:policyFilePath = Join-Path $script:policyDirPath "dsc.settings.json"
+            $script:existedBefore = Test-Path $script:policyDirPath
+
+            if (-not $script:existedBefore) {
+                New-Item -ItemType Directory -Path $script:policyDirPath -Force | Out-Null
+            }
+
+            # Write a simple policy settings file
+            @{ tracing = @{ level = "TRACE" } } | ConvertTo-Json -Depth 5 | Set-Content -Path $script:policyFilePath
+
+            # Grant Everyone write access to make the folder insecure
+            icacls $script:policyDirPath /grant "Everyone:(OI)(CI)(W)" /T | Out-Null
+        }
+
+        AfterAll {
+            # Remove the Everyone ACE to restore security
+            icacls $script:policyDirPath /remove "Everyone" /T | Out-Null
+
+            Remove-Item -Path $script:policyFilePath -ErrorAction SilentlyContinue
+            if (-not $script:existedBefore) {
+                Remove-Item -Recurse -Force -Path $script:policyDirPath -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Should emit a warning about insecure policy folder' {
+            dsc -l warn resource list 2> $TestDrive/tracing.txt
+            "$TestDrive/tracing.txt" | Should -FileContentMatch "is not secure, settings file will not be used"
+        }
+
+        It 'Should not exit with an error code' {
+            dsc -l warn resource list 2> $TestDrive/tracing.txt
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+
+    Context 'Linux policy folder with insecure permissions emits warning' -Skip:($IsWindows -or !$isElevated) {
+        BeforeAll {
+            $script:policyDirPath = "/etc/dsc"
+            $script:policyFilePath = Join-Path $script:policyDirPath "dsc.settings.json"
+            $script:existedBefore = Test-Path $script:policyDirPath
+
+            if (-not $script:existedBefore) {
+                New-Item -ItemType Directory -Path $script:policyDirPath -Force | Out-Null
+            }
+
+            # Write a simple policy settings file
+            @{ tracing = @{ level = "TRACE" } } | ConvertTo-Json -Depth 5 | Set-Content -Path $script:policyFilePath
+
+            # Make the folder world-writable (insecure)
+            chmod 777 $script:policyDirPath
+        }
+
+        AfterAll {
+            chmod 755 $script:policyDirPath
+
+            Remove-Item -Path $script:policyFilePath -ErrorAction SilentlyContinue
+            if (-not $script:existedBefore) {
+                Remove-Item -Recurse -Force -Path $script:policyDirPath -ErrorAction SilentlyContinue
+            }
+        }
+
+        It 'Should emit a warning about insecure policy folder' {
+            dsc -l warn resource list 2> $TestDrive/tracing.txt
+            "$TestDrive/tracing.txt" | Should -FileContentMatch "is not secure, settings file will not be used"
+        }
+
+        It 'Should not exit with an error code' {
+            dsc -l warn resource list 2> $TestDrive/tracing.txt
+            $LASTEXITCODE | Should -Be 0
+        }
+    }
+}

--- a/dsc/tests/dsc_settings_policy_security.tests.ps1
+++ b/dsc/tests/dsc_settings_policy_security.tests.ps1
@@ -17,7 +17,9 @@ Describe 'tests for policy folder security validation' {
             $script:policyFilePath = Join-Path $script:policyDirPath "dsc.settings.json"
             $script:existedBefore = Test-Path $script:policyDirPath
 
-            if (-not $script:existedBefore) {
+            if ($script:existedBefore) {
+                $script:originalAcl = Get-Acl -Path $script:policyDirPath
+            } else {
                 New-Item -ItemType Directory -Path $script:policyDirPath -Force | Out-Null
             }
 
@@ -29,11 +31,11 @@ Describe 'tests for policy folder security validation' {
         }
 
         AfterAll {
-            # Remove the Everyone ACE to restore security
-            icacls $script:policyDirPath /remove "Everyone" /T | Out-Null
-
             Remove-Item -Path $script:policyFilePath -ErrorAction SilentlyContinue
-            if (-not $script:existedBefore) {
+
+            if ($script:existedBefore) {
+                Set-Acl -Path $script:policyDirPath -AclObject $script:originalAcl
+            } else {
                 Remove-Item -Recurse -Force -Path $script:policyDirPath -ErrorAction SilentlyContinue
             }
         }
@@ -55,7 +57,9 @@ Describe 'tests for policy folder security validation' {
             $script:policyFilePath = Join-Path $script:policyDirPath "dsc.settings.json"
             $script:existedBefore = Test-Path $script:policyDirPath
 
-            if (-not $script:existedBefore) {
+            if ($script:existedBefore) {
+                $script:originalMode = (stat -c '%a' $script:policyDirPath)
+            } else {
                 New-Item -ItemType Directory -Path $script:policyDirPath -Force | Out-Null
             }
 
@@ -67,7 +71,9 @@ Describe 'tests for policy folder security validation' {
         }
 
         AfterAll {
-            chmod 755 $script:policyDirPath
+            if ($script:existedBefore) {
+                chmod $script:originalMode $script:policyDirPath
+            }
 
             Remove-Item -Path $script:policyFilePath -ErrorAction SilentlyContinue
             if (-not $script:existedBefore) {

--- a/lib/dsc-lib/Cargo.toml
+++ b/lib/dsc-lib/Cargo.toml
@@ -63,5 +63,8 @@ pretty_assertions = { workspace = true }
 # Enables parameterized test cases
 test-case = { workspace = true }
 
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+nix = { workspace = true, features = ["user"] }
+
 [build-dependencies]
 cc = { workspace = true }

--- a/lib/dsc-lib/Cargo.toml
+++ b/lib/dsc-lib/Cargo.toml
@@ -54,6 +54,7 @@ tree-sitter-dscexpression = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 registry = { workspace = true }
+windows = { workspace = true }
 
 [dev-dependencies]
 serde_yaml = { workspace = true }

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -931,7 +931,7 @@ settingNotFound = "Setting '%{name}' not found"
 failedToAbsolutizePath = "Failed to absolutize path '%{path}'"
 executableNotFoundInWorkingDirectory = "Executable '%{executable}' not found with working directory '%{cwd}'"
 executableNotFound = "Executable '%{executable}' not found"
-policyFolderNotSecure = "Policy folder '%{path}' is not secure. Required permissions: %{required}"
+policyFolderNotSecure = "Policy folder '%{path}' is not secure, settings file will not be used. Required permissions: %{required}"
 policyFolderNotSecureLinux = "Only root should have write access (no group/other write bits)"
 policyFolderNotSecureWindows = "Only SYSTEM and Administrators should have write access"
 

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -931,6 +931,9 @@ settingNotFound = "Setting '%{name}' not found"
 failedToAbsolutizePath = "Failed to absolutize path '%{path}'"
 executableNotFoundInWorkingDirectory = "Executable '%{executable}' not found with working directory '%{cwd}'"
 executableNotFound = "Executable '%{executable}' not found"
+policyFolderNotSecure = "Policy folder '%{path}' is not secure. Required permissions: %{required}"
+policyFolderNotSecureLinux = "Only root should have write access (no group/other write bits)"
+policyFolderNotSecureWindows = "Only SYSTEM and Administrators should have write access"
 
 [types.date_version]
 invalidDay = "day `%{day}` for month `%{month}` is invalid - must be between `01` and `%{max_days}`"

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -144,12 +144,13 @@ pub fn get_setting(value_name: &str) -> Result<DscSettingValue, DscError> {
     }
 
     // Third, get setting from the policy
-    settings_file_path = PathBuf::from(get_settings_policy_file_path());
-    if let Ok(v) = load_value_from_json(&settings_file_path, value_name) {
-        result.policy = v;
-        debug!("{}", t!("util.foundSetting", name = value_name, path = settings_file_path.to_string_lossy()));
-    } else {
-        debug!("{}", t!("util.notFoundSetting", name = value_name, path = settings_file_path.to_string_lossy()));
+    if let Some(settings_file_path) = get_settings_policy_file_path() {
+        if let Ok(v) = load_value_from_json(&settings_file_path, value_name) {
+            result.policy = v;
+            debug!("{}", t!("util.foundSetting", name = value_name, path = settings_file_path.to_string_lossy()));
+        } else {
+            debug!("{}", t!("util.notFoundSetting", name = value_name, path = settings_file_path.to_string_lossy()));
+        }
     }
 
     if (result.setting == serde_json::Value::Null) && (result.policy == serde_json::Value::Null) {
@@ -199,24 +200,24 @@ pub fn get_exe_path() -> Result<PathBuf, DscError> {
 }
 
 #[cfg(target_os = "windows")]
-fn get_settings_policy_file_path() -> String
+fn get_settings_policy_file_path() -> Option<PathBuf>
 {
     // $env:ProgramData+"\dsc\dsc.settings.json"
-    let Ok(local_program_data_path) = std::env::var("ProgramData") else { return String::new(); };
+    let Ok(local_program_data_path) = std::env::var("ProgramData") else { return None; };
     let dsc_folder = Path::new(&local_program_data_path).join("dsc");
     let settings_path = dsc_folder.join("dsc.settings.json").display().to_string();
 
     if !dsc_folder.exists() {
-        return settings_path;
+        return Some(PathBuf::from(settings_path));
     }
 
     if !verify_windows_acl(&dsc_folder) {
         let required = t!("util.policyFolderNotSecureWindows", path = dsc_folder.display());
         warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
-        return String::new();
+        return None;
     }
 
-    settings_path
+    Some(PathBuf::from(settings_path))
 }
 
 /// Returns `true` if only SYSTEM and Administrators have write access; `false` otherwise.
@@ -320,23 +321,23 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
 }
 
 #[cfg(not(target_os = "windows"))]
-fn get_settings_policy_file_path() -> String
+fn get_settings_policy_file_path() -> Option<PathBuf>
 {
     use std::os::unix::fs::MetadataExt;
 
     // "/etc/dsc/dsc.settings.json"
     // This location is writable only by root, but readable by all users
     let dsc_folder = Path::new("/etc").join("dsc");
-    let settings_path = dsc_folder.join("dsc.settings.json").display().to_string();
+    let settings_path = dsc_folder.join("dsc.settings.json");
 
     if !dsc_folder.exists() {
-        return settings_path;
+        return Some(settings_path);
     }
 
     // Fail closed: if we can't read metadata, treat as insecure
     let Ok(metadata) = fs::metadata(&dsc_folder) else {
         warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = t!("util.policyFolderNotSecureLinux")));
-        return String::new();
+        return None;
     };
 
     let mode = metadata.mode();
@@ -350,10 +351,10 @@ fn get_settings_policy_file_path() -> String
     if uid != 0 || group_write != 0 || other_write != 0 {
         let required = t!("util.policyFolderNotSecureLinux");
         warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
-        return String::new();
+        return None;
     }
 
-    settings_path
+    Some(settings_path)
 }
 
 /// Generates a resource ID from the specified type and name.

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -96,6 +96,59 @@ mod tests {
         let regex = convert_wildcard_to_regex(wildcard);
         assert_eq!(regex, "^r.*?$");
     }
+
+    #[cfg(not(target_os = "windows"))]
+    mod linux_permission_tests {
+        use super::*;
+        use std::fs as stdfs;
+
+        #[test]
+        fn test_verify_linux_permissions_nonexistent_path() {
+            let result = verify_linux_permissions(Path::new("/nonexistent/path/that/does/not/exist"));
+            assert!(!result, "nonexistent path should return false (fail closed)");
+        }
+
+        #[test]
+        fn test_verify_linux_permissions_non_root_owned() {
+            // A temp dir is owned by the current (non-root) user on CI
+            let dir = stdfs::canonicalize(env::temp_dir()).expect("temp dir");
+            let test_dir = dir.join("dsc_test_permissions");
+            let _ = stdfs::create_dir(&test_dir);
+            let result = verify_linux_permissions(&test_dir);
+            let _ = stdfs::remove_dir(&test_dir);
+            // On CI (non-root), the temp dir is not owned by root
+            if nix::unistd::Uid::effective().is_root() {
+                // If running as root, dir is root-owned, check mode bits instead
+                return;
+            }
+            assert!(!result, "directory not owned by root should return false");
+        }
+
+        #[test]
+        fn test_get_settings_policy_file_path_returns_some_when_dir_missing() {
+            // If /etc/dsc doesn't exist, the function should return Some with the path
+            // (the file may not exist but the path is still returned for attempted loading)
+            if Path::new("/etc/dsc").exists() {
+                // Can't test this case when the dir exists
+                return;
+            }
+            let result = get_settings_policy_file_path();
+            assert!(result.is_some(), "should return Some when /etc/dsc doesn't exist");
+            let path = result.unwrap();
+            assert!(path.to_string_lossy().contains("dsc.settings.json"));
+        }
+
+        #[test]
+        fn test_get_settings_policy_file_path_with_insecure_dir() {
+            // When /etc/dsc exists but is not root-owned, returns None
+            if !Path::new("/etc/dsc").exists() || nix::unistd::Uid::effective().is_root() {
+                return;
+            }
+            // /etc/dsc exists and we're not root - if it's owned by root
+            // it should return Some; this test just exercises the code path
+            let _result = get_settings_policy_file_path();
+        }
+    }
 }
 
 /// Will search setting files for the specified setting.
@@ -288,29 +341,41 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
         }
 
         let header = unsafe { &*(ace_ptr as *const windows::Win32::Security::ACE_HEADER) };
-        // Only check ACCESS_ALLOWED_ACE_TYPE (0)
-        if header.AceType != 0 {
-            continue;
-        }
 
         // Skip inherit-only ACEs as they don't apply to this folder
         if (header.AceFlags & INHERIT_ONLY_ACE) != 0 {
             continue;
         }
 
-        let ace = unsafe { &*(ace_ptr as *const ACCESS_ALLOWED_ACE) };
-        if (ace.Mask & WRITE_MASK) == 0 {
+        // Skip deny ACEs (types 1, 6, 10) - they restrict access, not grant it
+        if header.AceType == 1 || header.AceType == 6 || header.AceType == 10 {
             continue;
         }
 
-        // Get pointer to SID within the ACE (SidStart field)
-        let sid_ptr = &ace.SidStart as *const u32 as *const core::ffi::c_void;
-        let psid = windows::Win32::Security::PSID(sid_ptr as *mut core::ffi::c_void);
+        // For ACCESS_ALLOWED_ACE_TYPE (0), check the SID
+        if header.AceType == 0 {
+            let ace = unsafe { &*(ace_ptr as *const ACCESS_ALLOWED_ACE) };
+            if (ace.Mask & WRITE_MASK) == 0 {
+                continue;
+            }
 
-        let is_system = unsafe { IsWellKnownSid(psid, WinLocalSystemSid).as_bool() };
-        let is_admin = unsafe { IsWellKnownSid(psid, WinBuiltinAdministratorsSid).as_bool() };
+            let sid_ptr = &ace.SidStart as *const u32 as *const core::ffi::c_void;
+            let psid = windows::Win32::Security::PSID(sid_ptr as *mut core::ffi::c_void);
 
-        if !is_system && !is_admin {
+            let is_system = unsafe { IsWellKnownSid(psid, WinLocalSystemSid).as_bool() };
+            let is_admin = unsafe { IsWellKnownSid(psid, WinBuiltinAdministratorsSid).as_bool() };
+
+            if !is_system && !is_admin {
+                unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
+                return false;
+            }
+            continue;
+        }
+
+        // For any other allow-type ACE (callback, object, etc.) we cannot
+        // reliably extract the SID, so fail closed to be safe
+        let ace = unsafe { &*(ace_ptr as *const ACCESS_ALLOWED_ACE) };
+        if (ace.Mask & WRITE_MASK) != 0 {
             unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
             return false;
         }
@@ -323,8 +388,6 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
 #[cfg(not(target_os = "windows"))]
 fn get_settings_policy_file_path() -> Option<PathBuf>
 {
-    use std::os::unix::fs::MetadataExt;
-
     // "/etc/dsc/dsc.settings.json"
     // This location is writable only by root, but readable by all users
     let dsc_folder = Path::new("/etc").join("dsc");
@@ -334,27 +397,30 @@ fn get_settings_policy_file_path() -> Option<PathBuf>
         return Some(settings_path);
     }
 
-    // Fail closed: if we can't read metadata, treat as insecure
-    let Ok(metadata) = fs::metadata(&dsc_folder) else {
-        warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = t!("util.policyFolderNotSecureLinux")));
-        return None;
-    };
-
-    let mode = metadata.mode();
-    let uid = metadata.uid();
-
-    // Verify owner is root
-    // Verify no group or other write bits are set
-    let group_write = mode & 0o020;
-    let other_write = mode & 0o002;
-
-    if uid != 0 || group_write != 0 || other_write != 0 {
+    if !verify_linux_permissions(&dsc_folder) {
         let required = t!("util.policyFolderNotSecureLinux");
         warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
         return None;
     }
 
     Some(settings_path)
+}
+
+/// Returns `true` if the folder is owned by root and has no group/other write bits; `false` otherwise.
+#[cfg(not(target_os = "windows"))]
+fn verify_linux_permissions(folder: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+
+    // Fail closed: if we can't read metadata, treat as insecure
+    let Ok(metadata) = fs::metadata(folder) else {
+        return false;
+    };
+
+    let mode = metadata.mode();
+    let uid = metadata.uid();
+
+    // Verify owner is root and no group or other write bits are set
+    uid == 0 && (mode & 0o020) == 0 && (mode & 0o002) == 0
 }
 
 /// Generates a resource ID from the specified type and name.

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -236,7 +236,11 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
     const FILE_APPEND_DATA: u32 = 0x0004;
     const WRITE_DAC: u32 = 0x0004_0000;
     const WRITE_OWNER: u32 = 0x0008_0000;
-    const WRITE_MASK: u32 = FILE_WRITE_DATA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER;
+    const GENERIC_WRITE: u32 = 0x4000_0000;
+    const GENERIC_ALL: u32 = 0x1000_0000;
+    const WRITE_MASK: u32 = FILE_WRITE_DATA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER | GENERIC_WRITE | GENERIC_ALL;
+
+    const INHERIT_ONLY_ACE: u8 = 0x08;
 
     let folder_wide: Vec<u16> = dsc_folder
         .to_string_lossy()
@@ -260,13 +264,15 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
         )
     };
 
+    // Fail closed: if we can't read the security descriptor, treat as insecure
     if result.is_err() {
-        return true;
+        return false;
     }
 
+    // A NULL DACL means full access to everyone
     if p_dacl.is_null() {
         unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
-        return true;
+        return false;
     }
 
     let ace_count = unsafe { (*p_dacl).AceCount };
@@ -275,12 +281,19 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
         let mut ace_ptr: *mut core::ffi::c_void = ptr::null_mut();
         let ok = unsafe { GetAce(p_dacl, i as u32, &mut ace_ptr) };
         if ok.is_err() {
-            continue;
+            // Fail closed: if we can't read an ACE, treat as insecure
+            unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
+            return false;
         }
 
         let header = unsafe { &*(ace_ptr as *const windows::Win32::Security::ACE_HEADER) };
         // Only check ACCESS_ALLOWED_ACE_TYPE (0)
         if header.AceType != 0 {
+            continue;
+        }
+
+        // Skip inherit-only ACEs as they don't apply to this folder
+        if (header.AceFlags & INHERIT_ONLY_ACE) != 0 {
             continue;
         }
 
@@ -290,7 +303,7 @@ fn verify_windows_acl(dsc_folder: &Path) -> bool {
         }
 
         // Get pointer to SID within the ACE (SidStart field)
-        let sid_ptr = &(*ace).SidStart as *const u32 as *const core::ffi::c_void;
+        let sid_ptr = &ace.SidStart as *const u32 as *const core::ffi::c_void;
         let psid = windows::Win32::Security::PSID(sid_ptr as *mut core::ffi::c_void);
 
         let is_system = unsafe { IsWellKnownSid(psid, WinLocalSystemSid).as_bool() };
@@ -320,8 +333,10 @@ fn get_settings_policy_file_path() -> String
         return settings_path;
     }
 
+    // Fail closed: if we can't read metadata, treat as insecure
     let Ok(metadata) = fs::metadata(&dsc_folder) else {
-        return settings_path;
+        warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = t!("util.policyFolderNotSecureLinux")));
+        return String::new();
     };
 
     let mode = metadata.mode();

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -202,7 +202,6 @@ pub fn get_exe_path() -> Result<PathBuf, DscError> {
 fn get_settings_policy_file_path() -> String
 {
     // $env:ProgramData+"\dsc\dsc.settings.json"
-    // This location is writable only by admins, but readable by all users
     let Ok(local_program_data_path) = std::env::var("ProgramData") else { return String::new(); };
     let dsc_folder = Path::new(&local_program_data_path).join("dsc");
     let settings_path = dsc_folder.join("dsc.settings.json").display().to_string();
@@ -212,7 +211,7 @@ fn get_settings_policy_file_path() -> String
     }
 
     if !verify_windows_acl(&dsc_folder) {
-        let required = t!("util.policyFolderNotSecureWindows");
+        let required = t!("util.policyFolderNotSecureWindows", path = dsc_folder.display());
         warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
         return String::new();
     }

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -10,9 +10,8 @@ use std::{
     io::BufReader,
     path::{Path, PathBuf},
     env,
-    process,
 };
-use tracing::{debug, error};
+use tracing::{debug, warn};
 use which::which;
 
 pub struct DscSettingValue {
@@ -212,13 +211,18 @@ fn get_settings_policy_file_path() -> String
         return settings_path;
     }
 
-    verify_windows_acl(&dsc_folder);
+    if !verify_windows_acl(&dsc_folder) {
+        let required = t!("util.policyFolderNotSecureWindows");
+        warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
+        return String::new();
+    }
 
     settings_path
 }
 
+/// Returns `true` if only SYSTEM and Administrators have write access; `false` otherwise.
 #[cfg(target_os = "windows")]
-fn verify_windows_acl(dsc_folder: &Path) {
+fn verify_windows_acl(dsc_folder: &Path) -> bool {
     use windows::Win32::Security::{
         Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT},
         IsWellKnownSid, GetAce,
@@ -258,12 +262,12 @@ fn verify_windows_acl(dsc_folder: &Path) {
     };
 
     if result.is_err() {
-        return;
+        return true;
     }
 
     if p_dacl.is_null() {
         unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
-        return;
+        return true;
     }
 
     let ace_count = unsafe { (*p_dacl).AceCount };
@@ -294,15 +298,13 @@ fn verify_windows_acl(dsc_folder: &Path) {
         let is_admin = unsafe { IsWellKnownSid(psid, WinBuiltinAdministratorsSid).as_bool() };
 
         if !is_system && !is_admin {
-            let required = t!("util.policyFolderNotSecureWindows");
-            error!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
-            eprintln!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
             unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
-            process::exit(1);
+            return false;
         }
     }
 
     unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
+    true
 }
 
 #[cfg(not(target_os = "windows"))]
@@ -333,9 +335,8 @@ fn get_settings_policy_file_path() -> String
 
     if uid != 0 || group_write != 0 || other_write != 0 {
         let required = t!("util.policyFolderNotSecureLinux");
-        error!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
-        eprintln!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
-        process::exit(1);
+        warn!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
+        return String::new();
     }
 
     settings_path

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -10,8 +10,9 @@ use std::{
     io::BufReader,
     path::{Path, PathBuf},
     env,
+    process,
 };
-use tracing::debug;
+use tracing::{debug, error};
 use which::which;
 
 pub struct DscSettingValue {
@@ -204,15 +205,140 @@ fn get_settings_policy_file_path() -> String
     // $env:ProgramData+"\dsc\dsc.settings.json"
     // This location is writable only by admins, but readable by all users
     let Ok(local_program_data_path) = std::env::var("ProgramData") else { return String::new(); };
-    Path::new(&local_program_data_path).join("dsc").join("dsc.settings.json").display().to_string()
+    let dsc_folder = Path::new(&local_program_data_path).join("dsc");
+    let settings_path = dsc_folder.join("dsc.settings.json").display().to_string();
+
+    if !dsc_folder.exists() {
+        return settings_path;
+    }
+
+    verify_windows_acl(&dsc_folder);
+
+    settings_path
+}
+
+#[cfg(target_os = "windows")]
+fn verify_windows_acl(dsc_folder: &Path) {
+    use windows::Win32::Security::{
+        Authorization::{GetNamedSecurityInfoW, SE_FILE_OBJECT},
+        IsWellKnownSid, GetAce,
+        WinBuiltinAdministratorsSid, WinLocalSystemSid,
+        ACL, ACCESS_ALLOWED_ACE, PSECURITY_DESCRIPTOR,
+    };
+    use windows::Win32::Foundation::{LocalFree, HLOCAL};
+    use windows::core::PCWSTR;
+    use std::ptr;
+
+    const FILE_WRITE_DATA: u32 = 0x0002;
+    const FILE_APPEND_DATA: u32 = 0x0004;
+    const WRITE_DAC: u32 = 0x0004_0000;
+    const WRITE_OWNER: u32 = 0x0008_0000;
+    const WRITE_MASK: u32 = FILE_WRITE_DATA | FILE_APPEND_DATA | WRITE_DAC | WRITE_OWNER;
+
+    let folder_wide: Vec<u16> = dsc_folder
+        .to_string_lossy()
+        .encode_utf16()
+        .chain(std::iter::once(0))
+        .collect();
+
+    let mut p_sd: PSECURITY_DESCRIPTOR = PSECURITY_DESCRIPTOR(ptr::null_mut());
+    let mut p_dacl: *mut ACL = ptr::null_mut();
+
+    let result = unsafe {
+        GetNamedSecurityInfoW(
+            PCWSTR(folder_wide.as_ptr()),
+            SE_FILE_OBJECT,
+            windows::Win32::Security::DACL_SECURITY_INFORMATION,
+            None,
+            None,
+            Some(&mut p_dacl),
+            None,
+            &mut p_sd,
+        )
+    };
+
+    if result.is_err() {
+        return;
+    }
+
+    if p_dacl.is_null() {
+        unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
+        return;
+    }
+
+    let ace_count = unsafe { (*p_dacl).AceCount };
+
+    for i in 0..ace_count {
+        let mut ace_ptr: *mut core::ffi::c_void = ptr::null_mut();
+        let ok = unsafe { GetAce(p_dacl, i as u32, &mut ace_ptr) };
+        if ok.is_err() {
+            continue;
+        }
+
+        let header = unsafe { &*(ace_ptr as *const windows::Win32::Security::ACE_HEADER) };
+        // Only check ACCESS_ALLOWED_ACE_TYPE (0)
+        if header.AceType != 0 {
+            continue;
+        }
+
+        let ace = unsafe { &*(ace_ptr as *const ACCESS_ALLOWED_ACE) };
+        if (ace.Mask & WRITE_MASK) == 0 {
+            continue;
+        }
+
+        // Get pointer to SID within the ACE (SidStart field)
+        let sid_ptr = &(*ace).SidStart as *const u32 as *const core::ffi::c_void;
+        let psid = windows::Win32::Security::PSID(sid_ptr as *mut core::ffi::c_void);
+
+        let is_system = unsafe { IsWellKnownSid(psid, WinLocalSystemSid).as_bool() };
+        let is_admin = unsafe { IsWellKnownSid(psid, WinBuiltinAdministratorsSid).as_bool() };
+
+        if !is_system && !is_admin {
+            let required = t!("util.policyFolderNotSecureWindows");
+            error!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
+            eprintln!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
+            unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
+            process::exit(1);
+        }
+    }
+
+    unsafe { let _ = LocalFree(Some(HLOCAL(p_sd.0.cast()))); }
 }
 
 #[cfg(not(target_os = "windows"))]
 fn get_settings_policy_file_path() -> String
 {
+    use std::os::unix::fs::MetadataExt;
+
     // "/etc/dsc/dsc.settings.json"
-    // This location is writable only by admins, but readable by all users
-    Path::new("/etc").join("dsc").join("dsc.settings.json").display().to_string()
+    // This location is writable only by root, but readable by all users
+    let dsc_folder = Path::new("/etc").join("dsc");
+    let settings_path = dsc_folder.join("dsc.settings.json").display().to_string();
+
+    if !dsc_folder.exists() {
+        return settings_path;
+    }
+
+    let Ok(metadata) = fs::metadata(&dsc_folder) else {
+        return settings_path;
+    };
+
+    let mode = metadata.mode();
+    let uid = metadata.uid();
+
+    // Verify owner is root
+    // Verify no group or other write bits are set
+    let group_write = mode & 0o020;
+    let other_write = mode & 0o002;
+
+    if uid != 0 || group_write != 0 || other_write != 0 {
+        let required = t!("util.policyFolderNotSecureLinux");
+        error!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
+        eprintln!("{}", t!("util.policyFolderNotSecure", path = dsc_folder.display(), required = required));
+        process::exit(1);
+    }
+
+    settings_path
 }
 
 /// Generates a resource ID from the specified type and name.


### PR DESCRIPTION
## Motivation

The `dsc` settings policy file (`dsc.settings.json`) is loaded from a system-wide location (`/etc/dsc` on Linux, `%ProgramData%\dsc` on Windows). If an unprivileged user can write to that folder, they could inject arbitrary policy settings -- a potential privilege escalation vector. This PR adds a security check so that an insecure folder is detected and its settings are simply not loaded rather than silently trusted.

## Approach

`get_settings_policy_file_path` now validates folder permissions before returning the path:

- **Linux**: Checks that the `/etc/dsc` folder is owned by root (uid 0) and has no group or other write bits set.
- **Windows**: Enumerates the DACL on the `ProgramData\dsc` folder and verifies that only SYSTEM and Administrators have write access (FILE_WRITE_DATA, FILE_APPEND_DATA, WRITE_DAC, WRITE_OWNER).

If the check fails on either platform, a warning is emitted via `tracing::warn!` indicating the settings file will not be used, and an empty path is returned so execution continues without the policy settings. The process does **not** exit -- this is a graceful degradation.

## Notable details

- Added `Win32_Security` and `Win32_Security_Authorization` features to the workspace `windows` crate and added `windows` as a cfg(windows) dependency for `dsc-lib`.
- The `verify_windows_acl` helper returns a bool so the caller can decide what to do on failure, keeping the ACL logic self-contained.
- i18n strings added to `en-us.toml` under `[util]` for the warning messages.
- A new Pester test (`dsc_settings_policy_security.tests.ps1`) validates the warning is emitted and exit code remains 0 on both Windows (using `icacls` to grant Everyone write) and Linux (using `chmod 777`). Both contexts require elevation and restore original state in `AfterAll`.