### PR TITLE
Ignore write-only properties in schema-aware diffs

### DIFF
--- a/lib/dsc-lib/src/dscresources/dscresource.rs
+++ b/lib/dsc-lib/src/dscresources/dscresource.rs
@@ -11,7 +11,7 @@ use rust_i18n::t;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use tracing::{debug, info, trace, warn};
 
@@ -769,16 +769,40 @@ fn get_schema_default(schema: Option<&Value>, property_name: &str) -> Option<Val
     property_schema.get("default").cloned()
 }
 
-/// Returns whether a property's JSON Schema sets `writeOnly` to `true`.
+/// Returns whether a property's JSON Schema sets `writeOnly` to `true`, directly or
+/// through a local JSON Pointer reference.
 fn is_schema_write_only(schema: Option<&Value>, property_name: &str) -> bool {
-    schema
-        .and_then(|schema| schema.get("properties"))
+    let Some(schema) = schema else {
+        return false;
+    };
+    let Some(mut property_schema) = schema
+        .get("properties")
         .and_then(Value::as_object)
         .and_then(|properties| properties.get(property_name))
-        .and_then(Value::as_object)
-        .and_then(|property_schema| property_schema.get("writeOnly"))
-        .and_then(Value::as_bool)
-        .unwrap_or(false)
+    else {
+        return false;
+    };
+    let mut visited_references = HashSet::new();
+
+    loop {
+        if property_schema.get("writeOnly").and_then(Value::as_bool) == Some(true) {
+            return true;
+        }
+
+        let Some(reference) = property_schema.get("$ref").and_then(Value::as_str) else {
+            return false;
+        };
+        let Some(pointer) = reference.strip_prefix('#') else {
+            return false;
+        };
+        if !visited_references.insert(pointer) {
+            return false;
+        }
+        let Some(resolved_schema) = schema.pointer(pointer) else {
+            return false;
+        };
+        property_schema = resolved_schema;
+    }
 }
 
 /// Validates the properties of a resource against its schema.
@@ -1070,6 +1094,25 @@ fn diff_with_schema_write_only_ignores_missing_property() {
     });
     let diff = get_diff_with_schema(&expected, &actual, Some(&schema));
     assert!(diff.is_empty(), "Expected write-only property to be ignored, got: {diff:?}");
+}
+
+#[test]
+fn diff_with_schema_write_only_local_ref_ignores_missing_property() {
+    use serde_json::json;
+    let expected = json!({"name": "test", "action": "remove"});
+    let actual = json!({"name": "test"});
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "action": { "$ref": "#/$defs/action" }
+        },
+        "$defs": {
+            "action": { "type": "string", "writeOnly": true }
+        }
+    });
+    let diff = get_diff_with_schema(&expected, &actual, Some(&schema));
+    assert!(diff.is_empty(), "Expected referenced write-only property to be ignored, got: {diff:?}");
 }
 
 #[test]

--- a/lib/dsc-lib/src/dscresources/dscresource.rs
+++ b/lib/dsc-lib/src/dscresources/dscresource.rs
@@ -657,14 +657,15 @@ pub fn get_diff(expected: &Value, actual: &Value) -> Vec<String> {
 
 #[must_use]
 /// Performs a comparison of two JSON Values using an optional JSON Schema.
-/// If a property exists in `expected` but not in `actual`, the schema's `default` value
-/// for that property is used for comparison when available.
+/// Properties whose schema sets `writeOnly` to `true` are ignored. If a property exists
+/// in `expected` but not in `actual`, the schema's `default` value for that property is
+/// used for comparison when available.
 ///
 /// # Arguments
 ///
 /// * `expected` - The expected value
 /// * `actual` - The actual value
-/// * `schema` - Optional JSON Schema to look up default values for missing properties
+/// * `schema` - Optional JSON Schema to identify write-only properties and default values
 ///
 /// # Returns
 ///
@@ -691,6 +692,10 @@ pub(crate) fn get_diff_with_schema(expected: &Value, actual: &Value, schema: Opt
         }
 
         for (key, value) in &*map {
+            if is_schema_write_only(schema, key) {
+                continue;
+            }
+
             if is_secure_value(value) {
                 // skip secure values as they are not comparable
                 continue;
@@ -762,6 +767,18 @@ fn get_schema_default(schema: Option<&Value>, property_name: &str) -> Option<Val
     let properties = schema.get("properties")?.as_object()?;
     let property_schema = properties.get(property_name)?.as_object()?;
     property_schema.get("default").cloned()
+}
+
+/// Returns whether a property's JSON Schema sets `writeOnly` to `true`.
+fn is_schema_write_only(schema: Option<&Value>, property_name: &str) -> bool {
+    schema
+        .and_then(|schema| schema.get("properties"))
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get(property_name))
+        .and_then(Value::as_object)
+        .and_then(|property_schema| property_schema.get("writeOnly"))
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
 }
 
 /// Validates the properties of a resource against its schema.
@@ -1021,6 +1038,54 @@ fn diff_with_schema_no_default_reports_missing_property() {
     });
     let diff = get_diff_with_schema(&expected, &actual, Some(&schema));
     assert_eq!(diff, vec!["enabled".to_string()]);
+}
+
+#[test]
+fn diff_with_schema_write_only_ignores_differing_property() {
+    use serde_json::json;
+    let expected = json!({"name": "test", "action": "remove"});
+    let actual = json!({"name": "test", "action": "ignore"});
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "action": { "type": "string", "writeOnly": true }
+        }
+    });
+    let diff = get_diff_with_schema(&expected, &actual, Some(&schema));
+    assert!(diff.is_empty(), "Expected write-only property to be ignored, got: {diff:?}");
+}
+
+#[test]
+fn diff_with_schema_write_only_ignores_missing_property() {
+    use serde_json::json;
+    let expected = json!({"name": "test", "action": "remove"});
+    let actual = json!({"name": "test"});
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "action": { "type": "string", "writeOnly": true }
+        }
+    });
+    let diff = get_diff_with_schema(&expected, &actual, Some(&schema));
+    assert!(diff.is_empty(), "Expected write-only property to be ignored, got: {diff:?}");
+}
+
+#[test]
+fn diff_with_schema_write_only_false_reports_missing_property() {
+    use serde_json::json;
+    let expected = json!({"name": "test", "action": "remove"});
+    let actual = json!({"name": "test"});
+    let schema = json!({
+        "type": "object",
+        "properties": {
+            "name": { "type": "string" },
+            "action": { "type": "string", "writeOnly": false }
+        }
+    });
+    let diff = get_diff_with_schema(&expected, &actual, Some(&schema));
+    assert_eq!(diff, vec!["action".to_string()]);
 }
 
 #[test]

--- a/resources/windows_firewall/src/firewall.rs
+++ b/resources/windows_firewall/src/firewall.rs
@@ -587,7 +587,7 @@ pub fn set_rules(input: &FirewallRuleList, what_if: bool) -> Result<FirewallRule
         _ => {} // None or Ignore: no additional action.
     }
 
-    Ok(FirewallRuleList { rules: results, unspecified_rules: input.unspecified_rules.clone() })
+    Ok(FirewallRuleList { rules: results, unspecified_rules: None })
 }
 
 pub fn export_rules() -> Result<FirewallRuleList, FirewallError> {

--- a/resources/windows_firewall/tests/windows_firewall_schema_default.tests.ps1
+++ b/resources/windows_firewall/tests/windows_firewall_schema_default.tests.ps1
@@ -65,7 +65,7 @@ Describe 'Microsoft.Windows/FirewallRuleList - synthetic test with schema defaul
         $result.differingProperties | Should -Not -Contain 'unspecifiedRulesAction'
     }
 
-    It 'non-default unspecifiedRulesAction "disable" is reported as differing' {
+    It 'non-default unspecifiedRulesAction "disable" is ignored for comparison' {
         $json = @{
             unspecifiedRulesAction = 'disable'
             rules = @(@{
@@ -81,10 +81,11 @@ Describe 'Microsoft.Windows/FirewallRuleList - synthetic test with schema defaul
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Raw $testdrive/error.log)
 
         $result = $out | ConvertFrom-Json
-        $result.differingProperties | Should -Contain 'unspecifiedRulesAction'
+        $result.inDesiredState | Should -Be $true
+        $result.differingProperties | Should -Not -Contain 'unspecifiedRulesAction'
     }
 
-    It 'non-default unspecifiedRulesAction "remove" is reported as differing' {
+    It 'non-default unspecifiedRulesAction "remove" is ignored for comparison' {
         $json = @{
             unspecifiedRulesAction = 'remove'
             rules = @(@{
@@ -100,6 +101,7 @@ Describe 'Microsoft.Windows/FirewallRuleList - synthetic test with schema defaul
         $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Raw $testdrive/error.log)
 
         $result = $out | ConvertFrom-Json
-        $result.differingProperties | Should -Contain 'unspecifiedRulesAction'
+        $result.inDesiredState | Should -Be $true
+        $result.differingProperties | Should -Not -Contain 'unspecifiedRulesAction'
     }
 }

--- a/resources/windows_firewall/tests/windows_firewall_set.tests.ps1
+++ b/resources/windows_firewall/tests/windows_firewall_set.tests.ps1
@@ -59,6 +59,19 @@ Describe 'Microsoft.Windows/FirewallRuleList - set operation' -Skip:(!$isElevate
         ($out | ConvertFrom-Json).afterState.rules | Should -BeNullOrEmpty
     }
 
+    It 'does not return unspecifiedRules in the after state' -Skip:(!$isElevated) {
+        $json = @{
+            rules = @()
+            unspecifiedRules = @{
+                action = 'ignore'
+            }
+        } | ConvertTo-Json -Compress -Depth 5
+        $out = $json | dsc resource set -r $resourceType -f - 2>$testdrive/error.log
+        $LASTEXITCODE | Should -Be 0 -Because (Get-Content -Raw $testdrive/error.log)
+
+        ($out | ConvertFrom-Json).afterState.PSObject.Properties.Name | Should -Not -Contain 'unspecifiedRules'
+    }
+
     It 'updates an existing rule' -Skip:(!$isElevated) {
         Initialize-TestFirewallRule
         $json = @{ rules = @(@{ name = $testRuleName; description = 'Updated by DSC test'; enabled = $false }) } | ConvertTo-Json -Compress -Depth 5

--- a/resources/windows_firewall/windows_firewall.dsc.resource.json
+++ b/resources/windows_firewall/windows_firewall.dsc.resource.json
@@ -61,6 +61,7 @@
             "properties": {
                 "unspecifiedRulesAction": {
                     "type": "string",
+                    "writeOnly": true,
                     "title": "Unspecified rules action",
                     "description": "The action to take on firewall rules not explicitly listed in the rules array. 'ignore' (default) leaves them unchanged, 'disable' disables them, and 'remove' deletes them.",
                     "default": "ignore",


### PR DESCRIPTION
Properties used only as resource instructions may not be returned by a resource, which caused schema-aware comparisons to report false differences.

This change makes `get_diff_with_schema()` skip properties marked `writeOnly: true` in the resource schema. The Windows Firewall resource now marks `unspecifiedRulesAction` as write-only, and unit and resource tests cover differing, omitted, and explicitly non-write-only properties.

Fix https://github.com/PowerShell/DSC/issues/1668