### PR TITLE
(GH-1563) Enhance the PSScript resources

### DIFF
--- a/dsc/tests/dsc_metadata.tests.ps1
+++ b/dsc/tests/dsc_metadata.tests.ps1
@@ -155,7 +155,7 @@ Describe 'metadata tests' {
           - name: return variable
             type: Microsoft.DSC.Transitional/PowerShellScript
             properties:
-              SetScript: |
+              setScript: |
                 if ($IsWindows) {
                   $env:myTestVariable
                 }
@@ -189,7 +189,7 @@ Describe 'metadata tests' {
           - name: return path
             type: Microsoft.DSC.Transitional/PowerShellScript
             properties:
-              SetScript: |
+              setScript: |
                 $env:PATH
 '@
         $oldUserPath = [System.Environment]::GetEnvironmentVariable('PATH', [System.EnvironmentVariableTarget]::User)
@@ -219,7 +219,7 @@ Describe 'metadata tests' {
           - name: return variable
             type: Microsoft.DSC.Transitional/PowerShellScript
             properties:
-              SetScript: |
+              setScript: |
                 if ($IsWindows) {
                   $env:myTestVariable
                 }

--- a/resources/PSScript/psscript.dsc.resource.json
+++ b/resources/PSScript/psscript.dsc.resource.json
@@ -58,6 +58,50 @@
     "schema": {
         "embedded": {
             "type": "object",
+            "oneOf": [
+                {
+                    "description": "Defines constraints for the return data of the resource operations.",
+                    "oneOf": [
+                        {
+                            "description": "Defines the valid return data for `get` and `set` operations with a defined script.",
+                            "required": [
+                                "output"
+                            ]
+                        },
+                        {
+                            "description": "Defines the return data as an empty object for operations with an undefined script.",
+                            "minProperties": 0,
+                            "maxProperties": 0
+                        },
+                        {
+                            "description": "Defines the valid return data for implemented `test` operations.",
+                            "required": [
+                                "_inDesiredState"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "description": "Defines constraints for the input data of the resource operations. You must define at least one script property to use this resource.",
+                    "anyOf": [
+                        {
+                            "required": [
+                                "getScript"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "testScript"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "setScript"
+                            ]
+                        }
+                    ]
+                }
+            ],
             "properties": {
                 "getScript": {
                     "title": "Get operation script",

--- a/resources/PSScript/psscript.dsc.resource.json
+++ b/resources/PSScript/psscript.dsc.resource.json
@@ -75,7 +75,17 @@
                     "$ref": "#/$defs/powershellScript"
                 },
                 "input": {
-                    "type": ["string", "boolean", "integer", "object", "array", "null"]
+                    "title": "Script input data",
+                    "description": "Defines the data to pass to every script as a parameter. When defined, every script property must include a `param()` statement with a single parameter.",
+                    "writeOnly": true,
+                    "type": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "array"
+                    ]
                 },
                 "output": {
                     "type": ["array", "null"]

--- a/resources/PSScript/psscript.dsc.resource.json
+++ b/resources/PSScript/psscript.dsc.resource.json
@@ -60,13 +60,19 @@
             "type": "object",
             "properties": {
                 "getScript": {
-                    "type": ["string", "null"]
+                    "title": "Get operation script",
+                    "description": "A PowerShell script that retrieves the current state of the instance.",
+                    "$ref": "#/$defs/powershellScript"
                 },
                 "setScript": {
-                    "type": ["string", "null"]
+                    "title": "Set operation script",
+                    "description": "A PowerShell script that enforces the desired state for the instance.",
+                    "$ref": "#/$defs/powershellScript"
                 },
                 "testScript": {
-                    "type": ["string", "null"]
+                    "title": "Test operation script",
+                    "description": "A PowerShell script that checks whether the instance is in the desired state.",
+                    "$ref": "#/$defs/powershellScript"
                 },
                 "input": {
                     "type": ["string", "boolean", "integer", "object", "array", "null"]
@@ -79,6 +85,12 @@
                 }
             },
             "$defs": {
+                "powershellScript": {
+                    "writeOnly": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "contentMediaType": "text/vnd.microsoft.powershell"
+                },
                 "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json": {
                     "$schema": "https://json-schema.org/draft/2020-12/schema",
                     "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json",

--- a/resources/PSScript/psscript.dsc.resource.json
+++ b/resources/PSScript/psscript.dsc.resource.json
@@ -2,7 +2,7 @@
     "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
     "type": "Microsoft.DSC.Transitional/PowerShellScript",
     "description": "Enable running PowerShell 7 scripts inline",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "condition": "[not(equals(tryWhich('pwsh'), null()))]",
     "get": {
         "executable": "pwsh",
@@ -135,7 +135,18 @@
                     ]
                 },
                 "output": {
-                    "type": ["array", "null"]
+                    "title": "Script output data",
+                    "description": "Defines output emitted to the success stream from the invoked script. The resource result for an operation only includes this property when the script emits one or more items to the success stream.",
+                    "readOnly": true,
+                    "type": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "array",
+                        "null"
+                    ]
                 },
                 "_inDesiredState": {
                     "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json"

--- a/resources/PSScript/psscript.dsc.resource.json
+++ b/resources/PSScript/psscript.dsc.resource.json
@@ -57,7 +57,10 @@
     },
     "schema": {
         "embedded": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
+            "title": "Transitional PowerShell script resource",
+            "description": "Defines an instance of the `Microsoft.DSC.Transitional/PowerShellScript` resource, which enables users to define inline scripts for the get, set, and test resource operations.",
             "oneOf": [
                 {
                     "description": "Defines constraints for the return data of the resource operations.",

--- a/resources/PSScript/psscript.dsc.resource.json
+++ b/resources/PSScript/psscript.dsc.resource.json
@@ -75,8 +75,20 @@
                     "type": ["array", "null"]
                 },
                 "_inDesiredState": {
-                    "type": ["boolean", "null"],
-                    "default": null
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json"
+                }
+            },
+            "$defs": {
+                "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json",
+                    "title": "Instance is in the Desired State",
+                    "description": "Indicates whether the instance is in the desired state. This property is only returned by the `test` method.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "readOnly": true
                 }
             }
         }

--- a/resources/PSScript/psscript.ps1
+++ b/resources/PSScript/psscript.ps1
@@ -189,5 +189,22 @@ if ($Operation -eq 'Test') {
         exit 1
     }
 } else {
-    @{ output = $outputObjects } | ConvertTo-Json -Compress -Depth 10
+    $outputData = @{}
+    if ($outputObjects.Count -eq 1) {
+        $outputData.output = $outputObjects | Select-Object -First 1
+    } elseif ($outputObjects.Count -gt 1) {
+        $outputData.output = $outputObjects
+    }
+
+    $toJsonParams = @{
+        Compress = $true
+        Depth    = 10
+    }
+    # For PowerShell, use `-EnumsAsStrings` to ensure that enum values are serialized as strings instead of integers.
+    # No equivalent option for Windows PowerShell, so this is a limitation of the WindowsPowerShellScript resource.
+    if ($PSVersionTable.PSVersion -ge [Version]'6.0') {
+        $toJsonParams['EnumsAsStrings'] = $true
+    }
+
+    $outputData | ConvertTo-Json @toJsonParams
 }

--- a/resources/PSScript/psscript.ps1
+++ b/resources/PSScript/psscript.ps1
@@ -191,7 +191,7 @@ if ($Operation -eq 'Test') {
 } else {
     $outputData = @{}
     if ($outputObjects.Count -eq 1) {
-        $outputData.output = $outputObjects | Select-Object -First 1
+        $outputData.output = $outputObjects[0]
     } elseif ($outputObjects.Count -gt 1) {
         $outputData.output = $outputObjects
     }

--- a/resources/PSScript/psscript.tests.ps1
+++ b/resources/PSScript/psscript.tests.ps1
@@ -25,10 +25,10 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @"
-        GetScript: |
+        getScript: |
           "Hello, World!"
           1+1
-        SetScript: |
+        setScript: |
           throw 'This should not be executed'
 "@
         $result = dsc resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -42,7 +42,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @"
-        SetScript: |
+        setScript: |
           "Hello, World!"
           1+1
 "@
@@ -57,10 +57,10 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @"
-        GetScript: |
+        getScript: |
           "Hello, World!"
           1+1
-        SetScript: |
+        setScript: |
           "Hello, World!"
           2+2
 "@
@@ -78,7 +78,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        TestScript: |
+        testScript: |
             $true
 '@
         $result = dsc resource test -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -90,7 +90,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        TestScript: |
+        testScript: |
             $false
 '@
         $result = dsc resource test -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -102,7 +102,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        TestScript: |
+        testScript: |
             "This is not a boolean"
 '@
         $result = dsc resource test -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -116,7 +116,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        TestScript: |
+        testScript: |
             $true
             $false
 '@
@@ -127,14 +127,14 @@ Describe 'Tests for PSScript resource' {
         $errorLog | Should -BeLike '*ERROR*:*Test operation did not return a single boolean value.*' -Because $errorLog
     }
 
-    It 'Empty SetScript is ignored for <resourceType>' -TestCases $testCases {
+    It 'Empty setScript is ignored for <resourceType>' -TestCases $testCases {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           "Hello, World!"
           1+1
-        TestScript: |
+        testScript: |
           $true
 '@
 
@@ -146,14 +146,14 @@ Describe 'Tests for PSScript resource' {
         $result.afterState.output.Count | Should -Be 0
     }
 
-    It 'Empty GetScript is ignored for <resourceType>' -TestCases $testCases {
+    It 'Empty getScript is ignored for <resourceType>' -TestCases $testCases {
         param($resourceType)
 
         $yaml = @'
-        SetScript: |
+        setScript: |
           "Hello, World!"
           1+1
-        TestScript: |
+        testScript: |
           $true
 '@
         $result = dsc resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -161,14 +161,14 @@ Describe 'Tests for PSScript resource' {
         $result.actualState.output.Count | Should -Be 0 -Because ($result | ConvertTo-Json | Out-String)
     }
 
-    It 'Empty TestScript is ignored for <resourceType>' -TestCases $testCases {
+    It 'Empty testScript is ignored for <resourceType>' -TestCases $testCases {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           "Hello, World!"
           1+1
-        SetScript: |
+        setScript: |
           "Hello, World!"
           2+2
 '@
@@ -181,7 +181,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           Write-Warning "This is a warning"
           Write-Warning "This is second warning"
 '@
@@ -198,7 +198,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           Write-Error "This is an error"
 '@
 
@@ -213,7 +213,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           Write-Verbose "This is a verbose message"
 '@
         $result = dsc -l info resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -227,7 +227,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           Write-Debug "This is a debug message"
 '@
         $result = dsc -l debug resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -241,7 +241,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           $InformationPreference = 'Continue'
           Write-Information "This is an information message"
 '@
@@ -256,7 +256,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
           throw "This is an exception"
 '@
         $result = dsc resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
@@ -287,7 +287,8 @@ Describe 'Tests for PSScript resource' {
         $result = dsc resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content $TestDrive/error.txt -Raw | Out-String)
         $result.actualState.output.Count | Should -Be 1 -Because ($result | ConvertTo-Json -Depth 10 | Out-String)
-        $result.actualState.output[0] | Should -BeExactly "Input: This is a string"
+        $result.actualState.output.GetType().Name | Should -Be 'String'
+        $result.actualState.output | Should -BeExactly "Input: This is a string"
     }
 
     It 'Input without param block is an error for <resourceType>' -TestCases $testCases {
@@ -347,7 +348,8 @@ Describe 'Tests for PSScript resource' {
         $result = dsc -l debug resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content $TestDrive/error.txt -Raw | Out-String)
         $result.actualState.output.Count | Should -Be 1 -Because ($result | ConvertTo-Json -Depth 10 | Out-String)
-        $result.actualState.output[0] | Should -BeExactly "This should still be output"
+        $result.actualState.output.GetType().Name | Should -Be 'String'
+        $result.actualState.output | Should -BeExactly "This should still be output"
         $errorLog = Get-Content $TestDrive/error.txt -Raw
         $errorLog | Should -BeLike '*DEBUG*:*Non-terminating errors occurred during script execution.*' -Because $errorLog
     }
@@ -356,7 +358,7 @@ Describe 'Tests for PSScript resource' {
         param($resourceType)
 
         $yaml = @'
-        GetScript: |
+        getScript: |
             Get-Item "ThisFileDoesNotExist.txt" -ErrorAction Stop
 '@
         $result = dsc resource get -r $resourceType -i $yaml 2> $TestDrive/error.txt | ConvertFrom-Json

--- a/resources/PSScript/winpsscript.dsc.resource.json
+++ b/resources/PSScript/winpsscript.dsc.resource.json
@@ -74,8 +74,20 @@
                     "type": ["array", "null"]
                 },
                 "_inDesiredState": {
-                    "type": ["boolean", "null"],
-                    "default": null
+                    "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json"
+                }
+            },
+            "$defs": {
+                "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json": {
+                    "$schema": "https://json-schema.org/draft/2020-12/schema",
+                    "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json",
+                    "title": "Instance is in the Desired State",
+                    "description": "Indicates whether the instance is in the desired state. This property is only returned by the `test` method.",
+                    "type": [
+                        "boolean",
+                        "null"
+                    ],
+                    "readOnly": true
                 }
             }
         }

--- a/resources/PSScript/winpsscript.dsc.resource.json
+++ b/resources/PSScript/winpsscript.dsc.resource.json
@@ -57,6 +57,50 @@
     "schema": {
         "embedded": {
             "type": "object",
+            "oneOf": [
+                {
+                    "description": "Defines constraints for the return data of the resource operations.",
+                    "anyOf": [
+                        {
+                            "description": "Defines the valid return data for `get` and `set` operations with a defined script.",
+                            "required": [
+                                "output"
+                            ]
+                        },
+                        {
+                            "description": "Defines the return data as an empty object for operations with an undefined script.",
+                            "minProperties": 0,
+                            "maxProperties": 0
+                        },
+                        {
+                            "description": "Defines the valid return data for implemented `test` operations.",
+                            "required": [
+                                "_inDesiredState"
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "description": "Defines constraints for the input data of the resource operations. You must define at least one script property to use this resource.",
+                    "anyOf": [
+                        {
+                            "required": [
+                                "getScript"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "testScript"
+                            ]
+                        },
+                        {
+                            "required": [
+                                "setScript"
+                            ]
+                        }
+                    ]
+                }
+            ],
             "properties": {
                 "getScript": {
                     "title": "Get operation script",

--- a/resources/PSScript/winpsscript.dsc.resource.json
+++ b/resources/PSScript/winpsscript.dsc.resource.json
@@ -2,7 +2,7 @@
     "$schema": "https://aka.ms/dsc/schemas/v3/bundled/resource/manifest.json",
     "type": "Microsoft.DSC.Transitional/WindowsPowerShellScript",
     "description": "Enable running Windows PowerShell 5.1 scripts inline",
-    "version": "0.1.0",
+    "version": "0.2.0",
     "get": {
         "executable": "powershell",
         "args": [
@@ -134,7 +134,18 @@
                     ]
                 },
                 "output": {
-                    "type": ["array", "null"]
+                    "title": "Script output data",
+                    "description": "Defines output emitted to the success stream from the invoked script. The resource result for an operation only includes this property when the script emits one or more items to the success stream.",
+                    "readOnly": true,
+                    "type": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "array",
+                        "null"
+                    ]
                 },
                 "_inDesiredState": {
                     "$ref": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json"

--- a/resources/PSScript/winpsscript.dsc.resource.json
+++ b/resources/PSScript/winpsscript.dsc.resource.json
@@ -56,7 +56,10 @@
     },
     "schema": {
         "embedded": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
             "type": "object",
+            "title": "Transitional Windows PowerShell script resource",
+            "description": "Defines an instance of the `Microsoft.DSC.Transitional/WindowsPowerShellScript` resource, which enables users to define inline scripts for the get, set, and test resource operations.",
             "oneOf": [
                 {
                     "description": "Defines constraints for the return data of the resource operations.",

--- a/resources/PSScript/winpsscript.dsc.resource.json
+++ b/resources/PSScript/winpsscript.dsc.resource.json
@@ -74,7 +74,17 @@
                     "$ref": "#/$defs/powershellScript"
                 },
                 "input": {
-                    "type": ["string", "boolean", "integer", "object", "array", "null"]
+                    "title": "Script input data",
+                    "description": "Defines the data to pass to every script as a parameter. When defined, every script property must include a `param()` statement with a single parameter.",
+                    "writeOnly": true,
+                    "type": [
+                        "string",
+                        "boolean",
+                        "integer",
+                        "number",
+                        "object",
+                        "array"
+                    ]
                 },
                 "output": {
                     "type": ["array", "null"]

--- a/resources/PSScript/winpsscript.dsc.resource.json
+++ b/resources/PSScript/winpsscript.dsc.resource.json
@@ -59,13 +59,19 @@
             "type": "object",
             "properties": {
                 "getScript": {
-                    "type": ["string", "null"]
+                    "title": "Get operation script",
+                    "description": "A Windows PowerShell script that retrieves the current state of the instance.",
+                    "$ref": "#/$defs/powershellScript"
                 },
                 "setScript": {
-                    "type": ["string", "null"]
+                    "title": "Set operation script",
+                    "description": "A Windows PowerShell script that enforces the desired state for the instance.",
+                    "$ref": "#/$defs/powershellScript"
                 },
                 "testScript": {
-                    "type": ["string", "null"]
+                    "title": "Test operation script",
+                    "description": "A Windows PowerShell script that checks whether the instance is in the desired state.",
+                    "$ref": "#/$defs/powershellScript"
                 },
                 "input": {
                     "type": ["string", "boolean", "integer", "object", "array", "null"]
@@ -78,6 +84,12 @@
                 }
             },
             "$defs": {
+                "powershellScript": {
+                    "writeOnly": true,
+                    "type": "string",
+                    "minLength": 1,
+                    "contentMediaType": "text/vnd.microsoft.powershell"
+                },
                 "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json": {
                     "$schema": "https://json-schema.org/draft/2020-12/schema",
                     "$id": "https://raw.githubusercontent.com/PowerShell/DSC/main/schemas/v3/resource/properties/inDesiredState.json",


### PR DESCRIPTION
# PR Summary

This change:

1. Canonicalizes the JSON Schema for the transitional PowerShell script resources by

   - Adding the `title` and `description` keywords for every property.
   - Embedding the canonical property definition for `_inDesiredState` and referencing it instead of redefining it.
   - Using a shared subschema for the script properties that ensures they are strings with a minimum length of 1 and indicates that the expected content is PowerShell script code in with the `contentMediaType` keyword.
   - Adding constraints to verify the shape of an instance for input (requiring one or more script property) and output (requiring an empty object, an object with `output`, or an object with `_inDesiredState`).
   - Allowing users to pass non-integer numbers for `input` and forbidding passing `null`

1. Updates the emitted data for `output`. Prior to this change, the `output` property was always an array. This change checks whether the resource emitted any output and:

  - Emits an empty object when the script doesn't emit any data.
  - Emits an object with `output` defined as a scalar value when the script only emitted a single item.
  - Emits an object with `output` defined as an array when the script emitted two or more items.

1. Updates the version of the resource to reflect the changes in schema and behavior.

## PR Context

Addresses issues with the schema and implementation of the PSScript resources and fixes #1563.
