### PR TITLE
Add `--ignore-settings-file` and `DSC_IGNORE_SETTINGS_FILE` env var

### DIFF
--- a/dsc/locales/en-us.toml
+++ b/dsc/locales/en-us.toml
@@ -37,6 +37,7 @@ listFunctionAbout = "List or find functions"
 version = "The version of the resource to invoke in semver format"
 serverAbout = "Use DSC as a server over JSON-RPC (useful as MCP server)"
 bicepAbout = "Use DSC as a Bicep server over gRPC"
+ignoreSettingsFile = "Ignore the settings file when running the command"
 
 [main]
 failedToSpawnMain = "Failed to spawn dsc main thread: %{error}"

--- a/dsc/src/args.rs
+++ b/dsc/src/args.rs
@@ -55,6 +55,8 @@ pub struct Args {
     pub trace_format: Option<TraceFormat>,
     #[clap(short = 'p', long, help = t!("args.progressFormat").to_string(), value_enum)]
     pub progress_format: Option<ProgressFormat>,
+    #[clap(short = 'i', long, help = t!("args.ignoreSettingsFile").to_string())]
+    pub ignore_settings_file: bool,
 }
 
 #[derive(Debug, PartialEq, Eq, Subcommand)]

--- a/dsc/src/main.rs
+++ b/dsc/src/main.rs
@@ -4,10 +4,10 @@
 use args::{Args, SubCommand};
 use clap::{CommandFactory, Parser};
 use clap_complete::generate;
-use dsc_lib::progress::ProgressFormat;
+use dsc_lib::{progress::ProgressFormat, util::DSC_IGNORE_SETTINGS_FILE};
 use server::start_server;
 use rust_i18n::{i18n, t};
-use std::{io, process::exit};
+use std::{env::set_var, io, process::exit};
 use sysinfo::{Process, RefreshKind, System, get_current_pid, ProcessRefreshKind};
 use tracing::{error, info, warn, debug};
 
@@ -66,6 +66,13 @@ fn dsc_main() {
     }
 
     let args = Args::parse();
+
+    // if args.ignore_settings_file is set, we create an env var called `DSC_IGNORE_SETTINGS_FILE` set to value 1
+    if args.ignore_settings_file {
+        unsafe {
+            set_var(DSC_IGNORE_SETTINGS_FILE, "1");
+        }
+    }
 
     util::enable_tracing(args.trace_level.as_ref(), args.trace_format.as_ref());
 

--- a/dsc/tests/dsc_settings.tests.ps1
+++ b/dsc/tests/dsc_settings.tests.ps1
@@ -120,4 +120,23 @@ Describe 'tests for dsc settings' {
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly "Trace-level is Trace"
         "$TestDrive/tracing.txt" | Should -FileContentMatchExactly 'Using Resource Path: Defaultv1SettingsDir'
     }
+
+    It 'DSC_IGNORE_SETTINGS_FILE environment variable disables settings file' {
+        $oldEnv = $env:DSC_IGNORE_SETTINGS_FILE
+        try {
+            $env:DSC_IGNORE_SETTINGS_FILE = "1"
+            $null = dsc -l warn resource list 2> $TestDrive/tracing.txt
+            $errorLog = Get-Content "$TestDrive/tracing.txt" -Raw
+            $errorLog | Should -BeLike "*WARN*Ignoring settings file due to environment variable 'DSC_IGNORE_SETTINGS_FILE' being set or '--ignore-settings-file' flag being used*"
+        }
+        finally {
+            $env:DSC_IGNORE_SETTINGS_FILE = $oldEnv
+        }
+    }
+
+    It '--ignore-settings-file command-line argument disables settings file' {
+        $null = dsc --ignore-settings-file resource list 2> $TestDrive/tracing.txt
+        $errorLog = Get-Content "$TestDrive/tracing.txt" -Raw
+        $errorLog | Should -BeLike "*WARN*Ignoring settings file due to environment variable 'DSC_IGNORE_SETTINGS_FILE' being set or '--ignore-settings-file' flag being used*"
+    }
 }

--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -934,6 +934,7 @@ executableNotFound = "Executable '%{executable}' not found"
 policyFolderNotSecure = "Policy folder '%{path}' is not secure, settings file will not be used. Required permissions: %{required}"
 policyFolderNotSecureLinux = "Only root should have write access (no group/other write bits)"
 policyFolderNotSecureWindows = "Only SYSTEM and Administrators should have write access"
+ignoreSettingsFile = "Ignoring settings file due to environment variable 'DSC_IGNORE_SETTINGS_FILE' being set or '--ignore-settings-file' flag being used"
 
 [types.date_version]
 invalidDay = "day `%{day}` for month `%{month}` is invalid - must be between `01` and `%{max_days}`"

--- a/lib/dsc-lib/src/util.rs
+++ b/lib/dsc-lib/src/util.rs
@@ -14,6 +14,8 @@ use std::{
 use tracing::{debug, warn};
 use which::which;
 
+pub const DSC_IGNORE_SETTINGS_FILE: &str = "DSC_IGNORE_SETTINGS_FILE";
+
 pub struct DscSettingValue {
     pub setting:  Value,
     pub policy: Value,
@@ -171,6 +173,11 @@ pub fn get_setting(value_name: &str) -> Result<DscSettingValue, DscError> {
 
     let mut result: DscSettingValue = DscSettingValue::default();
     let mut settings_file_path : PathBuf;
+
+    if env::var(DSC_IGNORE_SETTINGS_FILE).is_ok() {
+        warn!("{}", t!("util.ignoreSettingsFile"));
+        return Ok(result);
+    }
 
     if let Some(exe_home) = get_exe_path()?.parent() {
         // First, get setting from the default settings file


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Partner has a need to ignore the settings file.  Added `--ignore-settings-file` switch but can also set `DSC_IGNORE_SETTINGS_FILE` env var (just has to exist, value doesn't matter) for the same purpose.  We can consider adding a setting to the file to now allow this switch should that need arise.

The implementation simply sets the env var if the switch is used.