### PR TITLE
Update code coverage report to always add comment even if failures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -303,7 +303,7 @@ jobs:
           if-no-files-found: ignore
 
   coverage-report:
-    if: github.event_name == 'pull_request'
+    if: ${{ always() && github.event_name == 'pull_request' }}
     # Use all platforms for changed-code coverage so platform-specific files are
     # included. Keep full-codebase coverage Linux-only to avoid inflating its
     # denominator with platform-specific sources.


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

- use `always()` to ensure the CC comment always gets added for PR even if test/build failures