### PR TITLE
feat: remove experimental flag `format()`

### DIFF
--- a/lib/dsc-lib/locales/en-us.toml
+++ b/lib/dsc-lib/locales/en-us.toml
@@ -456,7 +456,6 @@ invalidArgType = "Invalid argument type, argument must be an array or string"
 [functions.format]
 description = "Formats a string using the given arguments"
 syntax = "format( <string>, <value>, ... )"
-experimental = "`format()` function is experimental"
 formatInvalid = "First `format()` argument must be a string"
 numberTooLarge = "Number is too large"
 invalidArgType = "Unsupported argument type"

--- a/lib/dsc-lib/src/functions/format.rs
+++ b/lib/dsc-lib/src/functions/format.rs
@@ -7,7 +7,6 @@ use crate::functions::{FunctionArgKind, Function, FunctionCategory, FunctionMeta
 use rt_format::{Format as RtFormat, FormatArgument, ParsedFormat, argument::NoNamedArguments};
 use rust_i18n::t;
 use serde_json::Value;
-use tracing::warn;
 
 #[derive(Debug, PartialEq)]
 enum Variant {
@@ -103,7 +102,6 @@ impl Function for Format {
     }
 
     fn invoke(&self, args: &[Value], _context: &Context) -> Result<Value, DscError> {
-        warn!("{}", t!("functions.format.experimental"));
         let Some(format_string) = args[0].as_str() else {
             return Err(DscError::Parser(t!("functions.format.formatInvalid").to_string()));
         };


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request removes the warning message given on the `format()` function.

## PR Context

Fixes #1647.
