### PR TITLE
docs: Add extensions reference documentation

### DIFF
--- a/docs/reference/extensions/Microsoft/PowerShell/Discover/index.md
+++ b/docs/reference/extensions/Microsoft/PowerShell/Discover/index.md
@@ -27,6 +27,9 @@ the extension if `pwsh` isn't found.
 
 DSC uses the following expression to evaluate whether to load and use this extension:
 
+```yaml
+condition: "[not(equals(tryWhich('pwsh'), null()))]"
+```
 
 ## Description
 

--- a/docs/reference/extensions/Microsoft/PowerShell/Discover/index.md
+++ b/docs/reference/extensions/Microsoft/PowerShell/Discover/index.md
@@ -22,17 +22,20 @@ Author       : Microsoft
 
 ## Condition
 
-The extension only applies on systems where the `pwsh` executable is available in `PATH`. DSC
-evaluates this with the expression `[not(equals(tryWhich('pwsh'), null()))]` and skips the
-extension if `pwsh` isn't found.
+The extension only applies on systems where the `pwsh` executable is available in `PATH`. DSC skips
+the extension if `pwsh` isn't found.
+
+DSC uses the following expression to evaluate whether to load and use this extension:
+
 
 ## Description
 
 By default, DSC discovers command resources by searching the folders in the `PATH` or
 [`DSC_RESOURCE_PATH`][01] environment variable for manifest files. The
-`Microsoft.PowerShell/Discover` extension expands that discovery to PowerShell 7 modules: it
-recursively searches every folder in the `PSModulePath` environment variable for DSC manifest
-files and returns their paths to DSC.
+`Microsoft.PowerShell/Discover` extension expands that discovery to PowerShell 7 modules.
+
+This extension recursively searches every folder in the `PSModulePath` environment variable for DSC
+manifest files and returns their paths to DSC.
 
 With this extension, publishers can package command resources inside a PowerShell module and
 distribute the module through the PowerShell Gallery or a private repository. After a user
@@ -47,9 +50,9 @@ The extension searches for files with the following extensions, in any folder of
 - `.dsc.extension.json`, `.dsc.extension.yaml`, `.dsc.extension.yml`
 
 > [!NOTE]
-> This extension discovers *manifest-based* resources that happen to ship inside a PowerShell
-> module. It doesn't make class-based PowerShell DSC resources available to DSC - those are
-> handled by the [Microsoft.Adapter/PowerShell][02] adapter resource.
+> This extension discovers DSC _manifests_ that happen to ship inside a PowerShell module. It
+> doesn't make class-based PowerShell DSC (PSDSC) resources available to DSC. The
+> [Microsoft.Adapter/PowerShell][02] adapter discovers and invokes PSDSC resources.
 >
 > Folders for Windows PowerShell modules in `PSModulePath` are excluded from the search.
 

--- a/docs/reference/extensions/Microsoft/PowerShell/Discover/index.md
+++ b/docs/reference/extensions/Microsoft/PowerShell/Discover/index.md
@@ -1,0 +1,108 @@
+---
+description: Microsoft.PowerShell/Discover extension reference documentation
+ms.date:     08/08/2026
+ms.topic:    reference
+title:       Microsoft.PowerShell/Discover
+---
+
+# Microsoft.PowerShell/Discover
+
+## Synopsis
+
+Discovers DSC resources packaged in PowerShell 7 modules.
+
+## Metadata
+
+```yaml
+Version      : 0.1.1
+Kind         : extension
+Capabilities : [discover]
+Author       : Microsoft
+```
+
+## Condition
+
+The extension only applies on systems where the `pwsh` executable is available in `PATH`. DSC
+evaluates this with the expression `[not(equals(tryWhich('pwsh'), null()))]` and skips the
+extension if `pwsh` isn't found.
+
+## Description
+
+By default, DSC discovers command resources by searching the folders in the `PATH` or
+[`DSC_RESOURCE_PATH`][01] environment variable for manifest files. The
+`Microsoft.PowerShell/Discover` extension expands that discovery to PowerShell 7 modules: it
+recursively searches every folder in the `PSModulePath` environment variable for DSC manifest
+files and returns their paths to DSC.
+
+With this extension, publishers can package command resources inside a PowerShell module and
+distribute the module through the PowerShell Gallery or a private repository. After a user
+installs the module, for example with `Install-PSResource`, DSC discovers the packaged resources
+automatically - the module folder doesn't need to be added to `PATH` or `DSC_RESOURCE_PATH`.
+
+The extension searches for files with the following extensions, in any folder of the module:
+
+- `.dsc.resource.json`, `.dsc.resource.yaml`, `.dsc.resource.yml`
+- `.dsc.adaptedresource.json`, `.dsc.adaptedresource.yaml`, `.dsc.adaptedresource.yml`
+- `.dsc.manifests.json`, `.dsc.manifests.yaml`, `.dsc.manifests.yml`
+- `.dsc.extension.json`, `.dsc.extension.yaml`, `.dsc.extension.yml`
+
+> [!NOTE]
+> This extension discovers *manifest-based* resources that happen to ship inside a PowerShell
+> module. It doesn't make class-based PowerShell DSC resources available to DSC - those are
+> handled by the [Microsoft.Adapter/PowerShell][02] adapter resource.
+>
+> Folders for Windows PowerShell modules in `PSModulePath` are excluded from the search.
+
+## Caching
+
+Searching every module folder recursively can be slow on systems with many modules, so the
+extension caches its results between invocations. The cache is stored at the following location:
+
+- On Windows: `%LOCALAPPDATA%\dsc\PowerShellDiscoverCache.json`
+- On Linux and macOS: `~/.dsc/PowerShellDiscoverCache.json`
+
+The extension rescans the module folders and rebuilds the cache when any of the following change:
+
+- The set of folders in `PSModulePath` differs from the cached set.
+- The last-write time of a module folder, or of a module subfolder, differs from the cached time.
+- A cached manifest file no longer exists on disk.
+
+To force a full rescan, delete the cache file.
+
+## Requirements
+
+- PowerShell 7 (`pwsh`) must be available in `PATH`.
+
+## Examples
+
+List the extension and verify it's available:
+
+```sh
+dsc extension list Microsoft.PowerShell/Discover
+```
+
+```Output
+Type                           Version  Capabilities  Description
+--------------------------------------------------------------------------------------------------------------
+Microsoft.PowerShell/Discover  0.1.1    d--           Discovers DSC resources packaged in PowerShell 7 modules.
+```
+
+When the extension is available, resources packaged in installed PowerShell modules appear in the
+output of [dsc resource list][03] alongside resources discovered through `PATH`, and you can use
+them in configuration documents and resource commands like any other resource.
+
+## See also
+
+- [Microsoft.Windows.Appx/Discover extension][04]
+- [dsc extension list][05]
+- [DSC extension manifest discover property schema reference][06]
+- [DSC extension discover operation stdout schema reference][07]
+
+<!-- Link reference definitions -->
+[01]: ../../../../cli/index.md#dsc_resource_path
+[02]: ../../../../resources/Microsoft/Adapter/PowerShell/index.md
+[03]: ../../../../cli/resource/list.md
+[04]: ../../Windows/Appx/Discover/index.md
+[05]: ../../../../cli/extension/list.md
+[06]: ../../../../schemas/extension/manifest/discover.md
+[07]: ../../../../schemas/extension/stdout/discover.md

--- a/docs/reference/extensions/Microsoft/Windows/Appx/Discover/index.md
+++ b/docs/reference/extensions/Microsoft/Windows/Appx/Discover/index.md
@@ -1,0 +1,85 @@
+---
+description: Microsoft.Windows.Appx/Discover extension reference documentation
+ms.date:     08/08/2026
+ms.topic:    reference
+title:       Microsoft.Windows.Appx/Discover
+---
+
+# Microsoft.Windows.Appx/Discover
+
+## Synopsis
+
+Discovers DSC resources packaged as Appx packages.
+
+## Metadata
+
+```yaml
+Version      : 0.1.0
+Kind         : extension
+Capabilities : [discover]
+Author       : Microsoft
+```
+
+## Description
+
+By default, DSC discovers command resources by searching the folders in the `PATH` or
+[`DSC_RESOURCE_PATH`][01] environment variable for manifest files. The
+`Microsoft.Windows.Appx/Discover` extension expands that discovery to Appx packages on Windows:
+it enumerates the Appx packages installed for the current user and searches the installation
+folder of each package for DSC manifest files, returning their paths to DSC.
+
+With this extension, publishers can include a DSC resource in an application that's distributed
+through the Microsoft Store or installed as an MSIX/Appx package. After a user installs the
+application, DSC discovers the packaged resources automatically - the application's installation
+folder doesn't need to be added to `PATH` or `DSC_RESOURCE_PATH`.
+
+The extension searches the root of each package's installation folder for files with the
+following extensions:
+
+- `.dsc.resource.json`, `.dsc.resource.yaml`, `.dsc.resource.yml`
+- `.dsc.adaptedresource.json`, `.dsc.adaptedresource.yaml`, `.dsc.adaptedresource.yml`
+- `.dsc.manifests.json`, `.dsc.manifests.yaml`, `.dsc.manifests.yml`
+- `.dsc.extension.json`, `.dsc.extension.yaml`, `.dsc.extension.yml`
+
+> [!NOTE]
+> The extension searches only the root of each package's installation folder, not its
+> subfolders. Manifests must be placed at the top level of the package.
+
+## Requirements
+
+- The extension only applies on Windows. It uses Windows PowerShell and the `Get-AppxPackage`
+  cmdlet to enumerate installed packages.
+- The extension enumerates the Appx packages installed for the current user.
+
+## Examples
+
+List the extension and verify it's available:
+
+```sh
+dsc extension list Microsoft.Windows.Appx/Discover
+```
+
+```Output
+Type                             Version  Capabilities  Description
+------------------------------------------------------------------------------------------------------
+Microsoft.Windows.Appx/Discover  0.1.0    d--           Discovers DSC resources packaged as Appx packages.
+```
+
+When the extension is available, resources packaged in installed Appx packages appear in the
+output of [dsc resource list][02] alongside resources discovered through `PATH`, and you can use
+them in configuration documents and resource commands like any other resource.
+
+## See also
+
+- [Microsoft.PowerShell/Discover extension][03]
+- [dsc extension list][04]
+- [DSC extension manifest discover property schema reference][05]
+- [DSC extension discover operation stdout schema reference][06]
+
+<!-- Link reference definitions -->
+[01]: ../../../../../cli/index.md#dsc_resource_path
+[02]: ../../../../../cli/resource/list.md
+[03]: ../../../PowerShell/Discover/index.md
+[04]: ../../../../../cli/extension/list.md
+[05]: ../../../../../schemas/extension/manifest/discover.md
+[06]: ../../../../../schemas/extension/stdout/discover.md

--- a/docs/reference/extensions/Microsoft/Windows/Appx/Discover/index.md
+++ b/docs/reference/extensions/Microsoft/Windows/Appx/Discover/index.md
@@ -24,9 +24,10 @@ Author       : Microsoft
 
 By default, DSC discovers command resources by searching the folders in the `PATH` or
 [`DSC_RESOURCE_PATH`][01] environment variable for manifest files. The
-`Microsoft.Windows.Appx/Discover` extension expands that discovery to Appx packages on Windows:
-it enumerates the Appx packages installed for the current user and searches the installation
-folder of each package for DSC manifest files, returning their paths to DSC.
+`Microsoft.Windows.Appx/Discover` extension expands that discovery to Appx packages on Windows.
+
+This extension enumerates the Appx packages installed for the current user and searches the
+installation folder of each package for DSC manifest files, returning their paths to DSC.
 
 With this extension, publishers can include a DSC resource in an application that's distributed
 through the Microsoft Store or installed as an MSIX/Appx package. After a user installs the
@@ -42,8 +43,9 @@ following extensions:
 - `.dsc.extension.json`, `.dsc.extension.yaml`, `.dsc.extension.yml`
 
 > [!NOTE]
-> The extension searches only the root of each package's installation folder, not its
-> subfolders. Manifests must be placed at the top level of the package.
+> The extension only searches the root of each package's installation folder, _not_ its subfolders.
+> For the extension to discover any manifests, publishers must place them at the top level of the
+> package.
 
 ## Requirements
 

--- a/docs/reference/extensions/overview.md
+++ b/docs/reference/extensions/overview.md
@@ -1,0 +1,30 @@
+# Built-in DSC extension reference
+
+Each release of DSC includes built-in extensions that you can use immediately after you install
+DSC. Extensions augment the functionality of DSC itself, such as discovering resources in
+locations that DSC doesn't search by default. This document lists the available extensions and
+links to the reference documentation for each.
+
+## All built-in extensions
+
+- [Microsoft.PowerShell/Discover](./Microsoft/PowerShell/Discover/index.md)
+- [Microsoft.Windows.Appx/Discover](./Microsoft/Windows/Appx/Discover/index.md)
+
+## Built-in discovery extensions
+
+You can use the following built-in extensions to make DSC discover resource manifests in
+locations other than the `PATH` and `DSC_RESOURCE_PATH` environment variables:
+
+- [Microsoft.PowerShell/Discover](./Microsoft/PowerShell/Discover/index.md) - Discovers DSC
+  resources packaged in PowerShell 7 modules.
+- [Microsoft.Windows.Appx/Discover](./Microsoft/Windows/Appx/Discover/index.md) - Discovers DSC
+  resources packaged as Appx packages on Windows.
+
+## See also
+
+- [dsc extension list][01]
+- [DSC extension manifest schema reference][02]
+
+<!-- Link reference definitions -->
+[01]: ../cli/extension/list.md
+[02]: ../schemas/extension/manifest/root.md

--- a/docs/reference/resources/overview.md
+++ b/docs/reference/resources/overview.md
@@ -5,17 +5,25 @@ This document lists the available resources and links to the reference documenta
 
 ## All built-in resources
 
+- [DSC.PackageManagement/Apt](./DSC/PackageManagement/APT/index.md)
+- [DSC.PackageManagement/Brew](./DSC/PackageManagement/Brew/index.md)
 - [Microsoft/OSInfo](./Microsoft/OSInfo/index.md)
+- [Microsoft.Adapter/PowerShell](./Microsoft/Adapter/PowerShell/index.md)
+- [Microsoft.Adapter/WindowsPowerShell](./Microsoft/Adapter/WindowsPowerShell/index.md)
 - [Microsoft.DSC/Assertion](./Microsoft/DSC/Assertion/index.md)
 - [Microsoft.DSC/Group](./Microsoft/DSC/Group/index.md)
 - [Microsoft.DSC/Include](./Microsoft/DSC/Include/index.md)
-- [Microsoft.Adapter/PowerShell](./Microsoft/Adapter/PowerShell/index.md)
-- [Microsoft.Adapter/WindowsPowerShell](./Microsoft/Adapter/WindowsPowerShell/index.md)
 - [Microsoft.DSC/PowerShell](./Microsoft/DSC/PowerShell/index.md)
 - [Microsoft.DSC.Debug/Echo](./Microsoft/DSC/Debug/echo/index.md)
+- [Microsoft.DSC.Transitional/PowerShellScript](./Microsoft/DSC/Transitional/PowerShellScript/index.md)
 - [Microsoft.DSC.Transitional/RunCommandOnSet](./Microsoft/DSC/Transitional/RunCommandOnSet/index.md)
+- [Microsoft.DSC.Transitional/WindowsPowerShellScript](./Microsoft/DSC/Transitional/WindowsPowerShellScript/index.md)
+- [Microsoft.Windows/FeatureOnDemandList](./Microsoft/Windows/FeatureOnDemandList/index.md)
+- [Microsoft.Windows/FirewallRuleList](./Microsoft/Windows/FirewallRuleList/index.md)
+- [Microsoft.Windows/OptionalFeatureList](./Microsoft/Windows/OptionalFeatureList/index.md)
 - [Microsoft.Windows/RebootPending](./Microsoft/Windows/RebootPending/index.md)
 - [Microsoft.Windows/Registry](./Microsoft/Windows/Registry/index.md)
+- [Microsoft.Windows/Service](./Microsoft/Windows/Service/index.md)
 - [Microsoft.Windows/WindowsPowerShell](./Microsoft/Windows/WindowsPowerShell/index.md)
 - [Microsoft.Windows/WMI](./Microsoft/Windows/WMI/index.md)
 
@@ -46,10 +54,18 @@ Manifest:
 
 ## Built-in configurable resources
 
-The following built-in resources to change the state of a machine directly:
+The following built-in resources change the state of a machine directly:
 
+- [DSC.PackageManagement/Apt](./DSC/PackageManagement/APT/index.md)
+- [DSC.PackageManagement/Brew](./DSC/PackageManagement/Brew/index.md)
+- [Microsoft.DSC.Transitional/PowerShellScript](./Microsoft/DSC/Transitional/PowerShellScript/index.md)
 - [Microsoft.DSC.Transitional/RunCommandOnSet](./Microsoft/DSC/Transitional/RunCommandOnSet/index.md)
+- [Microsoft.DSC.Transitional/WindowsPowerShellScript](./Microsoft/DSC/Transitional/WindowsPowerShellScript/index.md)
+- [Microsoft.Windows/FeatureOnDemandList](./Microsoft/Windows/FeatureOnDemandList/index.md)
+- [Microsoft.Windows/FirewallRuleList](./Microsoft/Windows/FirewallRuleList/index.md)
+- [Microsoft.Windows/OptionalFeatureList](./Microsoft/Windows/OptionalFeatureList/index.md)
 - [Microsoft.Windows/Registry](./Microsoft/Windows/Registry/index.md)
+- [Microsoft.Windows/Service](./Microsoft/Windows/Service/index.md)
 
 ## Built-in debugging resources
 
@@ -66,3 +82,7 @@ instances:
 - [Microsoft.DSC/Assertion](./Microsoft/DSC/Assertion/index.md)
 - [Microsoft.DSC/Group](./Microsoft/DSC/Group/index.md)
 - [Microsoft.DSC/Include](./Microsoft/DSC/Include/index.md)
+
+## See also
+
+- [Built-in DSC extension reference](../extensions/overview.md)


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

This pull request adds the reference documentation for the two available extensions that are shipped with DSC + stale reference documentation entries in the `overview.md` (built-in resources)

## PR Context

No GitHub issue is available.
