### PR TITLE
Update Firewall manifest to declare implementsPretest

### DIFF
--- a/lib/dsc-lib/src/dscresources/command_resource.rs
+++ b/lib/dsc-lib/src/dscresources/command_resource.rs
@@ -440,7 +440,8 @@ fn get_desired_state(actual: &Value) -> Result<Option<bool>, DscError> {
     Ok(in_desired_state)
 }
 
-fn invoke_synthetic_test(resource: &DscResource, expected: &str, target_resource: Option<&DscResource>) -> Result<TestResult, DscError> {    let get_result = invoke_get(resource, expected, target_resource)?;
+fn invoke_synthetic_test(resource: &DscResource, expected: &str, target_resource: Option<&DscResource>) -> Result<TestResult, DscError> {
+    let get_result = invoke_get(resource, expected, target_resource)?;
     let actual_state = match get_result {
         GetResult::Group(results) => {
             let mut result_array: Vec<Value> = Vec::new();

--- a/resources/windows_firewall/windows_firewall.dsc.resource.json
+++ b/resources/windows_firewall/windows_firewall.dsc.resource.json
@@ -29,7 +29,7 @@
                 "whatIfArg": "--what-if"
             }
         ],
-        "implementsPretest": false,
+        "implementsPretest": true,
         "handlesExist": true,
         "return": "state",
         "whatIfReturns": "state",


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- Change Firewall manifest to declare `implementsPretest` so that when the `writeOnly` `unspecifiedRules` property is used, `set` is still called
- Fix a formatting issue in `invoke_synthetic_test()` funciton I noticed while exploring different options

## PR Context

Fix https://github.com/PowerShell/DSC/issues/1681