### PR TITLE
Update release pipelines to use msrustup 1.97.1

### DIFF
--- a/.pipelines/DSC-Official-PMC.yml
+++ b/.pipelines/DSC-Official-PMC.yml
@@ -20,7 +20,7 @@ variables:
   - name: PublishToPMC
     value: ${{ parameters.PublishToPMC }}
   - name: RustVersion
-    value: ms-prod-1.95
+    value: ms-prod-1.97.1
   - name: LinuxContainerImage
     value: 'onebranch.azurecr.io/linux/ubuntu-2204:latest'
   - name: RepoRoot

--- a/.pipelines/DSC-Official.yml
+++ b/.pipelines/DSC-Official.yml
@@ -32,7 +32,7 @@ variables:
   - name: PublishToStore
     value: ${{ parameters.PublishToStore }}
   - name: RustVersion
-    value: ms-prod-1.95
+    value: ms-prod-1.97.1
 
 resources:
   repositories:


### PR DESCRIPTION
<!-- Anything that looks like this is a comment and can't be seen after the Pull Request is created. -->

# PR Summary

Requires 1.97.1 for build to be successful due to changes to LLVM