### PR TITLE
In PSScript and PSAdapter, if TryDequeue fails, we just return

### DIFF
--- a/adapters/powershell/psDscAdapter/powershell.resource.ps1
+++ b/adapters/powershell/psDscAdapter/powershell.resource.ps1
@@ -41,13 +41,8 @@ trap {
 
 function Write-TraceQueue() {
     $trace = $null
-    while (!$traceQueue.IsEmpty) {
-        if ($traceQueue.TryDequeue([ref] $trace)) {
-            $host.ui.WriteErrorLine(($trace | ConvertTo-Json -Compress -Depth 10))
-        } else {
-            # this should only fail if empty, so we just return
-            return
-        }
+    while ($traceQueue.TryDequeue([ref] $trace)) {
+        $host.ui.WriteErrorLine($trace)
     }
 }
 

--- a/adapters/powershell/psDscAdapter/powershell.resource.ps1
+++ b/adapters/powershell/psDscAdapter/powershell.resource.ps1
@@ -44,6 +44,9 @@ function Write-TraceQueue() {
     while (!$traceQueue.IsEmpty) {
         if ($traceQueue.TryDequeue([ref] $trace)) {
             $host.ui.WriteErrorLine(($trace | ConvertTo-Json -Compress -Depth 10))
+        } else {
+            # this should only fail if empty, so we just return
+            return
         }
     }
 }

--- a/adapters/powershell/psDscAdapter/powershell.resource.ps1
+++ b/adapters/powershell/psDscAdapter/powershell.resource.ps1
@@ -41,8 +41,10 @@ trap {
 
 function Write-TraceQueue() {
     $trace = $null
-    while ($traceQueue.TryDequeue([ref] $trace)) {
-        $host.ui.WriteErrorLine($trace)
+    if (!$traceQueue.IsEmpty) {
+        while ($traceQueue.TryDequeue([ref] $trace)) {
+            $host.ui.WriteErrorLine($trace)
+        }
     }
 }
 

--- a/adapters/powershell/psDscAdapter/powershell.resource.ps1
+++ b/adapters/powershell/psDscAdapter/powershell.resource.ps1
@@ -43,7 +43,7 @@ function Write-TraceQueue() {
     $trace = $null
     if (!$traceQueue.IsEmpty) {
         while ($traceQueue.TryDequeue([ref] $trace)) {
-            $host.ui.WriteErrorLine($trace)
+            $host.ui.WriteErrorLine(($trace | ConvertTo-Json -Compress -Depth 10))
         }
     }
 }

--- a/resources/PSScript/psscript.ps1
+++ b/resources/PSScript/psscript.ps1
@@ -127,8 +127,10 @@ $outputObjects = [System.Collections.Generic.List[Object]]::new()
 
 function Write-TraceQueue() {
     $trace = $null
-    while ($traceQueue.TryDequeue([ref] $trace)) {
-        $host.ui.WriteErrorLine($trace)
+    if (!$traceQueue.IsEmpty) {
+        while ($traceQueue.TryDequeue([ref] $trace)) {
+            $host.ui.WriteErrorLine($trace)
+        }
     }
 }
 

--- a/resources/PSScript/psscript.ps1
+++ b/resources/PSScript/psscript.ps1
@@ -130,6 +130,9 @@ function Write-TraceQueue() {
     while (!$traceQueue.IsEmpty) {
         if ($traceQueue.TryDequeue([ref] $trace)) {
             $host.ui.WriteErrorLine($trace)
+        } else {
+            # this should only fail if empty, so we just return
+            return
         }
     }
 }

--- a/resources/PSScript/psscript.ps1
+++ b/resources/PSScript/psscript.ps1
@@ -129,7 +129,7 @@ function Write-TraceQueue() {
     $trace = $null
     if (!$traceQueue.IsEmpty) {
         while ($traceQueue.TryDequeue([ref] $trace)) {
-            $host.ui.WriteErrorLine($trace)
+            $host.ui.WriteErrorLine(($trace | ConvertTo-Json -Compress -Depth 10))
         }
     }
 }

--- a/resources/PSScript/psscript.ps1
+++ b/resources/PSScript/psscript.ps1
@@ -127,13 +127,8 @@ $outputObjects = [System.Collections.Generic.List[Object]]::new()
 
 function Write-TraceQueue() {
     $trace = $null
-    while (!$traceQueue.IsEmpty) {
-        if ($traceQueue.TryDequeue([ref] $trace)) {
-            $host.ui.WriteErrorLine($trace)
-        } else {
-            # this should only fail if empty, so we just return
-            return
-        }
+    while ($traceQueue.TryDequeue([ref] $trace)) {
+        $host.ui.WriteErrorLine($trace)
     }
 }
 


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Something is causing a hang.  According to the docs `TryDequeue` should only fail if empty, but perhaps there's some unknown interaction resulting in `TryDequeue` failing, but `IsEmpty` reports not, so change is to return if `TryDequeue` fails.

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1609
