### PR TITLE
Fix universal package publishing

### DIFF
--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -578,7 +578,7 @@ extends:
             targetPublishMode: 'Manual'
 
     - stage: ReleaseUniversalPackage
-      dependsOn: ['BuildAndSign','Release']
+      dependsOn: ['BuildAndSign', 'Validation']
       condition: and(succeeded(), ne(variables['Build.Reason'], 'Schedule'), eq(variables.officialBuild, true))
       variables:
         - name: PackageVersion
@@ -637,6 +637,22 @@ extends:
             }
 
           displayName: Prepare files for Universal Package
+
+        - task: PipAuthenticate@1
+          displayName: 'Pip Authenticate'
+          inputs:
+            artifactFeeds: 'One/dsc-cfs-publicpackages'
+
+        - task: AzureCLI@2
+          displayName: Install Azure DevOps Extension
+          inputs:
+            azureSubscription: PS-PS-DSC-UniversalFeed
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              az --version
+              az extension list
+              az extension add --name azure-devops --debug
 
         - task: AzureCLI@2
           displayName: Publish Windows - Universal Package


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Universal package publishing require installation of devops extension for azure cli.
The extension has dependencies on PyPi.
Acquiring dependencies from PyPi directly is prohibited and hence a CFS feed was added.

Also change the dependencies is build pipeline so universal package publishing runs in parallel with GitHub release.

## PR Context

<!-- Provide a little reasoning as to why this Pull Request helps and why you have opened it. -->
